### PR TITLE
Clarify MPI report contract and Avg % semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ Operational notes:
 - `mpi_summary()` and `ftimer_mpi_summary()` require `FTIMER_USE_MPI=ON`, a fully stopped timer set, and collective agreement on the communicator captured by `init`.
 - A successful MPI reduction returns a distinct `ftimer_mpi_summary_t` whose fields are globally meaningful on every participating rank.
 - The MPI result includes communicator-local rank attribution for total-time extrema and per-entry inclusive-time extrema. Ties resolve to the lowest rank that attains the extremum.
-- `print_mpi_summary()` and `write_mpi_summary()` are the first-class MPI reporting paths. They perform the collective MPI summary build and emit one report from communicator root.
+- `print_mpi_summary()` and `write_mpi_summary()` are the first-class MPI reporting paths. They perform the collective MPI summary build and emit one abbreviated report from communicator root. The printed per-entry table is not a serialization of every `ftimer_mpi_summary_t` field; inspect `mpi_summary()` results for min/max self time, self imbalance, min/max call counts, min/max rank-local `% Total`, and explicit `node_id`/`parent_id` tree links.
+- In MPI text reports, `Avg %` means the arithmetic mean of each rank's local `% Total` for that timer, not `100*Avg Incl/Avg total time`.
 - Callbacks configured on `type(ftimer_t)` are lightweight intra-run hooks. They report normal start/stop events with runtime-local numeric ids; current `main` does not promise a stable semantic id-to-name/path mapping for profiler backends or durable cross-run tooling.
 - Import shared types and constants from `ftimer_types`; `use ftimer` does not re-export them.
 
@@ -225,7 +226,7 @@ Use a separate build directory for each compiler or mode. Reconfiguring the same
 - The OpenMP path does not make fTimer thread-safe, does not provide thread-local timer instances, and should not be read as a general hybrid MPI+OpenMP timing model.
 - `on_event` remains a lightweight intra-run hook, not a serious profiler-backend integration contract with stable semantic timer identity.
 - If `FTIMER_USE_MPI=OFF`, `mpi_summary()` returns `FTIMER_ERR_NOT_IMPLEMENTED` and leaves the MPI result empty.
-- Formatted local and MPI report output are separate paths: `print_summary()`/`write_summary()` are local, while `print_mpi_summary()`/`write_mpi_summary()` emit communicator-level MPI reports from root.
+- Formatted local and MPI report output are separate paths: `print_summary()`/`write_summary()` are local, while `print_mpi_summary()`/`write_mpi_summary()` emit communicator-level MPI reports from root. MPI reports are deliberately abbreviated; `ftimer_mpi_summary_t` remains the complete structured data model.
 
 ## Performance Measurement
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -116,6 +116,8 @@ The supported pattern is simple: capture one communicator consistently at `init`
 - They are collective over the communicator captured by `init`, just like `mpi_summary()`
 - They build the same global MPI summary object that `mpi_summary()` returns
 - They emit one communicator-level report from rank 0; non-root participants take part in the collective build and then return success without duplicating output
+- The default MPI text report is an abbreviated view of `ftimer_mpi_summary_t`, not a serialization of every structured field. It prints communicator totals plus per-entry min/avg/max inclusive time, inclusive-time extrema ranks, inclusive imbalance, average self time, average call count, and `Avg %`; use `mpi_summary()` directly for min/max self time, self imbalance, min/max call count, min/max rank-local `% Total`, and explicit `node_id`/`parent_id` tree links.
+- In the MPI text report, `Avg %` is `avg_pct_time`: the arithmetic mean of each rank's local `% Total` for that timer. It is not recomputed as `100*avg_inclusive_time/avg_total_time`, because rank-local denominator differences are part of the reported statistic.
 
 ## Name Validation Error Contract
 

--- a/src/ftimer_summary.F90
+++ b/src/ftimer_summary.F90
@@ -6,7 +6,7 @@ module ftimer_summary
 
    public :: build_summary
    public :: format_summary
-    public :: format_mpi_summary
+   public :: format_mpi_summary
    public :: ftimer_summary_status
 
 contains
@@ -86,7 +86,8 @@ contains
       character(len=:), allocatable, intent(out) :: text
       type(ftimer_metadata_t), intent(in), optional :: metadata(:)
       character(len=*), parameter :: mpi_header_suffix = &
-         '  Min Incl (s)  Min Rank  Avg Incl (s)  Max Incl (s)  Max Rank   Imb.  Avg Self (s)    Avg Calls    Avg %'
+                                     '  Min Incl (s)  Min Rank  Avg Incl (s)  Max Incl (s)  Max Rank'// &
+                                     '   Imb.  Avg Self (s)    Avg Calls    Avg %'
       character(len=128) :: fmt
       character(len=64) :: value_line
       character(len=:), allocatable :: line
@@ -141,6 +142,12 @@ contains
             call append_line(text, padded(1:key_width)//' : '//trim(metadata(i)%value))
          end do
       end if
+
+      call append_line(text, '')
+      call append_line(text, 'Report note: per-entry table is an abbreviated view of ftimer_mpi_summary_t; '// &
+                       'use mpi_summary() for all min/max self, call, percent, and tree fields.')
+      call append_line(text, 'Avg % is the arithmetic mean of rank-local % Total values, '// &
+                       'not 100*Avg Incl/Avg total time.')
 
       call append_line(text, '')
       name_width = mpi_summary_name_width(summary)

--- a/tests/mpi/test_mpi_summary.pf
+++ b/tests/mpi/test_mpi_summary.pf
@@ -321,8 +321,17 @@ contains
       type(ftimer_t) :: timer
       type(ftimer_metadata_t) :: metadata(1)
       character(len=:), allocatable :: printed
+      character(len=*), parameter :: expected_header = &
+                                     'Timer name  Min Incl (s)  Min Rank  Avg Incl (s)  Max Incl (s)  Max Rank'// &
+                                     '   Imb.  Avg Self (s)    Avg Calls    Avg %'
+      character(len=*), parameter :: expected_inner_row = &
+                                     '  inner         4.000000         0      5.000000      6.000000'// &
+                                     '         1   1.200      5.000000       1.000     41.43'
+      character(len=*), parameter :: wrong_ratio_inner_row = &
+                                     '  inner         4.000000         0      5.000000      6.000000'// &
+                                     '         1   1.200      5.000000       1.000     41.67'
       character(len=*), parameter :: print_path = 'test_mpi_print_summary.txt'
-      integer :: flags(10)
+      integer :: flags(13)
       integer :: ierr
       integer :: rank
       integer :: unit
@@ -365,6 +374,9 @@ contains
          if (index(printed, 'abbreviated view of ftimer_mpi_summary_t') > 0) flags(8) = 1
          if (index(printed, 'Avg % is the arithmetic mean of rank-local % Total values') > 0) flags(9) = 1
          if (index(printed, 'not 100*Avg Incl/Avg total time') > 0) flags(10) = 1
+         if (index(printed, expected_header) > 0) flags(11) = 1
+         if (index(printed, expected_inner_row) > 0) flags(12) = 1
+         if (index(printed, wrong_ratio_inner_row) == 0) flags(13) = 1
       end if
       call MPI_Bcast(flags, size(flags), MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
       @assertEqual(MPI_SUCCESS, ierr)
@@ -379,6 +391,9 @@ contains
       @assertEqual(1, flags(8))
       @assertEqual(1, flags(9))
       @assertEqual(1, flags(10))
+      @assertEqual(1, flags(11))
+      @assertEqual(1, flags(12))
+      @assertEqual(1, flags(13))
 
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)

--- a/tests/mpi/test_mpi_summary.pf
+++ b/tests/mpi/test_mpi_summary.pf
@@ -55,7 +55,10 @@ contains
       @assertEqual(0, summary%entries(1)%min_inclusive_time_rank)
       @assertEqual(1, summary%entries(1)%max_inclusive_time_rank)
       call assert_real_close(summary%entries(1)%inclusive_imbalance, 14.0_wp/12.0_wp)
+      call assert_real_close(summary%entries(1)%min_self_time, 6.0_wp)
+      call assert_real_close(summary%entries(1)%max_self_time, 8.0_wp)
       call assert_real_close(summary%entries(1)%avg_self_time, 7.0_wp)
+      call assert_real_close(summary%entries(1)%self_imbalance, 8.0_wp/7.0_wp)
       call assert_real_close(summary%entries(1)%avg_call_count, 1.0_wp)
       call assert_real_close(summary%entries(1)%avg_pct_time, 100.0_wp)
       call assert_real_close(summary%entries(2)%min_inclusive_time, 4.0_wp)
@@ -64,7 +67,13 @@ contains
       @assertEqual(0, summary%entries(2)%min_inclusive_time_rank)
       @assertEqual(1, summary%entries(2)%max_inclusive_time_rank)
       call assert_real_close(summary%entries(2)%inclusive_imbalance, 6.0_wp/5.0_wp)
+      call assert_real_close(summary%entries(2)%min_pct_time, 40.0_wp)
+      call assert_real_close(summary%entries(2)%max_pct_time, 100.0_wp*6.0_wp/14.0_wp)
+      call assert_real_close(summary%entries(2)%avg_pct_time, 0.5_wp*(40.0_wp + 100.0_wp*6.0_wp/14.0_wp))
+      call assert_real_close(summary%entries(2)%min_self_time, 4.0_wp)
+      call assert_real_close(summary%entries(2)%max_self_time, 6.0_wp)
       call assert_real_close(summary%entries(2)%avg_self_time, 5.0_wp)
+      call assert_real_close(summary%entries(2)%self_imbalance, 6.0_wp/5.0_wp)
       call assert_real_close(summary%entries(2)%avg_call_count, 1.0_wp)
 
       call timer%finalize(ierr=ierr)
@@ -313,7 +322,7 @@ contains
       type(ftimer_metadata_t) :: metadata(1)
       character(len=:), allocatable :: printed
       character(len=*), parameter :: print_path = 'test_mpi_print_summary.txt'
-      integer :: flags(7)
+      integer :: flags(10)
       integer :: ierr
       integer :: rank
       integer :: unit
@@ -353,6 +362,9 @@ contains
          if (index(printed, 'Min total rank') > 0) flags(5) = 1
          if (index(printed, 'Max total rank') > 0) flags(6) = 1
          if (index(printed, 'Min Rank') > 0) flags(7) = 1
+         if (index(printed, 'abbreviated view of ftimer_mpi_summary_t') > 0) flags(8) = 1
+         if (index(printed, 'Avg % is the arithmetic mean of rank-local % Total values') > 0) flags(9) = 1
+         if (index(printed, 'not 100*Avg Incl/Avg total time') > 0) flags(10) = 1
       end if
       call MPI_Bcast(flags, size(flags), MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
       @assertEqual(MPI_SUCCESS, ierr)
@@ -364,6 +376,9 @@ contains
       @assertEqual(1, flags(5))
       @assertEqual(1, flags(6))
       @assertEqual(1, flags(7))
+      @assertEqual(1, flags(8))
+      @assertEqual(1, flags(9))
+      @assertEqual(1, flags(10))
 
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
@@ -641,10 +656,15 @@ contains
          @assertEqual(rhs%entries(i)%min_inclusive_time_rank, lhs%entries(i)%min_inclusive_time_rank)
          @assertEqual(rhs%entries(i)%max_inclusive_time_rank, lhs%entries(i)%max_inclusive_time_rank)
          call assert_real_close(lhs%entries(i)%inclusive_imbalance, rhs%entries(i)%inclusive_imbalance)
+         call assert_real_close(lhs%entries(i)%min_self_time, rhs%entries(i)%min_self_time)
+         call assert_real_close(lhs%entries(i)%max_self_time, rhs%entries(i)%max_self_time)
          call assert_real_close(lhs%entries(i)%avg_self_time, rhs%entries(i)%avg_self_time)
+         call assert_real_close(lhs%entries(i)%self_imbalance, rhs%entries(i)%self_imbalance)
          @assertEqual(rhs%entries(i)%min_call_count, lhs%entries(i)%min_call_count)
          @assertEqual(rhs%entries(i)%max_call_count, lhs%entries(i)%max_call_count)
          call assert_real_close(lhs%entries(i)%avg_call_count, rhs%entries(i)%avg_call_count)
+         call assert_real_close(lhs%entries(i)%min_pct_time, rhs%entries(i)%min_pct_time)
+         call assert_real_close(lhs%entries(i)%max_pct_time, rhs%entries(i)%max_pct_time)
          call assert_real_close(lhs%entries(i)%avg_pct_time, rhs%entries(i)%avg_pct_time)
       end do
    end subroutine assert_summary_equal


### PR DESCRIPTION
Closes #152.

## Summary
- Add an explicit note to MPI text reports that the per-entry table is an abbreviated view of `ftimer_mpi_summary_t`.
- Document that `Avg %` is the arithmetic mean of rank-local `% Total` values, not `100*Avg Incl/Avg total time`.
- Strengthen MPI summary tests for percent semantics and preserved structured fields.

## Validation
- `cmake --build build-mpi-tests --target ftimer_mpi_tests`
- `ctest --test-dir build-mpi-tests --output-on-failure -R ftimer_mpi_tests`
- `cmake --build build-smoke`
- `ctest --test-dir build-smoke --output-on-failure`
- `fprettify --diff src/ftimer_summary.F90 tests/mpi/test_mpi_summary.pf`
- `git diff --check`