### PR TITLE
Issue #54: tighten stderr contract parity coverage

### DIFF
--- a/tests/test_edge_cases.pf
+++ b/tests/test_edge_cases.pf
@@ -3,8 +3,9 @@ module test_edge_cases
    use ftimer_core, only: ftimer_t, ftimer_test_state_t
    use ftimer_types, only: FTIMER_ERR_ACTIVE, FTIMER_ERR_INVALID_NAME, FTIMER_ERR_NOT_INIT, FTIMER_ERR_UNKNOWN, &
                            FTIMER_NAME_LEN, FTIMER_SUCCESS, ftimer_call_stack_t, wp
+   use, intrinsic :: iso_fortran_env, only: error_unit
    use test_support, only: attach_mock_clock, begin_stderr_capture, end_stderr_capture, fake_time, &
-                           find_context_idx, snapshot_timer
+                           find_context_idx, read_unit_text, snapshot_timer
    implicit none
 
 contains
@@ -24,43 +25,79 @@ contains
    @test
    subroutine test_print_summary_before_init_with_ierr_is_silent()
       type(ftimer_t) :: timer
+      type(ftimer_test_state_t) :: after_state
+      type(ftimer_test_state_t) :: before_state
       character(len=:), allocatable :: stderr_text
       integer :: capture_ierr
       integer :: ierr
       integer :: saved_fd
+      integer :: unit
       logical :: is_silent
+      logical :: state_unchanged
+      character(len=:), allocatable :: unit_text
 
+      call snapshot_timer(timer, before_state)
+      open (newunit=unit, status='scratch', action='readwrite')
       call begin_stderr_capture('test_print_summary_before_init_with_ierr.err', saved_fd, capture_ierr)
       @assertEqual(0, capture_ierr)
 
-      call timer%print_summary(ierr=ierr)
+      call timer%print_summary(unit=unit, ierr=ierr)
 
       call end_stderr_capture('test_print_summary_before_init_with_ierr.err', saved_fd, stderr_text, capture_ierr)
       @assertEqual(0, capture_ierr)
       @assertEqual(FTIMER_ERR_NOT_INIT, ierr)
 
       is_silent = len_trim(stderr_text) == 0
+      unit_text = read_unit_text(unit)
+      call snapshot_timer(timer, after_state)
+      state_unchanged = (after_state%initialized .eqv. before_state%initialized) .and. &
+                        (after_state%num_segments == before_state%num_segments) .and. &
+                        (after_state%call_stack%depth == before_state%call_stack%depth) .and. &
+                        (after_state%init_wtime == before_state%init_wtime) .and. &
+                        (after_state%init_date == before_state%init_date)
+
       @assertTrue(is_silent)
+      @assertEqual('', unit_text)
+      @assertTrue(state_unchanged)
+      close (unit)
    end subroutine test_print_summary_before_init_with_ierr_is_silent
 
    @test
    subroutine test_print_summary_before_init_without_ierr_warns_to_stderr()
       type(ftimer_t) :: timer
+      type(ftimer_test_state_t) :: after_state
+      type(ftimer_test_state_t) :: before_state
       character(len=:), allocatable :: stderr_text
       integer :: capture_ierr
       integer :: saved_fd
+      integer :: unit
       logical :: has_warning
+      logical :: state_unchanged
+      character(len=:), allocatable :: unit_text
 
+      call snapshot_timer(timer, before_state)
+      open (newunit=unit, status='scratch', action='readwrite')
       call begin_stderr_capture('test_print_summary_before_init_without_ierr.err', saved_fd, capture_ierr)
       @assertEqual(0, capture_ierr)
 
-      call timer%print_summary()
+      call timer%print_summary(unit=unit)
 
       call end_stderr_capture('test_print_summary_before_init_without_ierr.err', saved_fd, stderr_text, capture_ierr)
       @assertEqual(0, capture_ierr)
 
       has_warning = index(stderr_text, 'ftimer print_summary before init') > 0
+      unit_text = read_unit_text(unit)
+      call snapshot_timer(timer, after_state)
+      state_unchanged = (after_state%initialized .eqv. before_state%initialized) .and. &
+                        (after_state%num_segments == before_state%num_segments) .and. &
+                        (after_state%call_stack%depth == before_state%call_stack%depth) .and. &
+                        (after_state%init_wtime == before_state%init_wtime) .and. &
+                        (after_state%init_date == before_state%init_date)
+
       @assertTrue(has_warning)
+      @assertEqual('', unit_text)
+      @assertTrue(state_unchanged)
+      close (unit)
    end subroutine test_print_summary_before_init_without_ierr_warns_to_stderr
 
    @test
@@ -361,6 +398,36 @@ contains
       @assertFalse(second_has_start)
       @assertTrue(second_has_stop)
    end subroutine test_stderr_capture_isolates_sequential_warning_blocks
+
+   @test
+   subroutine test_stderr_capture_restores_and_isolates_direct_stderr_writes()
+      character(len=:), allocatable :: first_stderr
+      character(len=:), allocatable :: second_stderr
+      integer :: capture_ierr
+      integer :: saved_fd
+      logical :: first_has_message
+      logical :: second_is_silent
+
+      call begin_stderr_capture('test_stderr_capture_direct_first.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      write (error_unit, '(a)') 'direct stderr message'
+
+      call end_stderr_capture('test_stderr_capture_direct_first.err', saved_fd, first_stderr, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      call begin_stderr_capture('test_stderr_capture_direct_second.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      call end_stderr_capture('test_stderr_capture_direct_second.err', saved_fd, second_stderr, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      first_has_message = index(first_stderr, 'direct stderr message') > 0
+      second_is_silent = len_trim(second_stderr) == 0
+
+      @assertTrue(first_has_message)
+      @assertTrue(second_is_silent)
+   end subroutine test_stderr_capture_restores_and_isolates_direct_stderr_writes
 
    @test
    subroutine test_dynamic_growth_creates_many_segments()

--- a/tests/test_nesting.pf
+++ b/tests/test_nesting.pf
@@ -195,6 +195,114 @@ contains
    end subroutine test_warn_mismatch_without_ierr_repairs_and_continues
 
    @test
+   subroutine test_warn_mismatch_multilevel_with_ierr_repairs_silently()
+      type(ftimer_t) :: timer
+      type(ftimer_test_state_t) :: state
+      character(len=:), allocatable :: stderr_text
+      integer :: capture_ierr
+      type(ftimer_call_stack_t) :: root_stack
+      type(ftimer_call_stack_t) :: a_stack
+      integer :: ierr
+      integer :: saved_fd
+      integer :: ctx_a
+      integer :: ctx_b_under_a
+      integer :: ctx_b_root
+      integer :: ctx_c_under_ab
+      integer :: ctx_c_under_b
+      logical :: is_silent
+      real(wp) :: time_a
+      real(wp) :: time_b_under_a
+      real(wp) :: time_c_under_ab
+
+      call timer%init(mismatch_mode=FTIMER_MISMATCH_WARN, ierr=ierr)
+      call attach_mock_clock(timer)
+
+      call timer%start("A", ierr=ierr)
+      fake_time = 1.0_wp
+      call timer%start("B", ierr=ierr)
+      fake_time = 2.0_wp
+      call timer%start("C", ierr=ierr)
+      fake_time = 4.0_wp
+
+      call begin_stderr_capture('test_warn_mismatch_multilevel_with_ierr.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      call timer%stop("A", ierr=ierr)
+
+      call end_stderr_capture('test_warn_mismatch_multilevel_with_ierr.err', saved_fd, stderr_text, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      @assertEqual(FTIMER_ERR_MISMATCH, ierr)
+      is_silent = len_trim(stderr_text) == 0
+      @assertTrue(is_silent)
+
+      call snapshot_timer(timer, state)
+      a_stack = build_stack([1])
+      ctx_a = find_context_idx(state, 1, root_stack)
+      ctx_b_under_a = find_context_idx(state, 2, a_stack)
+      ctx_b_root = find_context_idx(state, 2, root_stack)
+      ctx_c_under_ab = find_context_idx(state, 3, build_stack([1, 2]))
+      ctx_c_under_b = find_context_idx(state, 3, build_stack([2]))
+      time_a = state%segments(1)%time(ctx_a)
+      time_b_under_a = state%segments(2)%time(ctx_b_under_a)
+      time_c_under_ab = state%segments(3)%time(ctx_c_under_ab)
+
+      @assertEqual(2, state%call_stack%depth)
+      @assertEqual(3, state%call_stack%top())
+      @assertEqual(4.0_wp, time_a)
+      @assertEqual(3.0_wp, time_b_under_a)
+      @assertEqual(2.0_wp, time_c_under_ab)
+      @assertTrue(state%segments(2)%is_running(ctx_b_root))
+      @assertTrue(state%segments(3)%is_running(ctx_c_under_b))
+   end subroutine test_warn_mismatch_multilevel_with_ierr_repairs_silently
+
+   @test
+   subroutine test_warn_mismatch_multilevel_without_ierr_warns_and_repairs()
+      type(ftimer_t) :: timer
+      type(ftimer_test_state_t) :: state
+      character(len=:), allocatable :: stderr_text
+      integer :: capture_ierr
+      type(ftimer_call_stack_t) :: root_stack
+      integer :: saved_fd
+      integer :: ctx_b
+      integer :: ctx_c
+      integer :: warning_pos
+      logical :: has_warning
+
+      call timer%init(mismatch_mode=FTIMER_MISMATCH_WARN)
+      call attach_mock_clock(timer)
+
+      call timer%start("A")
+      fake_time = 1.0_wp
+      call timer%start("B")
+      fake_time = 2.0_wp
+      call timer%start("C")
+      fake_time = 4.0_wp
+
+      call begin_stderr_capture('test_warn_mismatch_multilevel_without_ierr.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      call timer%stop("A")
+
+      call end_stderr_capture('test_warn_mismatch_multilevel_without_ierr.err', saved_fd, stderr_text, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      warning_pos = index(stderr_text, 'ftimer stop mismatch: requested A but top of stack is C')
+      has_warning = warning_pos > 0
+      @assertTrue(has_warning)
+      @assertEqual(1, warning_pos)
+
+      call snapshot_timer(timer, state)
+      ctx_b = find_context_idx(state, 2, root_stack)
+      ctx_c = find_context_idx(state, 3, build_stack([2]))
+
+      @assertEqual(2, state%call_stack%depth)
+      @assertEqual(3, state%call_stack%top())
+      @assertTrue(state%segments(2)%is_running(ctx_b))
+      @assertTrue(state%segments(3)%is_running(ctx_c))
+   end subroutine test_warn_mismatch_multilevel_without_ierr_warns_and_repairs
+
+   @test
    subroutine test_repair_mismatch_repairs_silently()
       type(ftimer_t) :: timer
       type(ftimer_test_state_t) :: state

--- a/tests/test_procedural_api.pf
+++ b/tests/test_procedural_api.pf
@@ -4,8 +4,10 @@ module test_procedural_api
                      ftimer_lookup, ftimer_print_summary, ftimer_reset, ftimer_start, ftimer_start_id, &
                      ftimer_stop, ftimer_stop_id, ftimer_write_summary
    use ftimer_core, only: ftimer_t, ftimer_test_state_t
-   use ftimer_types, only: FTIMER_MISMATCH_STRICT, FTIMER_SUCCESS, ftimer_metadata_t, ftimer_summary_t, wp
-   use test_support, only: attach_mock_clock, fake_time, read_file_text, read_unit_text, snapshot_timer
+   use ftimer_types, only: FTIMER_MISMATCH_STRICT, FTIMER_ERR_NOT_INIT, FTIMER_SUCCESS, ftimer_metadata_t, &
+                           ftimer_summary_t, wp
+   use test_support, only: attach_mock_clock, begin_stderr_capture, end_stderr_capture, fake_time, read_file_text, &
+                           read_unit_text, snapshot_timer
    implicit none
 
 contains
@@ -323,6 +325,153 @@ contains
 
       call cleanup_matching_timers(oop_timer, ierr)
    end subroutine test_procedural_print_summary_matches_oop
+
+   @test
+   subroutine test_procedural_start_before_init_matches_oop_stderr_contract()
+      type(ftimer_t) :: oop_timer
+      type(ftimer_test_state_t) :: oop_state
+      type(ftimer_test_state_t) :: procedural_state
+      character(len=:), allocatable :: oop_stderr
+      character(len=:), allocatable :: procedural_stderr
+      integer :: capture_ierr
+      integer :: ierr
+      integer :: saved_fd
+      logical :: oop_silent
+      logical :: procedural_silent
+      logical :: oop_warned
+      logical :: procedural_warned
+
+      call begin_stderr_capture('test_procedural_start_before_init_oop_ierr.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+      call oop_timer%start("before_init", ierr=ierr)
+      call end_stderr_capture('test_procedural_start_before_init_oop_ierr.err', saved_fd, oop_stderr, capture_ierr)
+      @assertEqual(0, capture_ierr)
+      @assertEqual(FTIMER_ERR_NOT_INIT, ierr)
+
+      call begin_stderr_capture('test_procedural_start_before_init_procedural_ierr.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+      call ftimer_start("before_init", ierr=ierr)
+      call end_stderr_capture('test_procedural_start_before_init_procedural_ierr.err', saved_fd, procedural_stderr, &
+                              capture_ierr)
+      @assertEqual(0, capture_ierr)
+      @assertEqual(FTIMER_ERR_NOT_INIT, ierr)
+
+      oop_silent = len_trim(oop_stderr) == 0
+      procedural_silent = len_trim(procedural_stderr) == 0
+      @assertTrue(oop_silent)
+      @assertTrue(procedural_silent)
+
+      call begin_stderr_capture('test_procedural_start_before_init_oop_warn.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+      call oop_timer%start("before_init")
+      call end_stderr_capture('test_procedural_start_before_init_oop_warn.err', saved_fd, oop_stderr, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      call begin_stderr_capture('test_procedural_start_before_init_procedural_warn.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+      call ftimer_start("before_init")
+      call end_stderr_capture('test_procedural_start_before_init_procedural_warn.err', saved_fd, procedural_stderr, &
+                              capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      oop_warned = index(oop_stderr, 'ftimer start before init') > 0
+      procedural_warned = index(procedural_stderr, 'ftimer start before init') > 0
+      @assertTrue(oop_warned)
+      @assertTrue(procedural_warned)
+
+      call snapshot_timer(oop_timer, oop_state)
+      call snapshot_timer(ftimer_default_instance, procedural_state)
+      @assertFalse(oop_state%initialized)
+      @assertFalse(procedural_state%initialized)
+      @assertEqual(0, oop_state%num_segments)
+      @assertEqual(0, procedural_state%num_segments)
+      @assertEqual(0, oop_state%call_stack%depth)
+      @assertEqual(0, procedural_state%call_stack%depth)
+   end subroutine test_procedural_start_before_init_matches_oop_stderr_contract
+
+   @test
+   subroutine test_procedural_print_summary_before_init_matches_oop()
+      type(ftimer_t) :: oop_timer
+      type(ftimer_test_state_t) :: oop_state
+      type(ftimer_test_state_t) :: procedural_state
+      character(len=:), allocatable :: oop_stderr
+      character(len=:), allocatable :: procedural_stderr
+      character(len=:), allocatable :: oop_text
+      character(len=:), allocatable :: procedural_text
+      integer :: capture_ierr
+      integer :: ierr
+      integer :: oop_unit
+      integer :: procedural_unit
+      integer :: saved_fd
+      logical :: oop_warned
+      logical :: procedural_warned
+      logical :: oop_silent
+      logical :: procedural_silent
+
+      open (newunit=oop_unit, status='scratch', action='readwrite')
+      open (newunit=procedural_unit, status='scratch', action='readwrite')
+
+      call begin_stderr_capture('test_procedural_print_summary_before_init_oop.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+      call oop_timer%print_summary(unit=oop_unit)
+      call end_stderr_capture('test_procedural_print_summary_before_init_oop.err', saved_fd, oop_stderr, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      call begin_stderr_capture('test_procedural_print_summary_before_init_procedural.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+      call ftimer_print_summary(unit=procedural_unit)
+      call end_stderr_capture('test_procedural_print_summary_before_init_procedural.err', saved_fd, procedural_stderr, &
+                              capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      oop_text = read_unit_text(oop_unit)
+      procedural_text = read_unit_text(procedural_unit)
+      oop_warned = index(oop_stderr, 'ftimer print_summary before init') > 0
+      procedural_warned = index(procedural_stderr, 'ftimer print_summary before init') > 0
+
+      @assertTrue(oop_warned)
+      @assertTrue(procedural_warned)
+      @assertEqual('', oop_text)
+      @assertEqual('', procedural_text)
+
+      call begin_stderr_capture('test_procedural_print_summary_before_init_oop_ierr.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+      call oop_timer%print_summary(unit=oop_unit, ierr=ierr)
+      call end_stderr_capture('test_procedural_print_summary_before_init_oop_ierr.err', saved_fd, oop_stderr, &
+                              capture_ierr)
+      @assertEqual(0, capture_ierr)
+      @assertEqual(FTIMER_ERR_NOT_INIT, ierr)
+
+      call begin_stderr_capture('test_procedural_print_summary_before_init_procedural_ierr.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+      call ftimer_print_summary(unit=procedural_unit, ierr=ierr)
+      call end_stderr_capture('test_procedural_print_summary_before_init_procedural_ierr.err', saved_fd, &
+                              procedural_stderr, capture_ierr)
+      @assertEqual(0, capture_ierr)
+      @assertEqual(FTIMER_ERR_NOT_INIT, ierr)
+
+      oop_text = read_unit_text(oop_unit)
+      procedural_text = read_unit_text(procedural_unit)
+      oop_silent = len_trim(oop_stderr) == 0
+      procedural_silent = len_trim(procedural_stderr) == 0
+
+      @assertEqual('', oop_text)
+      @assertEqual('', procedural_text)
+      @assertTrue(oop_silent)
+      @assertTrue(procedural_silent)
+
+      call snapshot_timer(oop_timer, oop_state)
+      call snapshot_timer(ftimer_default_instance, procedural_state)
+      @assertFalse(oop_state%initialized)
+      @assertFalse(procedural_state%initialized)
+      @assertEqual(0, oop_state%num_segments)
+      @assertEqual(0, procedural_state%num_segments)
+      @assertEqual(0, oop_state%call_stack%depth)
+      @assertEqual(0, procedural_state%call_stack%depth)
+
+      close (oop_unit)
+      close (procedural_unit)
+   end subroutine test_procedural_print_summary_before_init_matches_oop
 
    @test
    subroutine test_procedural_write_summary_matches_oop()


### PR DESCRIPTION
## Summary

- Phase / issue: Phase 6 / #54
- Scope: Extend stderr-vs-`ierr` contract coverage for wrapper parity, before-init `print_summary(unit=...)` suppression/state stability, multi-level warn-mode diagnostics, and stderr-capture restoration/isolation.

## Checks

- [x] Linked to the relevant GitHub issue
- [x] `codex-software-review` label applied
- [ ] Added `codex-methodology-review` if core timing, MPI, or semantics changed
- [ ] Added `codex-red-team-review` if core timing stop/repair or MPI safety changed
- [x] Docs updated to match behavior changes
- [x] Tests or smoke-path coverage updated as appropriate
- [ ] Workflow/bootstrap docs updated if repo process changed

## Notes

- Follow-up work: None beyond normal review findings handling.
- Deferred items: None. This stays scoped to test coverage and harness hardening deferred from PR #53.

Closes #54.

Verification:
- `cmake --build build-pf`
- `ctest --test-dir build-pf --output-on-failure -R ftimer_serial_tests`
