### PR TITLE
Add CI smoke test for benchmark binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,25 @@ jobs:
       - name: Test
         run: ctest --test-dir build --output-on-failure
 
+  build-bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gfortran cmake
+
+      - name: Configure (bench)
+        run: cmake -B build -DFTIMER_BUILD_BENCH=ON
+
+      - name: Build
+        run: cmake --build build -j$(nproc)
+
+      - name: Smoke test
+        run: ctest --test-dir build --output-on-failure
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ endif()
 add_subdirectory(src)
 
 # Tests
-if(FTIMER_BUILD_TESTS OR FTIMER_BUILD_SMOKE_TESTS)
+if(FTIMER_BUILD_TESTS OR FTIMER_BUILD_SMOKE_TESTS OR FTIMER_BUILD_BENCH)
   enable_testing()
 endif()
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,2 +1,8 @@
 add_executable(ftimer_bench ftimer_bench.F90)
 target_link_libraries(ftimer_bench PRIVATE ftimer)
+
+add_test(NAME bench_smoke COMMAND ftimer_bench)
+set_tests_properties(bench_smoke PROPERTIES
+  TIMEOUT 120
+  LABELS bench
+)


### PR DESCRIPTION
Closes #60

## Summary

- Register `bench_smoke` as a CTest entry in `bench/CMakeLists.txt` with a 120-second timeout and `bench` label, verifying the binary links, runs, and exits cleanly
- Include `FTIMER_BUILD_BENCH` in the root `enable_testing()` guard so `ctest` works in bench-only builds
- Add a `build-bench` CI job that configures, builds, and runs `ctest` with `FTIMER_BUILD_BENCH=ON`

## Test plan

- [ ] New `build-bench` CI job passes (binary links and exits 0)
- [ ] Existing CI jobs unaffected
- [ ] `ctest --test-dir build-bench` runs `bench_smoke` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)