### PR TITLE
Add OpenMP build and test jobs to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,64 @@ jobs:
       - name: Test
         run: ctest --test-dir build --output-on-failure
 
+  build-openmp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gfortran cmake
+
+      # OpenMP smoke tests validate the OpenMP-enabled build path (no pFUnit required).
+      # pFUnit OpenMP behavioral tests run in the test-openmp job below.
+      - name: Configure (OpenMP)
+        run: FC=gfortran cmake -B build -DFTIMER_USE_OPENMP=ON
+
+      - name: Build
+        run: cmake --build build -j$(nproc)
+
+      - name: Smoke test
+        run: ctest --test-dir build --output-on-failure
+
+  test-openmp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # MPI is needed to build pFUnit (pfunit.mod requires MPI=YES).
+      # fTimer itself is built with OpenMP (not MPI) in this job.
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gfortran cmake libopenmpi-dev openmpi-bin
+
+      - name: Cache pFUnit
+        uses: actions/cache@v4
+        id: pfunit-cache
+        with:
+          path: /opt/pfunit
+          key: pfunit-${{ runner.os }}-gfortran-openmpi-v4.16.0
+
+      - name: Build pFUnit
+        if: steps.pfunit-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/pfunit-src
+          curl -fsSL https://github.com/Goddard-Fortran-Ecosystem/pFUnit/releases/download/v4.16.0/pFUnit-v4.16.0.tar | tar x --strip-components=1 -C /tmp/pfunit-src
+          FC=mpifort cmake -B /tmp/pfunit-build -S /tmp/pfunit-src -DCMAKE_INSTALL_PREFIX=/opt/pfunit -DMPI=YES
+          cmake --build /tmp/pfunit-build -j$(nproc)
+          cmake --install /tmp/pfunit-build
+
+      - name: Configure
+        run: FC=gfortran cmake -B build -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/opt/pfunit
+
+      - name: Build
+        run: cmake --build build -j$(nproc)
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Adds `build-openmp` CI job: configures with `FTIMER_USE_OPENMP=ON` and `FC=gfortran`, builds, and runs smoke tests
- Adds `test-openmp` CI job: builds pFUnit (cached), configures with `FTIMER_USE_OPENMP=ON` and pFUnit enabled, runs the full serial test suite including `test_openmp_guards.pf`
- Shares the same pFUnit cache key as the existing `test-serial` and `test-mpi` jobs

Closes #68

## Test plan

- [ ] `build-openmp` job passes (configure + build + smoke test)
- [ ] `test-openmp` job passes (pFUnit tests including OpenMP guard tests)
- [ ] Existing CI jobs unaffected (build-serial, build-mpi, test-serial, test-mpi, lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>