### PR TITLE
Fix macOS stderr capture harness instability

### DIFF
--- a/tests/test_edge_cases.pf
+++ b/tests/test_edge_cases.pf
@@ -324,6 +324,45 @@ contains
    end subroutine test_invalid_name_lookup_without_ierr_warns_stderr_and_is_noop
 
    @test
+   subroutine test_stderr_capture_isolates_sequential_warning_blocks()
+      type(ftimer_t) :: timer
+      character(len=:), allocatable :: first_stderr
+      character(len=:), allocatable :: second_stderr
+      integer :: capture_ierr
+      integer :: saved_fd
+      logical :: first_has_start
+      logical :: first_has_stop
+      logical :: second_has_start
+      logical :: second_has_stop
+
+      call begin_stderr_capture('test_stderr_capture_isolates_first.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      call timer%start('first')
+
+      call end_stderr_capture('test_stderr_capture_isolates_first.err', saved_fd, first_stderr, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      call begin_stderr_capture('test_stderr_capture_isolates_second.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      call timer%stop('second')
+
+      call end_stderr_capture('test_stderr_capture_isolates_second.err', saved_fd, second_stderr, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      first_has_start = index(first_stderr, 'ftimer start before init') > 0
+      first_has_stop = index(first_stderr, 'ftimer stop before init') > 0
+      second_has_start = index(second_stderr, 'ftimer start before init') > 0
+      second_has_stop = index(second_stderr, 'ftimer stop before init') > 0
+
+      @assertTrue(first_has_start)
+      @assertFalse(first_has_stop)
+      @assertFalse(second_has_start)
+      @assertTrue(second_has_stop)
+   end subroutine test_stderr_capture_isolates_sequential_warning_blocks
+
+   @test
    subroutine test_dynamic_growth_creates_many_segments()
       type(ftimer_t) :: timer
       type(ftimer_test_state_t) :: state

--- a/tests/test_support.F90
+++ b/tests/test_support.F90
@@ -1,7 +1,7 @@
 module test_support
    use ftimer_core, only: ftimer_t, ftimer_test_get_state, ftimer_test_state_t
    use ftimer_types, only: ftimer_call_stack_t, wp
-   use, intrinsic :: iso_c_binding, only: c_char, c_int, c_null_char, c_null_ptr, c_ptr
+   use, intrinsic :: iso_c_binding, only: c_associated, c_char, c_int, c_null_char, c_null_ptr, c_ptr
    use, intrinsic :: iso_fortran_env, only: error_unit, iostat_end, iostat_eor
    implicit none
    private
@@ -26,17 +26,7 @@ module test_support
    integer, save :: scripted_time_idx = 0
    logical, save :: use_scripted_times = .false.
 
-#ifdef __APPLE__
-   integer(c_int), parameter :: O_WRONLY = int(z'0001', c_int)
-   integer(c_int), parameter :: O_CREAT = int(z'0200', c_int)
-   integer(c_int), parameter :: O_TRUNC = int(z'0400', c_int)
-#else
-   integer(c_int), parameter :: O_WRONLY = int(z'0001', c_int)
-   integer(c_int), parameter :: O_CREAT = int(z'0040', c_int)
-   integer(c_int), parameter :: O_TRUNC = int(z'0200', c_int)
-#endif
    integer(c_int), parameter :: STDERR_FILENO = 2_c_int
-   integer(c_int), parameter :: STDERR_MODE = int(z'0180', c_int)
 
    interface
       integer(c_int) function c_close(fd) bind(C, name="close")
@@ -60,12 +50,21 @@ module test_support
          type(c_ptr), value :: stream
       end function c_fflush
 
-      integer(c_int) function c_open(path, flags, mode) bind(C, name="open")
-         import :: c_char, c_int
+      type(c_ptr) function c_fopen(path, mode) bind(C, name="fopen")
+         import :: c_char, c_ptr
          character(kind=c_char), intent(in) :: path(*)
-         integer(c_int), value :: flags
-         integer(c_int), value :: mode
-      end function c_open
+         character(kind=c_char), intent(in) :: mode(*)
+      end function c_fopen
+
+      integer(c_int) function c_fclose(stream) bind(C, name="fclose")
+         import :: c_int, c_ptr
+         type(c_ptr), value :: stream
+      end function c_fclose
+
+      integer(c_int) function c_fileno(stream) bind(C, name="fileno")
+         import :: c_int, c_ptr
+         type(c_ptr), value :: stream
+      end function c_fileno
    end interface
 
 contains
@@ -92,8 +91,10 @@ contains
       character(len=*), intent(in) :: path
       integer, intent(out) :: saved_fd
       integer, intent(out) :: ierr
+      character(kind=c_char, len=2), parameter :: c_write_mode = 'w'//c_null_char
       character(kind=c_char, len=:), allocatable :: c_path
       integer(c_int) :: capture_fd
+      type(c_ptr) :: capture_stream
       integer(c_int) :: saved_fd_c
 
       call delete_file_if_exists(path)
@@ -112,10 +113,23 @@ contains
          return
       end if
 
-      capture_fd = c_open(c_path, O_WRONLY + O_CREAT + O_TRUNC, STDERR_MODE)
+      ! Use stdio here instead of open(..., O_CREAT, mode): the variadic open
+      ! binding is not reliable on the affected macOS toolchain, and it can
+      ! leave capture files unreadable for later restore/read/delete steps.
+      capture_stream = c_fopen(c_path, c_write_mode)
+      if (.not. c_associated(capture_stream)) then
+         ierr = 1
+         saved_fd = int(saved_fd_c)
+         if (c_close(saved_fd_c) < 0_c_int) ierr = 1
+         saved_fd = -1
+         return
+      end if
+
+      capture_fd = c_fileno(capture_stream)
       if (capture_fd < 0_c_int) then
          ierr = 1
          saved_fd = int(saved_fd_c)
+         if (c_fclose(capture_stream) < 0_c_int) ierr = 1
          if (c_close(saved_fd_c) < 0_c_int) ierr = 1
          saved_fd = -1
          return
@@ -124,13 +138,13 @@ contains
       if (c_dup2(capture_fd, STDERR_FILENO) < 0_c_int) then
          ierr = 1
          saved_fd = int(saved_fd_c)
-         if (c_close(capture_fd) < 0_c_int) ierr = 1
+         if (c_fclose(capture_stream) < 0_c_int) ierr = 1
          if (c_close(saved_fd_c) < 0_c_int) ierr = 1
          saved_fd = -1
          return
       end if
 
-      if (c_close(capture_fd) < 0_c_int) then
+      if (c_fclose(capture_stream) < 0_c_int) then
          ierr = 1
          if (c_dup2(saved_fd_c, STDERR_FILENO) < 0_c_int) ierr = 1
          if (c_close(saved_fd_c) < 0_c_int) ierr = 1


### PR DESCRIPTION
## Summary

- Phase / issue: Phase 6 / Fixes #77
- Scope:
  - replace the fragile stderr capture file-open seam in `tests/test_support.F90`
  - restore a focused sequential capture/restore regression test in `tests/test_edge_cases.pf`
  - keep the existing stderr-vs-`ierr` assertions intact while making the harness reliable on the affected macOS/local path

## Checks

- [x] Linked to the relevant GitHub issue
- [x] `codex-software-review` label applied
- [ ] Added `codex-methodology-review` if core timing, MPI, or semantics changed
- [ ] Added `codex-red-team-review` if core timing stop/repair or MPI safety changed
- [ ] Docs updated to match behavior changes
- [x] Tests or smoke-path coverage updated as appropriate
- [ ] Workflow/bootstrap docs updated if repo process changed

## Notes

- Follow-up work:
  - none planned in this PR
- Deferred items:
  - platform-specific behavior is characterized here only as a test-harness issue; this PR does not broaden the library runtime contract

## Verification

- Reproduced the clean-`HEAD` local failure with `ctest --test-dir build --output-on-failure -R ftimer_serial_tests`
- Verified the fix with `ctest --test-dir build --output-on-failure -R ftimer_serial_tests`
