### PR TITLE
Reorder init arguments to eliminate positional ierr trap

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Current `main` provides:
 Current public surface on `main` supports both usage styles:
 
 - `use ftimer` exports `ftimer_init`, `ftimer_finalize`, `ftimer_start`, `ftimer_stop`, `ftimer_start_id`, `ftimer_stop_id`, `ftimer_lookup`, `ftimer_reset`, `ftimer_get_summary`, `ftimer_mpi_summary`, `ftimer_print_summary`, `ftimer_write_summary`, and `ftimer_default_instance`
-  Current Phase 6 note: the safe, documented positional `init` forms are `call timer%init()` and `call ftimer_init()`. Pass `ierr`, `comm`, and `mismatch_mode` by keyword in both APIs. With the current Fortran interface, positional integer calls still compile but are ambiguous and can silently bind to `ierr`, so they are documented as unsupported traps.
+  `ierr` is now the last optional argument in both `init` signatures (`comm`, `mismatch_mode`, `ierr`). A single positional integer safely binds to `comm` (`intent(in)`), not `ierr` (`intent(out)`), eliminating the silent-clobber trap from earlier phases. Keywords are recommended for readability.
 - OOP core: `init`, `finalize`, `start`, `stop`, `start_id`, `stop_id`, `lookup`, `reset`, `get_summary`, `mpi_summary`, `print_summary`, and `write_summary`
 - `use ftimer` does not re-export shared types or constants. Import `ftimer_summary_t`, `ftimer_metadata_t`, `FTIMER_MISMATCH_*`, and `FTIMER_MPI_SUMMARY_*` from `ftimer_types`.
 - Procedural wrappers are thin forwarding calls over the existing OOP implementation and preserve the intended `ierr`/stderr error contract

--- a/docs/design.md
+++ b/docs/design.md
@@ -31,7 +31,7 @@ Current `main` is intentionally narrower than the target design below:
 - `ftimer_core.F90` implements `init`, `finalize`, `start`, `stop`, `start_id`, `stop_id`, `lookup`, `reset`, `get_summary`, `print_summary`, and `write_summary`
 - `ftimer_summary.F90` implements local summary building and formatted text reporting
 - `ftimer.F90` now exports the current procedural surface: `ftimer_init`, `ftimer_finalize`, `ftimer_start`, `ftimer_stop`, `ftimer_start_id`, `ftimer_stop_id`, `ftimer_lookup`, `ftimer_reset`, `ftimer_get_summary`, `ftimer_mpi_summary`, `ftimer_print_summary`, `ftimer_write_summary`, and `ftimer_default_instance`
-  Current Phase 6 note: the safe, documented positional `init` forms on current `main` are `call timer%init()` and `call ftimer_init()`. Pass `ierr`, `comm`, and `mismatch_mode` by keyword in both APIs. With the current Fortran interface, positional integer calls still compile but are ambiguous and can silently bind to `ierr`, so they are documented as unsupported traps.
+  `ierr` is now the last optional argument in both `init` signatures (`comm`, `mismatch_mode`, `ierr`). A single positional integer safely binds to `comm` (`intent(in)`), not `ierr` (`intent(out)`), eliminating the silent-clobber trap from earlier phases. Keywords are recommended for readability.
 - stack-based nesting, context-sensitive accounting, injectable clock use, and strict/warn/repair mismatch dispatch are implemented in the core runtime
 - pFUnit-backed behavioral tests exist for the Phase 2 core behaviors plus Phase 3 summary/self-time/file/callback coverage, Phase 4 procedural parity coverage, and Phase 5 MPI summary coverage
 - `mpi_summary()` / `ftimer_mpi_summary()` now provide MPI-reduced structured summaries on root after a descriptor-hash preflight, return local-only summaries with `FTIMER_ERR_MPI_INCON` on inconsistent ranks, return `FTIMER_ERR_NOT_IMPLEMENTED` in non-MPI builds, and require all timers to be stopped before cross-rank reduction
@@ -142,8 +142,8 @@ call timer%finalize([ierr])
 
 ### Procedural Convenience Interface
 ```fortran
-! Current main only supports the no-argument positional form.
-! Pass ierr, comm, and mismatch_mode by keyword.
+! Signature: ftimer_init([comm], [mismatch_mode], [ierr])
+! Keywords are recommended for readability.
 call ftimer_init()
 call ftimer_init(ierr=ierr)
 call ftimer_init(comm=..., mismatch_mode=..., ierr=...)
@@ -158,7 +158,7 @@ call ftimer_finalize([ierr])
 
 | Type-bound method | Procedural wrapper | Description |
 |---|---|---|
-| `timer%init(...)` | `ftimer_init(...)` | Initialize. The safe, documented positional form is `init()`; pass `ierr`, `comm`, and `mismatch_mode` by keyword. Positional integer calls still compile today but are ambiguous and unsupported. |
+| `timer%init(...)` | `ftimer_init(...)` | Initialize. Accepts optional `comm`, `mismatch_mode`, `ierr` (in that order). With `ierr` last, a single positional integer safely binds to `comm`, not `ierr`. Keywords are recommended for readability. |
 | `timer%finalize([ierr])` | `ftimer_finalize(...)` | Deallocate all. Warns if timers active. |
 | `timer%start(name [, ierr])` | `ftimer_start(...)` | Start timer by name (auto-creates). |
 | `timer%stop(name [, ierr])` | `ftimer_stop(...)` | Stop timer by name. |

--- a/src/ftimer.F90
+++ b/src/ftimer.F90
@@ -22,14 +22,14 @@ module ftimer
 
 contains
 
-   subroutine ftimer_init(ierr, comm, mismatch_mode)
-      integer, intent(out), optional :: ierr
+   subroutine ftimer_init(comm, mismatch_mode, ierr)
       integer, intent(in), optional :: comm
       integer, intent(in), optional :: mismatch_mode
+      integer, intent(out), optional :: ierr
 
-      ! Contract: use only `ftimer_init()` positionally.
-      ! Positional integer calls still compile with this Fortran interface,
-      ! but they are ambiguous and bind to the first integer dummy (`ierr`).
+      ! Contract: ierr is last to eliminate the positional intent(out) trap.
+      ! A single positional integer now binds to comm (intent(in)), not ierr.
+      ! Keywords are recommended for readability.
       call ftimer_default_instance%init(ierr=ierr, comm=comm, mismatch_mode=mismatch_mode)
    end subroutine ftimer_init
 

--- a/src/ftimer_core.F90
+++ b/src/ftimer_core.F90
@@ -99,25 +99,25 @@ module ftimer_core
 
 contains
 
-   subroutine init(self, ierr, comm, mismatch_mode)
+   subroutine init(self, comm, mismatch_mode, ierr)
       class(ftimer_t), intent(inout) :: self
-      integer, intent(out), optional :: ierr
       integer, intent(in), optional :: comm
       integer, intent(in), optional :: mismatch_mode
+      integer, intent(out), optional :: ierr
 
-      ! Contract: use only `timer%init()` positionally.
-      ! Positional integer calls still compile with this Fortran interface,
-      ! but they are ambiguous and bind to the first integer dummy (`ierr`).
+      ! Contract: ierr is last to eliminate the positional intent(out) trap.
+      ! A single positional integer now binds to comm (intent(in)), not ierr.
+      ! Keywords are recommended for readability.
       !$omp master
       call init_impl(self, ierr=ierr, comm=comm, mismatch_mode=mismatch_mode)
 !$omp end master
    end subroutine init
 
-   subroutine init_impl(self, ierr, comm, mismatch_mode)
+   subroutine init_impl(self, comm, mismatch_mode, ierr)
       class(ftimer_t), intent(inout) :: self
-      integer, intent(out), optional :: ierr
       integer, intent(in), optional :: comm
       integer, intent(in), optional :: mismatch_mode
+      integer, intent(out), optional :: ierr
       real(wp) :: now
 
       if (present(mismatch_mode)) then

--- a/tests/check_init_contract_docs.cmake
+++ b/tests/check_init_contract_docs.cmake
@@ -4,30 +4,29 @@ set(design_path "${REPO_ROOT}/docs/design.md")
 file(READ "${readme_path}" readme_text)
 file(READ "${design_path}" design_text)
 
+# Reject the old dangerous signature where ierr came first.
 if(readme_text MATCHES "ftimer_init\\(ierr\\)")
   message(FATAL_ERROR "README still documents legacy positional ftimer_init(ierr).")
-endif()
-
-if(design_text MATCHES "call timer%init\\(\\[comm\\] \\[, mismatch_mode\\] \\[, ierr\\]\\)")
-  message(FATAL_ERROR "docs/design.md still documents the ambiguous positional OOP init shape.")
 endif()
 
 if(design_text MATCHES "call ftimer_init\\(\\[ierr\\]\\)")
   message(FATAL_ERROR "docs/design.md still documents a positional integer procedural init form.")
 endif()
 
-if(NOT readme_text MATCHES "Pass `ierr`, `comm`, and `mismatch_mode` by keyword")
-  message(FATAL_ERROR "README must state that integer init arguments are passed safely by keyword.")
+# Require documentation of the ierr-last reorder and its safety rationale.
+if(NOT readme_text MATCHES "`ierr` is now the last optional argument")
+  message(FATAL_ERROR "README must document that ierr is last in the init signature.")
 endif()
 
-if(NOT design_text MATCHES "Pass `ierr`, `comm`, and `mismatch_mode` by keyword")
-  message(FATAL_ERROR "docs/design.md must state that integer init arguments are passed safely by keyword.")
+if(NOT design_text MATCHES "`ierr` is now the last optional argument")
+  message(FATAL_ERROR "docs/design.md must document that ierr is last in the init signature.")
 endif()
 
-if(NOT readme_text MATCHES "positional integer calls still compile but are ambiguous")
-  message(FATAL_ERROR "README must warn that positional integer init calls still compile but are ambiguous.")
+# Require keyword recommendation.
+if(NOT readme_text MATCHES "Keywords are recommended for readability")
+  message(FATAL_ERROR "README must recommend keyword arguments for readability.")
 endif()
 
-if(NOT design_text MATCHES "positional integer calls still compile but are ambiguous")
-  message(FATAL_ERROR "docs/design.md must warn that positional integer init calls still compile but are ambiguous.")
+if(NOT design_text MATCHES "Keywords are recommended for readability")
+  message(FATAL_ERROR "docs/design.md must recommend keyword arguments for readability.")
 endif()

--- a/tests/test_procedural_api.pf
+++ b/tests/test_procedural_api.pf
@@ -121,25 +121,29 @@ contains
    end subroutine test_procedural_init_keyword_options_match_oop
 
    @test
-   subroutine test_init_positional_integer_trap_is_ambiguous_for_both_apis()
-      use ftimer_types, only: FTIMER_MISMATCH_WARN
+   subroutine test_init_positional_integer_binds_safely_to_comm()
       type(ftimer_t) :: oop_timer
       type(ftimer_test_state_t) :: oop_state
       type(ftimer_test_state_t) :: procedural_state
       integer :: ierr
-      integer :: oop_mode
-      integer :: procedural_mode
+      integer :: oop_val
+      integer :: procedural_val
 
-      oop_mode = FTIMER_MISMATCH_WARN
-      call oop_timer%init(oop_mode)
+      ! After reorder, a single positional integer binds to comm (intent(in)),
+      ! not ierr (intent(out)).  The caller's variable is NOT clobbered.
+      oop_val = 42
+      call oop_timer%init(oop_val)
       call snapshot_timer(oop_timer, oop_state)
 
-      procedural_mode = FTIMER_MISMATCH_WARN
-      call ftimer_init(procedural_mode)
+      procedural_val = 42
+      call ftimer_init(procedural_val)
       call snapshot_timer(ftimer_default_instance, procedural_state)
 
-      @assertEqual(FTIMER_SUCCESS, oop_mode)
-      @assertEqual(FTIMER_SUCCESS, procedural_mode)
+      ! Key safety assertion: caller's variable is NOT overwritten
+      @assertEqual(42, oop_val)
+      @assertEqual(42, procedural_val)
+
+      ! mismatch_mode defaults to strict (was not passed)
       @assertEqual(FTIMER_MISMATCH_STRICT, oop_state%mismatch_mode)
       @assertEqual(FTIMER_MISMATCH_STRICT, procedural_state%mismatch_mode)
 
@@ -147,7 +151,7 @@ contains
       @assertEqual(FTIMER_SUCCESS, ierr)
       call ftimer_finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
-   end subroutine test_init_positional_integer_trap_is_ambiguous_for_both_apis
+   end subroutine test_init_positional_integer_binds_safely_to_comm
 
    @test
    subroutine test_procedural_start_stop_matches_oop()


### PR DESCRIPTION
Closes #50

## Summary

- Move `ierr` to last position in both `init` signatures: `init(self, comm, mismatch_mode, ierr)` for OOP, `ftimer_init(comm, mismatch_mode, ierr)` for procedural
- A single positional integer now safely binds to `comm` (`intent(in)`) instead of `ierr` (`intent(out)`), eliminating the silent-clobber trap
- Rewrite the trap test to verify the caller's variable is **not** overwritten
- Update doc-contract CMake test, README, and design docs to reflect the new safe signature

All existing callers already use keyword arguments or no arguments — no call-site changes needed outside the rewritten trap test.

## Test plan

- [ ] All CI jobs pass (smoke, serial pFUnit, MPI, OpenMP, bench, lint)
- [ ] Rewritten `test_init_positional_integer_binds_safely_to_comm` passes
- [ ] `ftimer_init_contract_docs` CTest passes with updated wording
- [ ] `fprettify --diff` clean on changed `.F90` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)