### PR TITLE
Neutralize review-source language and add quota-signal guidance in maintainer guide

### DIFF
--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -64,15 +64,15 @@ After opening or materially updating the PR:
 1. Inform the user that you are monitoring for reviews.
 2. Poll every 60 seconds for up to 10 minutes.
 3. Inspect actual review artifacts, not just workflow success.
-4. Watch PR comments for a message from `chatgpt-codex-connector` indicating quota or usage limit reached — if one appears, switch to the fallback flow immediately without waiting for the full 10-minute window.
+4. After the trigger workflow completes, watch for a `chatgpt-codex-connector` response to the `@codex review` trigger comment indicating the review will not proceed (e.g., quota exhausted). Note: the connector may also post unrelated comments when PR text contains the word "Codex" — those are not fallback signals; only a response to the trigger itself counts.
 5. Once all expected reviews have arrived, respond to every finding.
-6. If reviews have not arrived after 10 minutes and no quota message has appeared, tell the user and ask how to proceed.
+6. If reviews have not arrived after 10 minutes and no unavailability signal has appeared on the trigger comment, tell the user and ask how to proceed.
 
 ### Fallback When Native Codex Review Is Unavailable
 
 Use this fallback only when the label-triggered review path is unavailable or insufficient, for example:
 
-- Codex usage quota is exhausted (signalled by a `chatgpt-codex-connector` comment on the PR)
+- a `chatgpt-codex-connector` response to the `@codex review` trigger comment indicates the review will not proceed (e.g., quota exhausted) — note that connector comments triggered by PR text containing "Codex" are not this signal
 - the trigger workflow posts successfully but no actual review artifacts arrive after the normal wait window
 - the GitHub/Codex integration is unavailable
 


### PR DESCRIPTION
## Summary

- Replace "Codex reviews" with neutral language in prose that describes the review process and outputs — infrastructure names (`codex-*` labels, `@codex review` comment syntax, `"Codex Review Triggers"` workflow, product-specific limitations section) are unchanged
- Add monitoring step: watch for a `chatgpt-codex-connector` comment indicating quota/usage limit reached and switch to fallback immediately without waiting the full 10-minute window

Documentation-only change. No source code, build system, or repository behavior changes.

Closes #65

## Test plan
- [ ] `docs/maintainer.md` renders correctly on GitHub
- [ ] Codex infrastructure names are unchanged throughout
- [ ] Quota-signal step is present in `### Monitoring Reviews`
- [ ] Fallback section updated to name the specific trigger signal
- [ ] Codex software review applied and findings handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)