### PR TITLE
[codex] Narrow product positioning docs for #120

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # fTimer
 
-fTimer is a lightweight, correctness-first wall-clock timing library for modern Fortran. It is built for codes that need hierarchical timers, predictable accounting, and summaries you can inspect programmatically instead of scraping from ad hoc text output.
+fTimer is a lightweight, correctness-first wall-clock timing library for modern Fortran. Current `main` is positioned first for disciplined serial and pure-MPI codes that need hierarchical timers, predictable accounting, and summaries you can inspect programmatically instead of scraping from ad hoc text output.
+
+> Current product position: fTimer's core supported stories are serial timing and pure-MPI timing. `FTIMER_USE_OPENMP=ON` is a narrow master-thread-only carve-out for bracketing a parallel region as a whole, not a general hybrid MPI+OpenMP timing model. The callback hook is a lightweight intra-run event hook, not a stable external-profiler integration contract.
 
 For a first release, the focus is a small, dependable core:
 
@@ -19,20 +21,20 @@ fTimer fits best when you want timing behavior you can trust:
 - mismatch handling is explicit and configurable (`strict`, `warn`, `repair`)
 - summaries are available as data first (`get_summary()`), with text formatting layered on top
 - an injectable clock supports deterministic tests and controlled benchmarking
-- callback hooks let external tools react to timer start/stop events
+- optional callback hooks let in-process code observe normal timer start/stop events during a run
 
-If you need a tiny serial timing helper, you can use fTimer that way. If you need structured local summaries, optional MPI reductions, and a clear error contract, that is where the library is strongest.
+If you need a tiny serial timing helper, you can use fTimer that way. If you need structured local summaries, opt-in pure-MPI reductions, and a clear error contract, that is where the library is strongest.
 
 ## Supported Workflows
 
 fTimer currently supports these usage paths:
 
 - Serial timing with local summaries and formatted reports
-- MPI builds that use `MPI_Wtime()` and can populate root-side reduced timing fields
-- OpenMP builds with master-thread-only timer guards for timing a parallel region as a whole
+- Pure-MPI builds that use `MPI_Wtime()` and can populate root-side reduced timing fields
+- A narrow OpenMP carve-out: master-thread-only timer guards for timing a parallel region as a whole
 - Downstream consumption through `find_package(fTimer CONFIG REQUIRED)`
 
-Important limitations are documented later in this README. The short version is that MPI support is real but opt-in, and OpenMP support is intentionally limited to the documented master-thread-only model.
+Important limitations are documented later in this README. The short version is that serial and pure-MPI are the core supported stories on current `main`; OpenMP support is intentionally limited to the documented master-thread-only model.
 
 ## Quick Start
 
@@ -138,14 +140,15 @@ Operational notes:
 - `get_summary()`, `print_summary()`, and `write_summary()` are local-only summary/reporting paths.
 - `mpi_summary()` and `ftimer_mpi_summary()` require `FTIMER_USE_MPI=ON`, a fully stopped timer set, and collective agreement on the communicator captured by `init`.
 - On a successful MPI reduction, reduced `min_time`, `max_time`, `avg_across_ranks`, and `imbalance` fields are populated only on communicator root.
+- `on_event` on `type(ftimer_t)` is a lightweight intra-run hook. It reports normal start/stop events with runtime-local numeric ids; current `main` does not promise a stable semantic id-to-name/path mapping for profiler backends or durable cross-run tooling.
 - Import shared types and constants from `ftimer_types`; `use ftimer` does not re-export them.
 
 ## Examples
 
 - `examples/basic_usage.F90`: serial start/stop plus summary retrieval and formatted output
 - `examples/nested_timers.F90`: nested timers and metadata headers
-- `examples/mpi_example.F90`: MPI timing with root-side reduced summary fields
-- `examples/openmp_example.F90`: the supported OpenMP pattern, where timers bracket the parallel region instead of running inside worker threads
+- `examples/mpi_example.F90`: pure-MPI timing with root-side reduced summary fields
+- `examples/openmp_example.F90`: the narrow OpenMP carve-out, where timers bracket the parallel region instead of running inside worker threads
 
 ## Build And Test
 
@@ -190,7 +193,7 @@ Supported toolchain matrix:
 - Serial smoke/library build: GNU Fortran and LLVM Flang are validated in automation
 - Serial plus pFUnit tests: GNU Fortran with a matching pFUnit installation
 - MPI: an MPI wrapper compiler such as `mpifort`
-- OpenMP: GNU Fortran only for the documented supported path
+- OpenMP: GNU Fortran only for the documented master-thread-only carve-out
 
 Other serial compilers may still work, but they are not part of the current release-validated matrix unless the repo adds direct automation for them.
 
@@ -202,8 +205,9 @@ Use a separate build directory for each compiler or mode. Reconfiguring the same
 - `FTIMER_USE_MPI=ON` is intended for wrapper-compiler setups such as `FC=mpifort`. Configure now fails early if the active compiler cannot compile a minimal `use mpi` probe against the discovered MPI installation.
 - `mpi_summary()` does not produce a fully global summary object on every rank. After a successful collective, local summary fields still describe the calling rank's local data; only communicator root also receives reduced cross-rank fields.
 - All ranks that participate in `mpi_summary()` must agree on the communicator captured by `init`. If would-be participants diverge onto different communicators, the library cannot safely discover that mistake after the split; the practical failure mode is a hang, not a clean local fallback.
-- `FTIMER_USE_OPENMP=ON` enables limited master-thread-only guards. Worker-thread timer calls inside an OpenMP parallel region are silent no-ops. To time a parallel region as a whole, place `start`/`stop` outside the `!$omp parallel` block.
-- OpenMP support does not make fTimer thread-safe and does not provide thread-local timer instances.
+- `FTIMER_USE_OPENMP=ON` enables only limited master-thread-only guards. Worker-thread timer calls inside an OpenMP parallel region are silent no-ops. To time a parallel region as a whole, place `start`/`stop` outside the `!$omp parallel` block.
+- The OpenMP path does not make fTimer thread-safe, does not provide thread-local timer instances, and should not be read as a general hybrid MPI+OpenMP timing model.
+- `on_event` remains a lightweight intra-run hook, not a serious profiler-backend integration contract with stable semantic timer identity.
 - If `FTIMER_USE_MPI=OFF`, `mpi_summary()` returns `FTIMER_ERR_NOT_IMPLEMENTED` and leaves the result local-only.
 - Formatted summary/report output is local-only.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -10,7 +10,9 @@ When current-state sources disagree, use this repository-wide precedence order: 
 
 ## Current Scope
 
-Current `main` ships a small, correctness-first wall-clock timing library for modern Fortran with these implemented capabilities:
+Current `main` ships a small, correctness-first wall-clock timing library for modern Fortran. The strongest supported stories today are disciplined serial timing and pure-MPI timing; the OpenMP path is a deliberately narrow carve-out for bracketing a parallel region as a whole.
+
+Implemented capabilities include:
 
 - stack-based start/stop timing with context-sensitive accounting
 - configurable mismatch handling (`strict`, `warn`, `repair`) with `strict` as the default
@@ -20,7 +22,7 @@ Current `main` ships a small, correctness-first wall-clock timing library for mo
 - limited OpenMP master-thread-only timer guards
 - installable CMake package exports, smoke tests, pFUnit behavioral tests, and a benchmark harness
 
-fTimer does not currently provide built-in hardware counter backends, JSON/CSV export utilities, or general thread-safe timing across OpenMP worker threads.
+fTimer does not currently provide built-in hardware counter backends, JSON/CSV export utilities, a serious profiler-backend callback contract, or general thread-safe timing across OpenMP worker threads.
 
 ## Repository Map
 
@@ -99,11 +101,11 @@ The CMake source order reflects the real dependency order:
 
 ### Module Roles
 
-`ftimer_types.F90` is the shared foundation. It defines kind parameters, error codes, mismatch-mode constants, MPI summary-state constants, summary types, call-stack/context helpers, and the abstract interfaces for clocks and callbacks.
+`ftimer_types.F90` is the shared foundation. It defines kind parameters, error codes, mismatch-mode constants, MPI summary-state constants, summary types, call-stack/context helpers, and the abstract interfaces for clocks and lightweight callback hooks.
 
 `ftimer_clock.F90` centralizes time acquisition. Serial builds use `system_clock`; MPI-enabled builds can use the MPI wall clock path. Tests rely on the injectable clock interface so behavior is deterministic without sleeps.
 
-`ftimer_core.F90` owns the mutable timer state in `ftimer_t`: timer definitions, active stack state, mismatch policy, communicator capture, callback registration, and the guarded timer entry points.
+`ftimer_core.F90` owns the mutable timer state in `ftimer_t`: timer definitions, active stack state, mismatch policy, communicator capture, lightweight callback registration, and the guarded timer entry points.
 
 `ftimer_core_summary_bindings.F90` is the submodule-backed binding layer that connects `ftimer_t` to local summary generation, formatted reporting, and file-output entry points without collapsing all summary logic into the core module body.
 
@@ -121,9 +123,9 @@ The current implementation is organized around a few design choices that show up
 - Context-sensitive accounting means the same timer name under different parent stacks is tracked independently.
 - Timing data is structured data first and formatted text second.
 - The clock is injectable, which keeps tests deterministic and benchmarking controlled.
-- Callback hooks fire for normal start/stop events only; internal mismatch repair transitions must stay invisible to callback consumers.
+- Callback hooks are lightweight intra-run hooks for normal start/stop events only; internal mismatch repair transitions must stay invisible to callback consumers, and current `main` does not define a stronger profiler-backend identity contract.
 - MPI summary reduction is descriptor-validated before collectives, and reduced cross-rank fields are valid only in the documented result shape.
-- OpenMP support is intentionally narrow: guarded timer operations run only on the master thread when `FTIMER_USE_OPENMP=ON`.
+- OpenMP support is intentionally narrow: guarded timer operations run only on the master thread when `FTIMER_USE_OPENMP=ON`, so this path should not be read as general hybrid-thread timing support.
 
 Those runtime semantics are specified in detail in [`docs/semantics.md`](semantics.md); this document focuses on how the repository realizes them.
 
@@ -157,6 +159,7 @@ Important current-state API notes:
 - `get_summary()` is the local structured summary path.
 - `print_summary()` and `write_summary()` format local report text.
 - `mpi_summary()` adds reduced MPI entry fields only in the documented root/non-root result states.
+- `on_event` remains a lightweight intra-run hook; the current public surface does not promise stable semantic timer identity for external-profiler integrations.
 - `ftimer_types` owns `ftimer_summary_t`, `ftimer_metadata_t`, mismatch constants, and MPI summary-state constants.
 
 ## Build, Test, and CI Reality
@@ -194,7 +197,7 @@ The current test inventory is:
 - smoke tests in `tests/test_phase0_smoke.F90`, runtime execution of `basic_usage`, installed-package consumer build-and-run checks, and build-contract regression checks under `tests/check_*_contracts.cmake`
 - serial pFUnit tests for core behavior, summaries, callbacks, reset behavior, call-stack behavior, and procedural parity
 - MPI pFUnit tests under `tests/mpi/`
-- OpenMP guard tests enabled when `FTIMER_USE_OPENMP=ON`
+- OpenMP guard tests enabled when `FTIMER_USE_OPENMP=ON`, covering the master-thread-only carve-out rather than general threaded timing support
 
 The default repository baseline is still the smoke/build-contract path. The full behavioral suite is enabled explicitly with `FTIMER_BUILD_TESTS=ON`.
 
@@ -254,6 +257,7 @@ Future-facing ideas should stay clearly separated from the current architecture 
 - built-in hardware counter or power-measurement backends
 - richer export formats such as CSV or JSON
 - broader OpenMP support beyond the documented master-thread-only guard model
+- stable semantic callback identity or a stronger external-profiler integration contract
 - hash-based timer lookup or other hot-path performance redesigns, if profiling ever justifies them
 
 If deferred work needs a maintained roadmap, record it in [`docs/implementation-history.md`](implementation-history.md) or in the relevant issue or PR discussion rather than mixing it into the current-state architecture narrative above.

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -6,6 +6,8 @@ This document describes the current runtime contract on `main`.
 
 Current `main` implements the Phase 2 core timer behavior, Phase 3 local summary/reporting behavior, Phase 4 procedural wrappers, Phase 5 MPI structured summaries, and the Phase 6 OpenMP guard behavior: stack-based start/stop timing, context-sensitive accounting, strict/warn/repair mismatch handling, `lookup`, `reset`, the `ierr` vs stderr error contract, `get_summary()`, `print_summary()`, `write_summary()`, `mpi_summary()`, self-time computation, callback suppression during repair, descriptor-hash MPI preflight, root-side MPI min/max/avg/imbalance fields, and limited master-thread-only OpenMP guards in `ftimer_core` when built with `FTIMER_USE_OPENMP=ON`. In non-MPI builds, `mpi_summary()` returns `FTIMER_ERR_NOT_IMPLEMENTED` with a local-only summary.
 
+This contract is strongest for disciplined serial and pure-MPI wall-clock timing. The OpenMP path is a narrow master-thread-only carve-out for bracketing a parallel region as a whole, not a general hybrid-thread timing contract. Likewise, `on_event` is a lightweight intra-run hook, not a stable external-profiler integration API.
+
 Current architecture, validation, and workflow notes belong in `docs/design.md`. Historical phase-roadmap notes belong in `docs/implementation-history.md`. When current-state sources disagree, use this repository-wide precedence order: current code under `src/`, then current behavioral tests, then `docs/semantics.md`, then `README.md`, then `docs/design.md`.
 
 ## Timing Model
@@ -95,16 +97,17 @@ OpenMP master thread only. When built with `FTIMER_USE_OPENMP=ON`, calls from no
 threads are suppressed before validation reaches `normalize_name` or `report_status` — they
 produce no stderr diagnostic, return 0 (for `lookup`), and leave any caller-provided `ierr`
 unchanged. This is a consequence of the master-thread-only guard model documented in
-"OpenMP Limitations" below.
+"OpenMP Carve-Out And Limitations" below.
 
 This is the deliberate policy rather than a stronger failure (e.g. `error stop`),
 chosen for consistency with the library's error contract and because callers that
 omit `ierr` have opted into the permissive path. Callers that require hard
 enforcement should pass `ierr` and check it.
 
-## OpenMP Limitations
+## OpenMP Carve-Out And Limitations
 
 - OpenMP guard behavior is enabled only when the library is built with `FTIMER_USE_OPENMP=ON`
+- This is a narrow master-thread-only carve-out for bracketing a parallel region as a whole; it is not general hybrid MPI+OpenMP timing support
 - The implemented model is master-thread-only timing; this phase does not make `fTimer` generally thread-safe
 - Inside OpenMP parallel regions, the guarded `ftimer_core` timer operations run only on the master thread
 - Non-master calls to those guarded core timer operations become no-ops instead of mutating shared timer state
@@ -124,6 +127,7 @@ The silent worker-thread no-op model has specific, observable consequences that 
 
 ## Callback Contract
 
-- `on_event` fires on normal start/stop only
+- `on_event` is an optional lightweight intra-run hook for normal start/stop events on one timer instance
+- The current callback contract exposes numeric runtime identifiers only; it does not define a stable semantic mapping back to timer names or full context paths for external-profiler backends
 - Repair transitions do NOT fire callbacks
 - `user_data` c_ptr for opaque state

--- a/examples/openmp_example.F90
+++ b/examples/openmp_example.F90
@@ -33,6 +33,9 @@ program openmp_example
    call ftimer_stop("parallel_region")
 
    call ftimer_get_summary(summary)
+   print '(a)', "fTimer OpenMP support is limited to master-thread-only region bracketing."
+   print '(a)', "This example measures one parallel region wall-clock interval,"
+   print '(a)', "not per-thread timings."
    print '(a,i0)', "OpenMP threads observed: ", nthreads
    print '(a,i0)', "Recorded timers: ", summary%num_entries
    call ftimer_print_summary()


### PR DESCRIPTION
## Summary
- narrow the repo positioning so current `main` is presented first for disciplined serial and pure-MPI timing
- make the OpenMP master-thread-only carve-out impossible to miss in the README, semantics/design docs, and the OpenMP example output
- soften callback claims so `on_event` is described as a lightweight intra-run hook rather than a stable profiler integration contract, and record the near-term `#121` deferral

## Why
Issue `#120` called out that the current OpenMP behavior is useful only for bracketing a parallel region as a whole unless the repo grows a real hybrid-thread timing story. This PR takes the narrowing path locked in the `#129` follow-up plan and keeps the docs/examples honest without changing runtime behavior.

## Impact
User-facing docs now emphasize serial and pure-MPI as the core supported stories on current `main`, explicitly warn that `FTIMER_USE_OPENMP=ON` is only a master-thread-only carve-out, and clarify that callbacks are lightweight runtime hooks with no stable semantic identity contract for profiler backends.

Issue `#121` is not implemented here; its near-term disposition is recorded as deferred until the later summary/API-shape tasks in the follow-up plan.

## Validation
- `git diff --check`
- `cmake --build build-openmp-smoke --target openmp_example`
- `./build-openmp-smoke/examples/openmp_example`

Fixes #120
Refs #121