### PR TITLE
Add OpenMP example for supported timing pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ For metadata headers, construct `ftimer_metadata_t` values directly by assigning
 - `examples/basic_usage.F90`: serial procedural usage with `start`, `stop`, `get_summary`, and `print_summary`
 - `examples/nested_timers.F90`: nested timers plus manual `ftimer_metadata_t` header fields
 - `examples/mpi_example.F90`: MPI-only example showing `ftimer_init(comm=...)` and root-side reduced summary fields from `ftimer_mpi_summary()`
+- `examples/openmp_example.F90`: OpenMP-only example showing the supported pattern of placing `start`/`stop` outside the `!$omp parallel` block to time the full parallel region wall-clock duration
 
 ## Target Capabilities
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,3 +9,8 @@ if(FTIMER_USE_MPI)
   add_executable(mpi_example mpi_example.F90)
   target_link_libraries(mpi_example PRIVATE ftimer)
 endif()
+
+if(FTIMER_USE_OPENMP)
+  add_executable(openmp_example openmp_example.F90)
+  target_link_libraries(openmp_example PRIVATE ftimer)
+endif()

--- a/examples/openmp_example.F90
+++ b/examples/openmp_example.F90
@@ -1,0 +1,41 @@
+program openmp_example
+   use ftimer, only: ftimer_finalize, ftimer_get_summary, ftimer_init, &
+                     ftimer_print_summary, ftimer_start, ftimer_stop
+   use ftimer_types, only: ftimer_summary_t
+   use omp_lib, only: omp_get_num_threads
+   implicit none
+   integer :: i
+   integer :: nthreads
+   real :: accumulator
+   type(ftimer_summary_t) :: summary
+
+   nthreads = 1
+   accumulator = 0.0
+
+   call ftimer_init()
+
+   ! Supported pattern: time the parallel region as a whole by starting and
+   ! stopping outside the !$omp parallel block.
+   call ftimer_start("parallel_region")
+!$omp parallel default(none) shared(accumulator, nthreads) private(i)
+   do i = 1, 150000
+!$omp atomic update
+      accumulator = accumulator + real(i)
+   end do
+!$omp single
+   nthreads = omp_get_num_threads()
+!$omp end single
+
+   ! Misleading anti-pattern: placing ftimer_start/ftimer_stop inside this
+   ! parallel region does not collect per-thread timings. Worker-thread calls
+   ! are silent no-ops under the supported FTIMER_USE_OPENMP contract.
+!$omp end parallel
+   call ftimer_stop("parallel_region")
+
+   call ftimer_get_summary(summary)
+   print '(a,i0)', "OpenMP threads observed: ", nthreads
+   print '(a,i0)', "Recorded timers: ", summary%num_entries
+   call ftimer_print_summary()
+   call ftimer_finalize()
+   if (accumulator < 0.0) print *, accumulator
+end program openmp_example


### PR DESCRIPTION
## Summary

- Phase / issue: Phase 6 / Closes #56
- Scope: add an OpenMP example program that demonstrates the supported master-thread timing pattern, wire it into the examples build only when `FTIMER_USE_OPENMP=ON`, and list it in the README examples section

## Checks

- [x] Linked to the relevant GitHub issue
- [ ] `codex-software-review` label applied
- [ ] Added `codex-methodology-review` if core timing, MPI, or semantics changed
- [ ] Added `codex-red-team-review` if core timing stop/repair or MPI safety changed
- [x] Docs updated to match behavior changes
- [ ] Tests or smoke-path coverage updated as appropriate
- [ ] Workflow/bootstrap docs updated if repo process changed

## Notes

- Follow-up work: none
- Deferred items: none