### PR TITLE
docs: centralize detailed prompt library inventory

### DIFF
--- a/.github/prompts/detailed/README.md
+++ b/.github/prompts/detailed/README.md
@@ -1,9 +1,27 @@
 # Detailed Review Prompts
 
-This directory stores the long-form review prompt library.
+This directory is the authoritative inventory for the long-form review prompt library.
 
 - `.github/prompts/*.md` remains the condensed prompt set used by the native label-triggered Codex PR workflow.
-- `software-review.md`, `methodology-review.md`, and `red-team-review.md` are the detailed fallback versions of those PR-triggered reviews.
-- `api-compat-review.md`, `build-portability-review.md`, `completion-audit-review.md`, `docs-contract-review.md`, `mpi-safety-review.md`, `performance-overhead-review.md`, `pragmatic-design-review.md`, and `test-quality-review.md` are additional deep-review prompts for longer-horizon repository reviews that are not wired to PR labels by default.
-  - Use `completion-audit-review.md` at issue, phase, or release boundaries to verify that claimed work is actually complete and that docs, tests, and acceptance criteria are honestly closed.
-  - Use `pragmatic-design-review.md` selectively on PRs that introduce new abstractions, wrappers, or architecture to catch unnecessary complexity before it accumulates.
+- Keep the top-level prompts reserved for label-triggered native reviews.
+- Use the detailed prompts in this directory for manual fallback reviews or deeper repository-health reviews that are not wired to PR labels by default.
+- Do not paste a detailed prompt into a PR unless you are intentionally using the documented fallback flow.
+
+## Prompt Catalog
+
+### Fallback versions of the PR-triggered reviews
+
+- `software-review.md` — detailed fallback version of the `codex-software-review` PR review.
+- `methodology-review.md` — detailed fallback version of the `codex-methodology-review` PR review.
+- `red-team-review.md` — detailed fallback version of the `codex-red-team-review` PR review.
+
+### Additional detailed reviews
+
+- `api-compat-review.md` — targeted review for API stability, user-facing compatibility, and upgrade risk.
+- `build-portability-review.md` — targeted review for build behavior, toolchain assumptions, and portability regressions.
+- `completion-audit-review.md` — use at issue, phase, or release boundaries to verify that claimed work is actually complete and that docs, tests, and acceptance criteria are honestly closed. Not intended as a routine per-PR review.
+- `docs-contract-review.md` — targeted review for documentation accuracy and implementation-contract drift.
+- `mpi-safety-review.md` — targeted review for MPI collectives, rank consistency, and distributed-summary safety.
+- `performance-overhead-review.md` — targeted review for overhead, hot-path cost, and unintended performance regressions.
+- `pragmatic-design-review.md` — use selectively on PRs that introduce new abstractions, wrappers, or architecture; skip it for narrow bug fixes or documentation-only changes.
+- `test-quality-review.md` — targeted review for whether tests really exercise the claimed behavior and guard against regressions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,7 @@ Short version:
 
 For deeper workflow details (monitoring, fallback review, findings disposition, merge criteria), use `docs/maintainer.md` for routing to: `docs/workflows/pr-open.md`, `docs/workflows/review-monitoring.md`, `docs/workflows/findings-disposition.md`.
 
-The native Codex trigger comments are intentionally posted as single-line `@codex review ...` comments built from `.github/prompts/*.md`. The long-form prompt library lives in `.github/prompts/detailed/`: it contains detailed versions of the three PR-triggered review types plus eight additional review prompts for API/compatibility, build/portability, completion auditing, docs/contracts, MPI safety, performance/overhead, pragmatic design, and test quality.
+The native Codex trigger comments are intentionally posted as single-line `@codex review ...` comments built from `.github/prompts/*.md`. Keep those top-level prompts reserved for the label-triggered PR workflow. Use the detailed prompt library for manual fallback reviews or deeper repository-health reviews that are not wired to PR labels, and treat `.github/prompts/detailed/README.md` as the authoritative catalog of prompt names and usage context.
 
 ### Review Standards
 
@@ -219,7 +219,7 @@ The native Codex trigger comments are intentionally posted as single-line `@code
 4. **Verify docs match implementation**: If the PR changes behavior, check that CLAUDE.md, README, and any relevant comments are updated.
 5. **Prefer fewer, more serious findings**: Two real concerns are worth more than twenty style nits.
 6. **Begin your response with the review type heading** expected by the prompt so it is clear which review you are responding to.
-7. **Match the detailed prompt library when used**: `.github/prompts/detailed/` also defines long-form review headings such as `## API / Compatibility Review`, `## Build / Portability Review`, `## Completion Audit Review`, `## Docs / Contract Review`, `## MPI Safety Review`, `## Performance / Overhead Review`, `## Pragmatic Design Review`, and `## Test Quality Review`.
+7. **Match the detailed prompt library when used**: follow the prompt names, headings, and usage context documented in `.github/prompts/detailed/README.md`.
 
 ## Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,7 @@ Short version:
 
 For deeper workflow details (monitoring, fallback review, findings disposition, merge criteria), use `docs/maintainer.md` for routing to: `docs/workflows/pr-open.md`, `docs/workflows/review-monitoring.md`, `docs/workflows/findings-disposition.md`.
 
-The native Codex trigger comments are intentionally posted as single-line `@codex review ...` comments built from `.github/prompts/*.md`. The long-form prompt library lives in `.github/prompts/detailed/`: it contains detailed versions of the three PR-triggered review types plus eight additional review prompts for API/compatibility, build/portability, completion auditing, docs/contracts, MPI safety, performance/overhead, pragmatic design, and test quality.
+The native Codex trigger comments are intentionally posted as single-line `@codex review ...` comments built from `.github/prompts/*.md`. Keep those top-level prompts reserved for the label-triggered PR workflow. Use the detailed prompt library for manual fallback reviews or deeper repository-health reviews that are not wired to PR labels, and treat `.github/prompts/detailed/README.md` as the authoritative catalog of prompt names and usage context.
 
 ### Review Standards
 
@@ -219,7 +219,7 @@ The native Codex trigger comments are intentionally posted as single-line `@code
 4. **Verify docs match implementation**: If the PR changes behavior, check that CLAUDE.md, README, and any relevant comments are updated.
 5. **Prefer fewer, more serious findings**: Two real concerns are worth more than twenty style nits.
 6. **Begin your response with the review type heading** expected by the prompt so it is clear which review you are responding to.
-7. **Match the detailed prompt library when used**: `.github/prompts/detailed/` also defines long-form review headings such as `## API / Compatibility Review`, `## Build / Portability Review`, `## Completion Audit Review`, `## Docs / Contract Review`, `## MPI Safety Review`, `## Performance / Overhead Review`, `## Pragmatic Design Review`, and `## Test Quality Review`.
+7. **Match the detailed prompt library when used**: follow the prompt names, headings, and usage context documented in `.github/prompts/detailed/README.md`.
 
 ## Configuration
 

--- a/docs/workflows/pr-open.md
+++ b/docs/workflows/pr-open.md
@@ -28,14 +28,8 @@ For every scoped piece of work:
 
 ## Detailed Prompt Library
 
-The native trigger workflow posts single-line `@codex review ...` comments built from `.github/prompts/`. The long-form prompt library lives in `.github/prompts/detailed/`. Keep the top-level prompts reserved for label-triggered native reviews; use the detailed prompts for manual fallback reviews or deeper repo-health reviews that are not wired to PR labels. Do not paste a detailed prompt into a PR unless you are intentionally using the documented fallback flow.
+The native trigger workflow posts single-line `@codex review ...` comments built from `.github/prompts/`. The authoritative inventory for the long-form prompt library lives in `.github/prompts/detailed/README.md`.
 
-The detailed prompt set has two roles:
+Keep the top-level prompts reserved for label-triggered native reviews. Use the detailed prompts for manual fallback reviews or deeper repo-health reviews that are not wired to PR labels by default. Do not paste a detailed prompt into a PR unless you are intentionally using the documented fallback flow.
 
-- long-form fallback versions of the three PR-triggered review types: `software-review.md`, `methodology-review.md`, and `red-team-review.md`
-- additional long-horizon review prompts that are not label-triggered by default: `api-compat-review.md`, `build-portability-review.md`, `completion-audit-review.md`, `docs-contract-review.md`, `mpi-safety-review.md`, `performance-overhead-review.md`, `pragmatic-design-review.md`, and `test-quality-review.md`
-
-Use the additional detailed prompts for targeted repository reviews outside the normal PR trigger flow, such as periodic maintainability checks, pre-release audits, or focused follow-up investigation on a risky area.
-
-- Use `completion-audit-review.md` at issue, phase, or release boundaries to verify that claimed work is actually complete and that docs, tests, and acceptance criteria are honestly closed. Not intended as a routine per-PR review.
-- Use `pragmatic-design-review.md` selectively on PRs that introduce new abstractions, wrappers, or architecture. Skip it for narrow bug fixes or documentation-only changes.
+When you need the available detailed prompt names or their intended usage context, consult `.github/prompts/detailed/README.md` instead of duplicating that inventory here.


### PR DESCRIPTION
## Summary
- make `.github/prompts/detailed/README.md` the authoritative catalog for the detailed prompt library
- keep `AGENTS.md`, `CLAUDE.md`, and `docs/workflows/pr-open.md` focused on stable operational guidance plus a pointer to the catalog
- preserve the auto-injected agent instructions while removing the duplicated prompt inventory

Closes #62

## Testing
- not run (documentation-only change)