### PR TITLE
Switch Codex reviews to sequential triggering

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,14 +6,15 @@
 ## Checks
 
 - [ ] Linked to the relevant GitHub issue
-- [ ] `codex-software-review` label applied
-- [ ] Added `codex-methodology-review` if core timing, MPI, or semantics changed
-- [ ] Added `codex-red-team-review` if core timing stop/repair or MPI safety changed
+- [ ] `codex-software-review` applied as the first and only active Codex review label
+- [ ] `codex-methodology-review` will be applied later, by itself, if core timing, MPI, or semantics changed
+- [ ] `codex-red-team-review` will be applied later, by itself, if core timing stop/repair or MPI safety changed
 - [ ] Docs updated to match behavior changes
 - [ ] Tests or smoke-path coverage updated as appropriate
 - [ ] Workflow/bootstrap docs updated if repo process changed
 
 ## Notes
 
+- Sequential Codex review order: software -> methodology -> red-team
 - Follow-up work:
 - Deferred items:

--- a/.github/review-bootstrap.md
+++ b/.github/review-bootstrap.md
@@ -1,0 +1,64 @@
+# Codex Review Bootstrap
+
+This repository uses label-triggered Codex reviews on pull requests. The trigger workflow posts `@codex review` comments from the repository owner account using `CODEX_TRIGGER_PAT`.
+
+## Prerequisites
+
+- Labels:
+  - `codex-software-review`
+  - `codex-methodology-review`
+  - `codex-red-team-review`
+- Repository secret:
+  - `CODEX_TRIGGER_PAT` with `pull-requests:write`
+- `main` ruleset:
+  - require pull requests
+  - require CI and lint
+  - block direct pushes and force pushes
+  - require conversation resolution
+
+## Current Limitations
+
+Observed behavior of native Codex GitHub reviews:
+
+- A successful trigger workflow only proves that the `@codex review` comment was posted.
+- The returned review body may ignore prompt instructions about top-level headings or other formatting.
+- A "no findings" outcome may not leave a distinct visible review body.
+- GitHub does not expose a clean mapping from a specific trigger comment to a specific review object.
+
+Because of that, this repo uses **sequential review triggering** instead of posting multiple review requests in parallel.
+
+## Sequential Review Process
+
+1. Open the PR and apply only `codex-software-review`.
+2. Wait for the trigger comment and the actual Codex review output.
+3. Respond to findings, fix or disposition them, and resolve the review threads.
+4. Remove `codex-software-review`.
+5. If needed, apply only `codex-methodology-review` and repeat.
+6. If needed, apply only `codex-red-team-review` and repeat.
+
+Recommended order:
+
+1. `codex-software-review`
+2. `codex-methodology-review`
+3. `codex-red-team-review`
+
+Keep exactly one Codex review label active on the PR at a time.
+
+## Investigation Commands
+
+These commands are the current best way to inspect what actually happened:
+
+- Trigger comments:
+  - `gh api repos/jaharris87/fTimer/issues/<PR_NUMBER>/comments`
+- Review objects:
+  - `gh api repos/jaharris87/fTimer/pulls/<PR_NUMBER>/reviews`
+- Inline review comments:
+  - `gh api repos/jaharris87/fTimer/pulls/<PR_NUMBER>/comments`
+- Review thread state:
+  - `gh api graphql -f query='query { repository(owner:"jaharris87", name:"fTimer") { pullRequest(number: <PR_NUMBER>) { reviewThreads(first: 50) { nodes { id isResolved path } } } } }'`
+- Trigger workflow runs:
+  - `gh run list --workflow "Codex Review Triggers"`
+- CI/check status:
+  - `gh pr checks <PR_NUMBER>`
+
+Treat the workflow run as "trigger posted", not "review completed".

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -6,7 +6,14 @@ name: Codex Review Triggers
 # Prerequisites:
 #   1. Create a fine-grained PAT with pull-requests:write on this repo
 #   2. Add it as a repository secret named CODEX_TRIGGER_PAT
-#   3. Create the review labels documented in README.md and CLAUDE.md
+#   3. Create the review labels documented in .github/review-bootstrap.md
+#
+# Important behavior notes:
+#   - A successful workflow run only proves that the trigger comment was posted.
+#   - Native Codex reviews do not reliably preserve custom top-level headings.
+#   - "No findings" outcomes may not leave a distinct visible review body.
+#   - To keep provenance clear, this workflow enforces one active Codex review
+#     label at a time and posts trigger comments sequentially.
 #
 # Why a PAT instead of github.token?
 #   Codex ignores @codex review comments from github-actions[bot].
@@ -22,71 +29,97 @@ permissions:
   issues: write
 
 jobs:
-  software-review:
-    if: github.event.label.name == 'codex-software-review'
+  post-review-trigger:
+    if: contains(fromJson('["codex-software-review","codex-methodology-review","codex-red-team-review"]'), github.event.label.name)
     concurrency:
-      group: codex-software-review-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
+      group: codex-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Post software review trigger
+      - name: Compute review metadata
+        id: meta
+        env:
+          TRIGGER_LABEL: ${{ github.event.label.name }}
+        run: |
+          case "$TRIGGER_LABEL" in
+            codex-software-review)
+              echo "review_type=software" >> "$GITHUB_OUTPUT"
+              echo "prompt_path=.github/prompts/software-review.md" >> "$GITHUB_OUTPUT"
+              ;;
+            codex-methodology-review)
+              echo "review_type=methodology" >> "$GITHUB_OUTPUT"
+              echo "prompt_path=.github/prompts/methodology-review.md" >> "$GITHUB_OUTPUT"
+              ;;
+            codex-red-team-review)
+              echo "review_type=red-team" >> "$GITHUB_OUTPUT"
+              echo "prompt_path=.github/prompts/red-team-review.md" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+          python3 <<'PY'
+          import json
+          import os
+
+          allowed = {
+              "codex-software-review",
+              "codex-methodology-review",
+              "codex-red-team-review",
+          }
+
+          with open(os.environ["GITHUB_EVENT_PATH"], "r", encoding="utf-8") as fh:
+              event = json.load(fh)
+
+          labels = [label["name"] for label in event["pull_request"]["labels"]]
+          active = [label for label in labels if label in allowed]
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"active_codex_count={len(active)}\n")
+              out.write(f"active_codex_labels={','.join(active)}\n")
+          PY
+
+      - name: Post sequential-review guidance
+        if: steps.meta.outputs.active_codex_count != '1'
+        env:
+          GH_TOKEN: ${{ secrets.CODEX_TRIGGER_PAT }}
+        run: |
+          cat > /tmp/codex-sequential-guidance.md <<EOF
+          Sequential Codex review triggering requires exactly one active Codex review label on the pull request.
+
+          Trigger that just fired: \`${{ github.event.label.name }}\`
+          Active Codex review labels right now: \`${{ steps.meta.outputs.active_codex_labels }}\`
+
+          Remove the extra Codex review labels, wait for the current review to land and be resolved, then apply the next label.
+
+          Recommended order:
+          1. \`codex-software-review\`
+          2. \`codex-methodology-review\` (if needed)
+          3. \`codex-red-team-review\` (if needed)
+
+          See \`.github/review-bootstrap.md\` for the detailed workflow and investigation commands.
+          EOF
+
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body-file /tmp/codex-sequential-guidance.md
+
+      - name: Post review trigger
+        if: steps.meta.outputs.active_codex_count == '1'
         env:
           GH_TOKEN: ${{ secrets.CODEX_TRIGGER_PAT }}
         run: |
           {
+            echo "<!-- codex-review-trigger:type=${{ steps.meta.outputs.review_type }} -->"
+            echo "Review request type: ${{ steps.meta.outputs.review_type }}"
+            echo "Requested via label: \`${{ github.event.label.name }}\`"
+            echo "Sequential trigger: yes"
+            echo
             echo "@codex review"
             echo
-            cat .github/prompts/software-review.md
-          } > /tmp/codex-software-comment.md
+            cat "${{ steps.meta.outputs.prompt_path }}"
+          } > /tmp/codex-review-comment.md
 
           gh pr comment "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" \
-            --body-file /tmp/codex-software-comment.md
-
-  methodology-review:
-    if: github.event.label.name == 'codex-methodology-review'
-    concurrency:
-      group: codex-methodology-review-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Post methodology review trigger
-        env:
-          GH_TOKEN: ${{ secrets.CODEX_TRIGGER_PAT }}
-        run: |
-          {
-            echo "@codex review"
-            echo
-            cat .github/prompts/methodology-review.md
-          } > /tmp/codex-methodology-comment.md
-
-          gh pr comment "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
-            --body-file /tmp/codex-methodology-comment.md
-
-  red-team-review:
-    if: github.event.label.name == 'codex-red-team-review'
-    concurrency:
-      group: codex-red-team-review-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Post red team review trigger
-        env:
-          GH_TOKEN: ${{ secrets.CODEX_TRIGGER_PAT }}
-        run: |
-          {
-            echo "@codex review"
-            echo
-            cat .github/prompts/red-team-review.md
-          } > /tmp/codex-red-team-comment.md
-
-          gh pr comment "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
-            --body-file /tmp/codex-red-team-comment.md
+            --body-file /tmp/codex-review-comment.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,21 +106,34 @@ This workflow is **mandatory** for every PR. Do not skip any step.
 When you open or materially update a pull request:
 
 0. Create or link the GitHub issue for the phase/task before opening the PR.
-1. Always add the label `codex-software-review`.
-2. If changes touch `src/ftimer_core.F90`, `src/ftimer_summary.F90`, `src/ftimer_mpi.F90`, or `docs/semantics.md`, also add `codex-methodology-review`.
-3. If changes touch `src/ftimer_core.F90` (especially `start`, `stop`, `repair_mismatch`) or `src/ftimer_mpi.F90`, also add `codex-red-team-review`.
-4. Do not manually paste large review prompts into the PR unless explicitly asked.
-5. Let GitHub workflows trigger Codex review comments from the saved prompt files in `.github/prompts/`.
+1. Apply `codex-software-review` first, and keep it as the **only active Codex review label** on the PR.
+2. Do **not** apply `codex-methodology-review` or `codex-red-team-review` at the same time.
+3. If changes touch `src/ftimer_core.F90`, `src/ftimer_summary.F90`, `src/ftimer_mpi.F90`, or `docs/semantics.md`, apply `codex-methodology-review` only **after** the software review has landed, been handled, and its label has been removed.
+4. If changes touch `src/ftimer_core.F90` (especially `start`, `stop`, `repair_mismatch`) or `src/ftimer_mpi.F90`, apply `codex-red-team-review` only **after** the prior Codex review has landed, been handled, and its label has been removed.
+5. Do not manually paste large review prompts into the PR unless explicitly asked.
+6. Let GitHub workflows trigger Codex review comments from the saved prompt files in `.github/prompts/`.
 
 ### Step 2: Monitor for Codex reviews
 
 After opening the PR and applying labels, **you must proactively monitor for Codex review completion**. Do not wait for the user to ask.
 
 1. Inform the user that you are monitoring for Codex reviews.
-2. Poll the PR comments every 60 seconds for new comments from `chatgpt-codex-connector` or containing Codex review content.
-3. Codex reviews typically arrive within 2-5 minutes. Continue polling for up to 10 minutes.
-4. Once all expected reviews have arrived (one per label applied), proceed to Step 3.
-5. If reviews have not arrived after 10 minutes, inform the user and ask how to proceed.
+2. Treat a passing `Codex Review Triggers` workflow as **"trigger comment posted"**, not as proof that a review arrived.
+3. Inspect the PR review objects and inline review comments, not just the issue comments. Native Codex reviews may ignore requested top-level headings and "no findings" outcomes may not leave a distinct visible review body.
+4. Poll every 60 seconds for up to 10 minutes.
+5. Once the current review has arrived and any findings have been handled, remove that label before applying the next Codex review label.
+6. If a review has not arrived after 10 minutes, inform the user and ask how to proceed.
+
+### Review Inspection
+
+When you need to inspect what actually happened on a PR, use:
+
+- `gh pr checks <PR_NUMBER>`
+- `gh api repos/jaharris87/fTimer/issues/<PR_NUMBER>/comments`
+- `gh api repos/jaharris87/fTimer/pulls/<PR_NUMBER>/reviews`
+- `gh api repos/jaharris87/fTimer/pulls/<PR_NUMBER>/comments`
+
+For review-thread resolution state, use the GraphQL review thread query documented in `.github/review-bootstrap.md`.
 
 ### Step 3: Respond to each review finding
 
@@ -158,4 +171,5 @@ After responding to all reviews, give the user a concise summary:
 - Create the review labels manually in GitHub: `codex-software-review`, `codex-methodology-review`, `codex-red-team-review`.
 - Add a repository secret named `CODEX_TRIGGER_PAT` for the review-trigger workflow.
 - Configure a `main` ruleset that requires pull requests, passing CI/lint checks, blocks direct pushes and force pushes, and requires conversation resolution.
+- Use the sequential Codex review process documented in `.github/review-bootstrap.md`.
 - CMake is the only supported build system in Phase 0. FPM support is intentionally deferred.


### PR DESCRIPTION
## Summary

Switches the Codex PR review workflow from parallel label triggering to a sequential one-label-at-a-time process.

Closes #3.

## Why

Observed behavior of native Codex GitHub reviews makes parallel triggers hard to audit:

- trigger workflow success only proves the `@codex review` comment was posted
- returned review bodies do not reliably preserve prompt-specific top-level headings
- "no findings" outcomes may not leave a distinct visible review body
- GitHub does not expose clean provenance from trigger comment to returned review object

This change makes the workflow and docs match that reality.

## What Changed

- replaced the three independent trigger jobs with one shared sequential trigger job
- enforced exactly one active Codex review label at a time
- added `.github/review-bootstrap.md` for maintainer setup, limitations, and investigation commands
- updated `CLAUDE.md` to document the sequential process and how to inspect actual review artifacts
- updated the PR template to match the one-label-at-a-time workflow

## Validation

- parsed `.github/workflows/codex-review.yml` successfully with Ruby/Psych
- checked the repo for the stale parallel-trigger guidance that this PR replaces
