### PR TITLE
Separate maintainer process from CLAUDE guidance

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -6,7 +6,7 @@ name: Codex Review Triggers
 # Prerequisites:
 #   1. Create a fine-grained PAT with pull-requests:write on this repo
 #   2. Add it as a repository secret named CODEX_TRIGGER_PAT
-#   3. Create the review labels documented in README.md and CLAUDE.md
+#   3. Create the review labels documented in docs/maintainer.md
 #
 # Why a PAT instead of github.token?
 #   Codex ignores @codex review comments from github-actions[bot].

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,8 @@ Phase 0 is scaffold work. The library, examples, install package, and smoke test
 
 During Phase 0, the public API is placeholder-only: routine signatures should preserve the intended error-reporting contract, and unimplemented timer operations should report that status rather than silently succeeding.
 
+Detailed repository operations and PR/review handling live in `docs/maintainer.md`. Use that file for GitHub workflow details; keep this file focused on coding/build/test behavior and the short mandatory PR summary below.
+
 **Test-driven development is mandatory.** Write tests first, confirm they fail, then implement. All tests use the injectable mock clock for deterministic results — tests never sleep or depend on wall-clock timing.
 
 ### Test Categories
@@ -104,49 +106,16 @@ These are critical — violating them causes cryptic build failures:
 
 This workflow is **mandatory** for every PR. Do not skip any step.
 
-### Step 1: Open the PR and apply labels
+Short version:
 
-When you open or materially update a pull request:
+- create or link the GitHub issue first
+- open a PR from a feature branch
+- always apply `codex-software-review`
+- also apply `codex-methodology-review` or `codex-red-team-review` when the diff warrants them
+- monitor for the actual Codex review output
+- reply to every finding, resolve every review thread, and do not merge while merge-blocking findings remain
 
-0. Create or link the GitHub issue for the phase/task before opening the PR.
-1. Always add the label `codex-software-review`.
-2. If changes touch `src/ftimer_core.F90`, `src/ftimer_summary.F90`, `src/ftimer_mpi.F90`, or `docs/semantics.md`, also add `codex-methodology-review`.
-3. If changes touch `src/ftimer_core.F90` (especially `start`, `stop`, `repair_mismatch`) or `src/ftimer_mpi.F90`, also add `codex-red-team-review`.
-4. Do not manually paste large review prompts into the PR unless explicitly asked.
-5. Let GitHub workflows trigger Codex review comments from the saved prompt files in `.github/prompts/`.
-
-### Step 2: Monitor for Codex reviews
-
-After opening the PR and applying labels, **you must proactively monitor for Codex review completion**. Do not wait for the user to ask.
-
-1. Inform the user that you are monitoring for Codex reviews.
-2. Poll the PR comments every 60 seconds for new comments from `chatgpt-codex-connector` or containing Codex review content.
-3. Codex reviews typically arrive within 2-5 minutes. Continue polling for up to 10 minutes.
-4. Once all expected reviews have arrived (one per label applied), proceed to Step 3.
-5. If reviews have not arrived after 10 minutes, inform the user and ask how to proceed.
-
-### Step 3: Respond to each review finding
-
-For **every finding** in every Codex review, post a reply comment on the PR responding in one of three categories:
-
-- **Agree and fix**: Make the code change, push it, and note what you fixed in the reply.
-- **Disagree with evidence**: Explain why the finding is incorrect, citing specific code, tests, or design decisions.
-- **Defer with reason**: Acknowledge the concern but explain why it is out of scope for this PR.
-
-Group your responses into a single comment per review. Every finding must be addressed — do not silently skip any.
-
-### Merge-blocking criteria
-
-Do not merge the PR if any finding classified as **bug**, **leakage**, or **silent wrong answer** remains unaddressed (neither fixed nor disagreed-with-evidence). Findings classified as **nit**, **design concern**, or **methodology concern** do not block merge unless escalated by the user.
-
-### Step 4: Report to the user
-
-After responding to all reviews, give the user a concise summary:
-- How many findings per review type
-- What you agreed and fixed
-- What you disagreed with and why
-- What you deferred
-- Whether any merge-blocking findings remain
+Use `docs/maintainer.md` for the full operating procedure, investigation commands, and merge criteria.
 
 ## Configuration
 
@@ -156,9 +125,4 @@ After responding to all reviews, give the user a concise summary:
 - **`CMAKE_INSTALL_PREFIX`**: Where `make install` places the library and module files.
 - **pFUnit**: Optional until the real test tree exists. Set `PFUNIT_DIR` explicitly when enabling `FTIMER_BUILD_TESTS`.
 
-## Repository Bootstrap
-
-- Create the review labels manually in GitHub: `codex-software-review`, `codex-methodology-review`, `codex-red-team-review`.
-- Add a repository secret named `CODEX_TRIGGER_PAT` for the review-trigger workflow.
-- Configure a `main` ruleset that requires pull requests, passing CI/lint checks, blocks direct pushes and force pushes, and requires conversation resolution.
-- CMake is the only supported build system in Phase 0. FPM support is intentionally deferred.
+CMake is the only supported build system in Phase 0. FPM support is intentionally deferred.

--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -1,0 +1,125 @@
+# Maintainer Guide
+
+This document covers repository operations, pull request workflow, and Codex review handling. It is intentionally separate from `CLAUDE.md`, which should stay focused on coding, build/test, architecture, and implementation guidance.
+
+## Repository Bootstrap
+
+- Create the review labels in GitHub:
+  - `codex-software-review`
+  - `codex-methodology-review`
+  - `codex-red-team-review`
+- Add a repository secret named `CODEX_TRIGGER_PAT` for the review-trigger workflow.
+- Configure a `main` ruleset that:
+  - requires pull requests before merge
+  - requires CI and lint checks
+  - blocks direct pushes and force pushes
+  - requires conversation resolution
+
+## Standard PR Workflow
+
+For every scoped piece of work:
+
+1. Create or link the GitHub issue first.
+2. Create a feature branch from updated local `main`.
+3. Implement the change on that feature branch.
+4. Open a pull request to `main`.
+5. Apply the Codex review labels required by the diff.
+6. Monitor for Codex reviews and handle every finding.
+7. Do not merge while merge-blocking findings remain unresolved.
+
+## Codex Review Workflow
+
+This workflow is mandatory for every PR.
+
+### Which Labels To Apply
+
+- Always apply `codex-software-review`.
+- Also apply `codex-methodology-review` when changes touch:
+  - `src/ftimer_core.F90`
+  - `src/ftimer_summary.F90`
+  - `src/ftimer_mpi.F90`
+  - `docs/semantics.md`
+- Also apply `codex-red-team-review` when changes touch:
+  - `src/ftimer_core.F90`, especially `start`, `stop`, or `repair_mismatch`
+  - `src/ftimer_mpi.F90`
+
+Do not manually paste the large saved prompts into the PR unless explicitly asked. Let `.github/workflows/codex-review.yml` post the trigger comments from `.github/prompts/`.
+
+### Monitoring Reviews
+
+After opening or materially updating the PR:
+
+1. Inform the user that you are monitoring for Codex reviews.
+2. Poll every 60 seconds for up to 10 minutes.
+3. Inspect actual review artifacts, not just workflow success.
+4. Once all expected reviews have arrived, respond to every finding.
+5. If reviews have not arrived after 10 minutes, tell the user and ask how to proceed.
+
+### How To Inspect What Actually Happened
+
+Useful commands:
+
+- Trigger comments and general PR comments:
+  - `gh pr view <PR_NUMBER> --comments`
+  - `gh api repos/jaharris87/fTimer/issues/<PR_NUMBER>/comments`
+- Review objects:
+  - `gh api repos/jaharris87/fTimer/pulls/<PR_NUMBER>/reviews`
+- Inline review findings:
+  - `gh api repos/jaharris87/fTimer/pulls/<PR_NUMBER>/comments`
+- Review thread state:
+  - `gh api graphql -f query='query { repository(owner:"jaharris87", name:"fTimer") { pullRequest(number: <PR_NUMBER>) { reviewThreads(first: 50) { nodes { id isResolved path } } } } }'`
+- Checks and trigger workflow status:
+  - `gh pr checks <PR_NUMBER>`
+  - `gh run list --workflow "Codex Review Triggers"`
+
+## Known Limitations Of Native Codex GitHub Reviews
+
+- A passing trigger workflow only proves that the `@codex review` comment was posted.
+- Codex review bodies may ignore prompt instructions about top-level headings.
+- A "no findings" outcome may appear as a generic comment or reaction rather than a distinct type-specific review body.
+- GitHub does not expose clean provenance from a particular trigger comment to a particular returned review object.
+
+In practice, infer review type from the review contents and the trigger context when the returned wrapper is generic.
+
+## Responding To Findings
+
+For every finding in every Codex review, post a reply on the PR in one of these categories:
+
+- Agree and fix
+- Disagree with evidence
+- Defer with reason
+
+Every finding must be addressed explicitly.
+
+When responding:
+
+- cite the fix commit when you agree and fix
+- cite code/tests/docs when you disagree
+- explain scope clearly when you defer
+
+After replying:
+
+- resolve the review thread
+- verify whether any unresolved review threads remain
+
+## Merge-Blocking Criteria
+
+Do not merge the PR if any finding classified as:
+
+- bug
+- leakage
+- silent wrong answer
+
+remains unresolved without either a fix or a disagreement backed by evidence.
+
+Findings classified as nit, design concern, or methodology concern do not block merge unless the user decides otherwise.
+
+## Closeout To The User
+
+After handling the reviews, report:
+
+- how many findings appeared per review type
+- what was fixed
+- what was disagreed with and why
+- what was deferred
+- whether any merge-blocking findings remain


### PR DESCRIPTION
## Summary

Separates detailed maintainer/repository operations from `CLAUDE.md` into a dedicated `docs/maintainer.md` guide.

Closes #7.

## Why

`CLAUDE.md` was carrying both builder-agent guidance and detailed maintainer workflow instructions. That makes it easier for the maintainer process to drift and harder to keep Claude-focused coding guidance concise.

This split keeps the immediate coding/build/test guidance in `CLAUDE.md`, while moving the long-form PR/review/bootstrap operations into `docs/maintainer.md`.

## What Changed

- added `docs/maintainer.md` for:
  - repo bootstrap
  - standard PR workflow
  - Codex review workflow
  - investigation commands
  - known limitations of native Codex GitHub reviews
  - merge-blocking criteria and closeout expectations
- reduced `CLAUDE.md` to:
  - coding/build/test guidance
  - architecture and implementation constraints
  - a short mandatory PR-review summary plus a pointer to the maintainer guide
- updated `.github/workflows/codex-review.yml` comments to point to `docs/maintainer.md`

## Claude Impact

The split is designed to avoid degrading Claude sessions:

- `CLAUDE.md` still contains the short mandatory PR-review summary Claude needs during active development
- the detailed operational procedure remains available in-repo via `docs/maintainer.md`
- no build/test/architecture guidance was removed from `CLAUDE.md`
