### PR TITLE
docs: require subagent manual fallback reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,7 @@ Short version:
 - let the Codex review router reconcile automatic labels from `.github/codex-review-roles.json`, then verify the result and add any optional deeper-review labels you still want
 - monitor for the actual Codex review output
 - when waiting on `@codex` review, poll in small intervals but give the native review flow at least 5 minutes before considering manual fallback unless the connector explicitly reports that review will not proceed
+- if native Codex review is unavailable and manual fallback is used, do not satisfy review coverage by self-reviewing from the same session; launch fresh-context adversarial subagents for each active review role, collect their findings, address actionable findings, run focused fresh-context follow-up subagent reviews on any fixes, and only then post manual-fallback coverage markers
 - reply to every finding, resolve every review thread, record coverage markers for the active review roles on the current head SHA, and do not merge while merge-blocking findings remain
 
 For deeper workflow details (monitoring, fallback review, findings disposition, merge criteria), use `docs/maintainer.md` for routing to: `docs/workflows/pr-open.md`, `docs/workflows/review-monitoring.md`, `docs/workflows/findings-disposition.md`.

--- a/docs/workflows/findings-disposition.md
+++ b/docs/workflows/findings-disposition.md
@@ -23,8 +23,12 @@ After replying:
 
 - resolve the review thread
 - once a review role is actually satisfied for the current head SHA, post a coverage marker comment so `Codex Review Coverage` can pass
+- for manual fallback coverage, confirm the role was satisfied by fresh-context subagent review rather than same-session self-review, and summarize any follow-up subagent review after fixes
 - verify whether any unresolved review threads remain
 - post coverage markers only from a trusted repo commenter account with repo `write`, `maintain`, or `admin` permission, or from an explicitly allowed bot account; untrusted PR-author comments do not satisfy the coverage gate
+- post one coverage marker per PR comment; do not place multiple hidden coverage tokens in one comment
+
+The coverage marker workflow does not currently verify subagent provenance. For manual fallback coverage, the subagent-backed review trail is enforced by maintainer audit of the PR comments and disposition notes.
 
 Coverage marker examples:
 

--- a/docs/workflows/review-monitoring.md
+++ b/docs/workflows/review-monitoring.md
@@ -54,14 +54,19 @@ Use this fallback only when the label-triggered review path is unavailable or in
 Fallback procedure:
 
 1. Still apply the review labels and monitor for the native review flow first.
-2. Request the missing review manually, for example via ChatGPT with GitHub integration.
-   Use the matching detailed prompt from `.github/prompts/detailed/` when doing this.
-3. Ask the manual review to use the exact heading from the matching detailed prompt for that role.
+2. For each missing active review role, launch a fresh-context, read-only, adversarial subagent rather than reviewing your own PR from the same agent session.
+   Use the matching detailed prompt from `.github/prompts/detailed/` when preparing the subagent task.
+3. Instruct each subagent to inspect the current PR diff and relevant surrounding files without relying on prior review comments or the implementer's context.
+4. Ask each manual fallback review to use the exact heading from the matching detailed prompt for that role.
    Common examples include `## Software Review`, `## Methodology Review`, `## Red Team Review`, `## Docs / Contract Review`, and `## Test Quality Review`.
-4. Post the manual review output to the PR as a comment, or post a durable link plus a short summary of the findings.
-5. Add a short PR comment explaining why fallback review was used and which review type it covered.
-6. Handle every finding exactly as in the normal workflow: agree and fix, disagree with evidence, or defer with reason.
-7. Resolve all related review threads or PR discussion threads before merge.
+5. Post the subagent review output to the PR as comments, or post a durable summary that names the subagent-backed roles, records every finding, and links or quotes enough detail for later audit.
+6. Add a short PR comment explaining why fallback review was used and that fresh-context subagents, not same-session self-review, covered the affected roles.
+7. Handle every finding exactly as in the normal workflow: agree and fix, disagree with evidence, or defer with reason.
+8. When fallback findings lead to fixes, push the fixes, rerun relevant validation, and launch focused fresh-context follow-up subagent reviews for the affected roles before posting coverage markers for the new head SHA.
+9. Post one coverage marker comment per active review role on the current head SHA. Do not combine multiple hidden coverage tokens into one PR comment; the coverage checker reads one marker per comment.
+10. Resolve all related review threads or PR discussion threads before merge.
+
+The subagent requirement is a human-audited workflow rule. The `Codex Review Coverage` check still validates only trusted marker comments with the existing `source=manual-fallback` token; it does not currently prove that a marker came from a subagent-backed process. Make the subagent trail visible in PR comments so maintainers can audit it.
 
 This fallback does not replace required CI, required PR checks, or the normal Codex-label workflow when native Codex review is available.
 


### PR DESCRIPTION
## Summary
- require fresh-context adversarial subagents for manual fallback review coverage instead of same-session self-review
- document follow-up subagent review after fallback findings are fixed
- clarify that coverage markers should be posted one role per PR comment

## Validation
- git diff --check

## Notes
This codifies the manual fallback strategy used after native Codex review was unavailable on PR #163.