### PR TITLE
Issue #30: expand mismatch-repair test coverage

### DIFF
--- a/tests/test_callbacks.pf
+++ b/tests/test_callbacks.pf
@@ -2,7 +2,8 @@ module test_callbacks
    use, intrinsic :: iso_c_binding, only: c_associated, c_loc, c_ptr
    use pfunit
    use ftimer_core, only: ftimer_t
-   use ftimer_types, only: FTIMER_EVENT_START, FTIMER_EVENT_STOP, FTIMER_MISMATCH_REPAIR, FTIMER_SUCCESS, wp
+   use ftimer_types, only: FTIMER_ERR_MISMATCH, FTIMER_EVENT_START, FTIMER_EVENT_STOP, FTIMER_MISMATCH_REPAIR, &
+                           FTIMER_MISMATCH_WARN, FTIMER_SUCCESS, wp
    use test_support, only: attach_mock_clock, fake_time
    implicit none
 
@@ -59,9 +60,10 @@ contains
       type(ftimer_t) :: timer
       integer, target :: token
       integer :: ierr
-      logical :: first_event_is_start
-      logical :: second_event_is_start
-      logical :: third_event_is_stop
+      integer, parameter :: expected_timer_ids(5) = [1, 2, 3, 3, 2]
+      integer, parameter :: expected_events(5) = [FTIMER_EVENT_START, FTIMER_EVENT_START, FTIMER_EVENT_START, &
+                                                  FTIMER_EVENT_STOP, FTIMER_EVENT_STOP]
+      real(wp), parameter :: expected_timestamps(5) = [0.0_wp, 1.0_wp, 2.0_wp, 5.0_wp, 8.0_wp]
 
       call reset_callback_log()
       call timer%init(mismatch_mode=FTIMER_MISMATCH_REPAIR, ierr=ierr)
@@ -75,30 +77,73 @@ contains
       fake_time = 1.0_wp
       call timer%start("B", ierr=ierr)
       fake_time = 2.0_wp
+      call timer%start("C", ierr=ierr)
+      fake_time = 3.0_wp
       call timer%stop("A", ierr=ierr)
       fake_time = 5.0_wp
+      call timer%stop("C", ierr=ierr)
+      fake_time = 8.0_wp
       call timer%stop("B", ierr=ierr)
 
       @assertEqual(FTIMER_SUCCESS, ierr)
 
-      first_event_is_start = callback_events(1) == FTIMER_EVENT_START
-      second_event_is_start = callback_events(2) == FTIMER_EVENT_START
-      third_event_is_stop = callback_events(3) == FTIMER_EVENT_STOP
-
-      @assertEqual(3, callback_count)
-      @assertTrue(first_event_is_start)
-      @assertTrue(second_event_is_start)
-      @assertTrue(third_event_is_stop)
-      @assertEqual(1, callback_timer_ids(1))
-      @assertEqual(2, callback_timer_ids(2))
-      @assertEqual(2, callback_timer_ids(3))
-      @assertEqual(0.0_wp, callback_timestamps(1))
-      @assertEqual(1.0_wp, callback_timestamps(2))
-      @assertEqual(5.0_wp, callback_timestamps(3))
-      @assertTrue(callback_has_user_data(1))
-      @assertTrue(callback_has_user_data(2))
-      @assertTrue(callback_has_user_data(3))
+      call assert_callback_trace(5, expected_timer_ids, expected_events, expected_timestamps)
    end subroutine test_repair_does_not_fire_internal_callbacks
+
+   @test
+   subroutine test_warn_does_not_fire_internal_callbacks()
+      type(ftimer_t) :: timer
+      integer, target :: token
+      integer :: ierr
+      integer, parameter :: expected_timer_ids(5) = [1, 2, 3, 3, 2]
+      integer, parameter :: expected_events(5) = [FTIMER_EVENT_START, FTIMER_EVENT_START, FTIMER_EVENT_START, &
+                                                  FTIMER_EVENT_STOP, FTIMER_EVENT_STOP]
+      real(wp), parameter :: expected_timestamps(5) = [0.0_wp, 1.0_wp, 2.0_wp, 5.0_wp, 8.0_wp]
+
+      call reset_callback_log()
+      call timer%init(mismatch_mode=FTIMER_MISMATCH_WARN, ierr=ierr)
+      call attach_mock_clock(timer)
+
+      token = 13
+      timer%on_event => record_callback
+      timer%user_data = c_loc(token)
+
+      call timer%start("A", ierr=ierr)
+      fake_time = 1.0_wp
+      call timer%start("B", ierr=ierr)
+      fake_time = 2.0_wp
+      call timer%start("C", ierr=ierr)
+      fake_time = 3.0_wp
+      call timer%stop("A", ierr=ierr)
+
+      @assertEqual(FTIMER_ERR_MISMATCH, ierr)
+
+      fake_time = 5.0_wp
+      call timer%stop("C", ierr=ierr)
+      fake_time = 8.0_wp
+      call timer%stop("B", ierr=ierr)
+
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call assert_callback_trace(5, expected_timer_ids, expected_events, expected_timestamps)
+   end subroutine test_warn_does_not_fire_internal_callbacks
+
+   subroutine assert_callback_trace(expected_count, expected_timer_ids, expected_events, expected_timestamps)
+      integer, intent(in) :: expected_count
+      integer, intent(in) :: expected_timer_ids(:)
+      integer, intent(in) :: expected_events(:)
+      real(wp), intent(in) :: expected_timestamps(:)
+      integer :: i
+
+      @assertEqual(expected_count, callback_count)
+
+      do i = 1, expected_count
+         @assertEqual(expected_timer_ids(i), callback_timer_ids(i))
+         @assertEqual(expected_events(i), callback_events(i))
+         @assertEqual(expected_timestamps(i), callback_timestamps(i))
+         @assertTrue(callback_has_user_data(i))
+      end do
+   end subroutine assert_callback_trace
 
    subroutine record_callback(timer_id, context_idx, event, timestamp, user_data)
       integer, intent(in) :: timer_id

--- a/tests/test_nesting.pf
+++ b/tests/test_nesting.pf
@@ -3,7 +3,8 @@ module test_nesting
    use ftimer_core, only: ftimer_t, ftimer_test_state_t
    use ftimer_types, only: FTIMER_ERR_MISMATCH, FTIMER_MISMATCH_REPAIR, FTIMER_MISMATCH_WARN, FTIMER_SUCCESS, &
                            ftimer_call_stack_t, wp
-   use test_support, only: attach_mock_clock, build_stack, fake_time, find_context_idx, snapshot_timer
+   use test_support, only: attach_mock_clock, attach_scripted_mock_clock, build_stack, fake_time, find_context_idx, &
+                           get_mock_clock_call_count, snapshot_timer
    implicit none
 
 contains
@@ -192,5 +193,137 @@ contains
       @assertEqual(1, state%call_stack%depth)
       @assertTrue(state%segments(2)%is_running(ctx_b))
    end subroutine test_repair_mismatch_repairs_silently
+
+   @test
+   subroutine test_repair_uses_single_now_for_unwind_target_and_restart()
+      type(ftimer_t) :: timer
+      type(ftimer_test_state_t) :: state
+      type(ftimer_call_stack_t) :: root_stack
+      type(ftimer_call_stack_t) :: a_stack
+      type(ftimer_call_stack_t) :: ab_stack
+      type(ftimer_call_stack_t) :: b_stack
+      integer :: ierr
+      integer :: ctx_a_root
+      integer :: ctx_b_under_a
+      integer :: ctx_b_root
+      integer :: ctx_c_under_ab
+      integer :: ctx_c_under_b
+      integer :: call_count
+      real(wp) :: time_a_root
+      real(wp) :: time_b_under_a
+      real(wp) :: time_b_root
+      real(wp) :: time_c_under_ab
+      real(wp) :: time_c_under_b
+      real(wp), parameter :: scripted_times(6) = [0.0_wp, 10.0_wp, 20.0_wp, 30.0_wp, 40.0_wp, 50.0_wp]
+
+      call timer%init(mismatch_mode=FTIMER_MISMATCH_REPAIR, ierr=ierr)
+      call attach_scripted_mock_clock(timer, scripted_times)
+
+      call timer%start("A", ierr=ierr)
+      call timer%start("B", ierr=ierr)
+      call timer%start("C", ierr=ierr)
+      call timer%stop("A", ierr=ierr)
+      call timer%stop("C", ierr=ierr)
+      call timer%stop("B", ierr=ierr)
+
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call snapshot_timer(timer, state)
+
+      a_stack = build_stack([1])
+      ab_stack = build_stack([1, 2])
+      b_stack = build_stack([2])
+      ctx_a_root = find_context_idx(state, 1, root_stack)
+      ctx_b_under_a = find_context_idx(state, 2, a_stack)
+      ctx_b_root = find_context_idx(state, 2, root_stack)
+      ctx_c_under_ab = find_context_idx(state, 3, ab_stack)
+      ctx_c_under_b = find_context_idx(state, 3, b_stack)
+      time_a_root = state%segments(1)%time(ctx_a_root)
+      time_b_under_a = state%segments(2)%time(ctx_b_under_a)
+      time_b_root = state%segments(2)%time(ctx_b_root)
+      time_c_under_ab = state%segments(3)%time(ctx_c_under_ab)
+      time_c_under_b = state%segments(3)%time(ctx_c_under_b)
+      call_count = get_mock_clock_call_count()
+
+      @assertEqual(0, state%call_stack%depth)
+      @assertEqual(30.0_wp, time_a_root)
+      @assertEqual(20.0_wp, time_b_under_a)
+      @assertEqual(20.0_wp, time_b_root)
+      @assertEqual(10.0_wp, time_c_under_ab)
+      @assertEqual(10.0_wp, time_c_under_b)
+      @assertFalse(state%segments(2)%is_running(ctx_b_root))
+      @assertFalse(state%segments(3)%is_running(ctx_c_under_b))
+      @assertEqual(6, call_count)
+      @assertEqual(30.0_wp, state%segments(2)%start_time(ctx_b_root))
+      @assertEqual(30.0_wp, state%segments(3)%start_time(ctx_c_under_b))
+   end subroutine test_repair_uses_single_now_for_unwind_target_and_restart
+
+   @test
+   subroutine test_warn_multi_level_mismatch_restarts_in_order_and_continues()
+      type(ftimer_t) :: timer
+      type(ftimer_test_state_t) :: state
+      type(ftimer_call_stack_t) :: root_stack
+      type(ftimer_call_stack_t) :: a_stack
+      type(ftimer_call_stack_t) :: ab_stack
+      type(ftimer_call_stack_t) :: b_stack
+      integer :: ierr
+      integer :: ctx_a_root
+      integer :: ctx_b_under_a
+      integer :: ctx_b_root
+      integer :: ctx_c_under_ab
+      integer :: ctx_c_under_b
+      real(wp) :: time_a_root
+      real(wp) :: time_b_under_a
+      real(wp) :: time_b_root
+      real(wp) :: time_c_under_ab
+      real(wp) :: time_c_under_b
+
+      call timer%init(mismatch_mode=FTIMER_MISMATCH_WARN, ierr=ierr)
+      call attach_mock_clock(timer)
+
+      call timer%start("A", ierr=ierr)
+      fake_time = 1.0_wp
+      call timer%start("B", ierr=ierr)
+      fake_time = 2.0_wp
+      call timer%start("C", ierr=ierr)
+      fake_time = 5.0_wp
+      call timer%stop("A", ierr=ierr)
+
+      @assertEqual(FTIMER_ERR_MISMATCH, ierr)
+
+      call snapshot_timer(timer, state)
+      @assertEqual(2, state%call_stack%depth)
+      @assertEqual(3, state%call_stack%top())
+
+      fake_time = 8.0_wp
+      call timer%stop("C", ierr=ierr)
+      fake_time = 13.0_wp
+      call timer%stop("B", ierr=ierr)
+
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call snapshot_timer(timer, state)
+
+      a_stack = build_stack([1])
+      ab_stack = build_stack([1, 2])
+      b_stack = build_stack([2])
+      ctx_a_root = find_context_idx(state, 1, root_stack)
+      ctx_b_under_a = find_context_idx(state, 2, a_stack)
+      ctx_b_root = find_context_idx(state, 2, root_stack)
+      ctx_c_under_ab = find_context_idx(state, 3, ab_stack)
+      ctx_c_under_b = find_context_idx(state, 3, b_stack)
+      time_a_root = state%segments(1)%time(ctx_a_root)
+      time_b_under_a = state%segments(2)%time(ctx_b_under_a)
+      time_b_root = state%segments(2)%time(ctx_b_root)
+      time_c_under_ab = state%segments(3)%time(ctx_c_under_ab)
+      time_c_under_b = state%segments(3)%time(ctx_c_under_b)
+
+      @assertEqual(0, state%call_stack%depth)
+      @assertEqual(5.0_wp, time_a_root)
+      @assertEqual(4.0_wp, time_b_under_a)
+      @assertEqual(8.0_wp, time_b_root)
+      @assertEqual(3.0_wp, time_c_under_ab)
+      @assertEqual(3.0_wp, time_c_under_b)
+      @assertFalse(state%segments(2)%is_running(ctx_b_root))
+      @assertFalse(state%segments(3)%is_running(ctx_c_under_b))
+   end subroutine test_warn_multi_level_mismatch_restarts_in_order_and_continues
 
 end module test_nesting

--- a/tests/test_support.F90
+++ b/tests/test_support.F90
@@ -6,15 +6,22 @@ module test_support
    private
 
    public :: attach_mock_clock
+   public :: attach_scripted_mock_clock
    public :: build_stack
    public :: fake_time
+   public :: get_mock_clock_call_count
    public :: find_context_idx
    public :: mock_clock
    public :: read_file_text
+   public :: reset_mock_clock_state
    public :: read_unit_text
    public :: snapshot_timer
 
    real(wp), save :: fake_time = 0.0_wp
+   real(wp), allocatable, save :: scripted_times(:)
+   integer, save :: mock_clock_call_count = 0
+   integer, save :: scripted_time_idx = 0
+   logical, save :: use_scripted_times = .false.
 
 contains
 
@@ -22,8 +29,19 @@ contains
       class(ftimer_t), intent(inout) :: timer
 
       timer%clock => mock_clock
-      fake_time = 0.0_wp
+      call reset_mock_clock_state()
    end subroutine attach_mock_clock
+
+   subroutine attach_scripted_mock_clock(timer, values)
+      class(ftimer_t), intent(inout) :: timer
+      real(wp), intent(in) :: values(:)
+
+      timer%clock => mock_clock
+      call reset_mock_clock_state()
+      use_scripted_times = .true.
+      allocate (scripted_times(size(values)))
+      scripted_times = values
+   end subroutine attach_scripted_mock_clock
 
    type(ftimer_call_stack_t) function build_stack(ids) result(stack)
       integer, intent(in) :: ids(:)
@@ -45,8 +63,31 @@ contains
    function mock_clock() result(t)
       real(wp) :: t
 
+      mock_clock_call_count = mock_clock_call_count + 1
+
+      if (use_scripted_times) then
+         if (.not. allocated(scripted_times)) error stop "scripted mock clock is not configured"
+         if (scripted_time_idx >= size(scripted_times)) error stop "scripted mock clock exhausted"
+
+         scripted_time_idx = scripted_time_idx + 1
+         t = scripted_times(scripted_time_idx)
+         return
+      end if
+
       t = fake_time
    end function mock_clock
+
+   integer function get_mock_clock_call_count() result(count)
+      count = mock_clock_call_count
+   end function get_mock_clock_call_count
+
+   subroutine reset_mock_clock_state()
+      fake_time = 0.0_wp
+      mock_clock_call_count = 0
+      scripted_time_idx = 0
+      use_scripted_times = .false.
+      if (allocated(scripted_times)) deallocate (scripted_times)
+   end subroutine reset_mock_clock_state
 
    subroutine snapshot_timer(timer, state)
       class(ftimer_t), intent(in) :: timer


### PR DESCRIPTION
Closes #30

## Summary
- add a stateful scripted mock clock and call-count tracking for mismatch-repair tests
- add single-now and multi-level unwind/restart coverage in `tests/test_nesting.pf`
- add explicit warn-mode callback-suppression coverage and strengthen repair-mode coverage in `tests/test_callbacks.pf`

## Scenarios Added
- single-now repair accounting with a scripted clock that would fail if repair read the clock more than once
- multi-level `A -> B -> C` mismatch repair with continued execution afterward and assertions on restart order, stack shape, contexts, and accumulated times
- warn-mode callback suppression coverage for internal unwind/target-stop/restart transitions
- stronger repair-mode callback suppression coverage using a deeper mismatch scenario

## Pre-change Main Result
- no production bug was exposed by the new tests; the current `ftimer_core` mismatch-repair implementation already satisfied these invariants once the stronger tests were added
- this PR is therefore tests-only

## Production Changes
- none

## Verification
- `FC=/opt/homebrew/bin/gfortran cmake --fresh -B build -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/Users/hrh/.local/PFUNIT-4.15`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `FC=/opt/homebrew/bin/gfortran cmake --fresh -B build-smoke`
- `cmake --build build-smoke`
- `ctest --test-dir build-smoke --output-on-failure`
- `FC=/opt/homebrew/bin/gfortran cmake --fresh -B build-openmp -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/Users/hrh/.local/PFUNIT-4.15`
- `cmake --build build-openmp`
- `ctest --test-dir build-openmp --output-on-failure`
- `FC=/opt/homebrew/bin/gfortran cmake --fresh -B build-mpi -DFTIMER_USE_MPI=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/Users/hrh/.local/PFUNIT-4.15`
- `cmake --build build-mpi`
- `ctest --test-dir build-mpi --output-on-failure -L mpi`
- `find src -name '*.F90' -exec fprettify --diff {} +`
- `find tests -name '*.pf' -exec fprettify --diff {} +`
- `find tests -name '*.F90' -exec fprettify --diff {} +`

## Review Workflow
- applying `codex-software-review`
- applying `codex-methodology-review`
- not applying `codex-red-team-review` because `src/ftimer_core.F90` was not changed
- requesting the detailed/manual `Test Quality Review` path because there is no native label-triggered path for that review type