### PR TITLE
[codex] Curate installed module surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ The supported downstream contract is the installed package export. New adopters 
 
 The downstream example under [`tests/install-consumer/`](tests/install-consumer/) is also part of the smoke path. It shows the supported installed-package happy path with `find_package(fTimer CONFIG REQUIRED)`, `use ftimer_types`, timer start/stop calls, and summary retrieval from an installed prefix.
 
+The installed public module surface is intentionally curated to these modules: `ftimer`, `ftimer_clock`, `ftimer_core`, `ftimer_mpi`, `ftimer_summary`, and `ftimer_types`. The current validated toolchain matrix does not require any extra compiler-specific companion artifacts in the installed include tree. If a future compiler proves that such artifacts are truly required for downstream consumption, they should be added deliberately and documented as an explicit exception rather than leaked accidentally.
+
 ## API Surface
 
 The public API supports two styles:

--- a/cmake/install_ftimer_modules.cmake.in
+++ b/cmake/install_ftimer_modules.cmake.in
@@ -1,7 +1,5 @@
-# Install a curated public module surface rather than copying the entire
-# compiler module output directory wholesale. Compiler-specific companion
-# artifacts for the public `ftimer_core` surface are installed only when the
-# compiler emits them.
+# Install the intentional public module surface rather than copying the entire
+# compiler module output directory wholesale.
 
 set(ftimer_install_module_dir "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@/ftimer")
 file(MAKE_DIRECTORY "${ftimer_install_module_dir}")
@@ -27,27 +25,5 @@ foreach(ftimer_module_name IN LISTS ftimer_public_module_names)
     DESTINATION "${ftimer_install_module_dir}"
     TYPE FILE
     FILES "${ftimer_module_file}"
-  )
-endforeach()
-
-set(ftimer_public_companion_globs
-  "@CMAKE_BINARY_DIR@/mod/ftimer/ftimer_core-*.mod"
-  "@CMAKE_BINARY_DIR@/mod/ftimer/ftimer_core-*.smod"
-  "@CMAKE_BINARY_DIR@/mod/ftimer_core-*.mod"
-  "@CMAKE_BINARY_DIR@/mod/ftimer_core-*.smod"
-)
-
-set(ftimer_public_companion_files)
-foreach(ftimer_companion_glob IN LISTS ftimer_public_companion_globs)
-  file(GLOB ftimer_globbed_companions LIST_DIRECTORIES FALSE "${ftimer_companion_glob}")
-  list(APPEND ftimer_public_companion_files ${ftimer_globbed_companions})
-endforeach()
-list(REMOVE_DUPLICATES ftimer_public_companion_files)
-
-foreach(ftimer_companion_file IN LISTS ftimer_public_companion_files)
-  file(INSTALL
-    DESTINATION "${ftimer_install_module_dir}"
-    TYPE FILE
-    FILES "${ftimer_companion_file}"
   )
 endforeach()

--- a/tests/check_installed_package_consumer.cmake
+++ b/tests/check_installed_package_consumer.cmake
@@ -4,6 +4,7 @@ set(install_prefix "${TEST_BINARY_DIR}/prefix")
 set(consumer_build_dir "${TEST_BINARY_DIR}/consumer-build")
 set(consumer_source_dir "${REPO_ROOT}/tests/install-consumer")
 set(test_name "${TEST_NAME}")
+set(installed_module_dir "${install_prefix}/include/ftimer")
 
 if(test_name STREQUAL "")
   set(test_name "ftimer_installed_package_consumer")
@@ -94,6 +95,35 @@ execute_process(
 )
 if(NOT producer_install_result EQUAL 0)
   message(FATAL_ERROR "Failed to install the producer package.")
+endif()
+
+set(expected_installed_modules
+  ftimer.mod
+  ftimer_clock.mod
+  ftimer_core.mod
+  ftimer_mpi.mod
+  ftimer_summary.mod
+  ftimer_types.mod
+)
+
+file(GLOB installed_module_paths LIST_DIRECTORIES FALSE "${installed_module_dir}/*")
+set(installed_module_names)
+foreach(installed_module_path IN LISTS installed_module_paths)
+  get_filename_component(installed_module_name "${installed_module_path}" NAME)
+  list(APPEND installed_module_names "${installed_module_name}")
+endforeach()
+
+list(SORT expected_installed_modules)
+list(SORT installed_module_names)
+
+if(NOT installed_module_names STREQUAL expected_installed_modules)
+  list(JOIN expected_installed_modules ", " expected_installed_modules_text)
+  list(JOIN installed_module_names ", " installed_module_names_text)
+  message(FATAL_ERROR
+    "Installed module surface mismatch.\n"
+    "Expected: ${expected_installed_modules_text}\n"
+    "Actual: ${installed_module_names_text}"
+  )
 endif()
 
 set(consumer_configure_args


### PR DESCRIPTION
## Summary
- stop exporting compiler-specific `ftimer_core-*` companion artifacts from the installed include tree
- assert in the installed-consumer smoke test that the installed module surface is exactly the intended public set
- document the curated installed module contract in the README, including that the current validated matrix does not require any extra companion artifacts

## Why
Issue #106 stayed open after PR #107 because the install step still had a fallback that exported any `ftimer_core-*` companion module artifact the compiler emitted. That left the installed surface more permissive and compiler-dependent than the intended public API contract.

This PR finishes that follow-up by making the installed include tree explicit and test-enforced instead of relying on broad companion globs.

## Impact
Downstream consumers now see only the intended installed public modules:
- `ftimer`
- `ftimer_clock`
- `ftimer_core`
- `ftimer_mpi`
- `ftimer_summary`
- `ftimer_types`

The validated GNU and Homebrew Flang paths both pass with that stricter surface, so there is no current documented exception for extra compiler-specific companion artifacts.

## Validation
- `FC=gfortran cmake --fresh -B build-smoke-gfortran-106`
- `cmake --build build-smoke-gfortran-106`
- `ctest --test-dir build-smoke-gfortran-106 --output-on-failure`
- `FC=flang cmake --fresh -B build-smoke-flang-106`
- `cmake --build build-smoke-flang-106`
- `ctest --test-dir build-smoke-flang-106 --output-on-failure`

Closes #106
