### PR TITLE
[codex] Make README release-ready for initial adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ end program quick_start
 
 Use `ftimer` for the procedural API and `ftimer_types` for shared types and constants such as `ftimer_summary_t`, `ftimer_metadata_t`, `FTIMER_MISMATCH_*`, and `FTIMER_MPI_SUMMARY_*`.
 
+For metadata headers, construct `ftimer_metadata_t` values by assigning `%key` and `%value` directly. fTimer does not currently provide a helper constructor such as `ftimer_metadata(...)`.
+
 ## First Success
 
 The fastest evaluation path is the serial smoke build plus the `basic_usage` example:


### PR DESCRIPTION
## Summary
Rewrites the top-level README so it reads like release-ready software instead of an implementation-phase status note.

## What changed
- replace phase/history framing with product-focused positioning and supported workflows
- add a copy-pasteable first-success walkthrough with expected output shape
- add installed-package consumer guidance using `find_package(fTimer CONFIG REQUIRED)` and `CMAKE_PREFIX_PATH`
- keep current MPI/OpenMP constraints explicit without centering internal project history
- retain the required `ftimer_init` contract note that `ierr` is the last optional argument

## Why
Issue #95 calls for a README that a first-time adopter can evaluate from the public entry page alone. The supporting README gaps from #91 and #96 are covered in the same rewrite.

## Validation
- `cmake -B build-smoke`
- `cmake --build build-smoke --target basic_usage`
- `./build-smoke/examples/basic_usage`
- `ctest --test-dir build-smoke --output-on-failure`

Closes #95
Closes #91
Closes #96