### PR TITLE
Clarify local summary active snapshot semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ fTimer fits best when you want timing behavior you can trust:
 - nested timers are treated as a real hierarchy, not a flat label list
 - mismatch handling is explicit and configurable (`strict`, `warn`, `repair`)
 - summaries are available as data first (`get_summary()`), with text formatting layered on top
+- local summaries are live snapshots: active timers are included explicitly and marked in the data model/report output
 - local summary entries retain formatter-friendly preorder `name`/`depth` data and also expose explicit `node_id`/`parent_id` tree links
 - pure-MPI reductions return a distinct `ftimer_mpi_summary_t` with globally meaningful fields on every participating rank
 - an injectable clock supports deterministic tests and controlled benchmarking
@@ -147,6 +148,7 @@ Operational notes:
 - Clock changes are allowed before `init()` or before a run records timing data. After timing has started, `set_clock()` and `clear_clock()` return `FTIMER_ERR_ACTIVE` (or warn to stderr when `ierr` is omitted) and leave state unchanged. Use `reset()`, `init()`, or `finalize()` to begin a fresh run on a different clock.
 - Configure callbacks through `set_callback()` and `clear_callback()`. Callback configuration is rejected while timers are active, `clear_callback()` also clears callback `user_data`, and `finalize()` clears callback configuration.
 - `get_summary()`, `print_summary()`, and `write_summary()` are local-only summary/reporting paths.
+- `get_summary()`, `print_summary()`, and `write_summary()` are live snapshot APIs. They include active local timer contexts through the snapshot timestamp without stopping them, and mark that state with `summary%has_active_timers`, each entry's `is_active`, and, when active entries exist, the formatted report's `Active timers`/`Active` fields. For a final local report, stop all timers first and verify `summary%has_active_timers == .false.`.
 - Local summary entries retain preorder formatting compatibility and now expose explicit tree structure through `node_id` and `parent_id`. `node_id` values are stable only within one produced summary object, and roots use `parent_id = 0`.
 - `mpi_summary()` and `ftimer_mpi_summary()` require `FTIMER_USE_MPI=ON`, a fully stopped timer set, and collective agreement on the communicator captured by `init`.
 - A successful MPI reduction returns a distinct `ftimer_mpi_summary_t` whose fields are globally meaningful on every participating rank.

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -70,17 +70,24 @@ Current architecture, validation, and workflow notes belong in `docs/design.md`.
 ## Local Summary Contract
 
 - `get_summary()` returns a local-only `ftimer_summary_t`
+- `get_summary()`, `print_summary()`, and `write_summary()` are live snapshot APIs, not stopped-run-only final-report APIs
+- If timers are active at the snapshot timestamp, local summaries include those active contexts with elapsed time computed through that timestamp; they do not synthesize hidden stops, fire callbacks, or mutate runtime state
+- `summary%has_active_timers` is true when at least one returned entry was active at the snapshot timestamp
 - `summary%entries` remain in preorder so current formatted-report traversal and existing depth-oriented consumers keep working
-- Each entry retains `name` and `depth`, and now also exposes explicit tree linkage through `node_id` and `parent_id`
+- Each entry retains `name` and `depth`, exposes explicit tree linkage through `node_id` and `parent_id`, and exposes `is_active` for that timer context at the snapshot timestamp
+- `call_count` remains the count of user-visible `start` calls for that exact timer context. Repair-mode internal continuations can therefore appear as active entries with `is_active = .true.` and `call_count = 0`; that is not a hidden user call.
 - `node_id` is unique and stable only within one produced summary object
 - `parent_id` refers to another entry's `node_id`; roots use `parent_id = 0`
 - Current `main` does not promise that local summary node ids remain stable across separate runs or across independently produced summary objects
+- `print_summary()` and `write_summary()` format the same local snapshot data. When any returned entry is active, formatted reports add active-state information and reserve the `Active timers` metadata key for the built-in snapshot status line. A formatted local report whose `Active timers` field is `yes` is an interim snapshot, not a final stopped-run report.
+- A caller that requires a final local report should stop all timers first and verify `summary%has_active_timers == .false.`
 
 ## MPI Guarantees
 
 - `mpi_summary()` is collective over the communicator captured by `init`
 - Omitting `comm` at `init` means `mpi_summary()` uses `MPI_COMM_WORLD`
 - All ranks in that communicator must enter `mpi_summary()` with fully stopped timers
+- Unlike local summaries, MPI summaries are final stopped-run summaries only; active timers return `FTIMER_ERR_ACTIVE`
 - The current validated MPI interface path is `use mpi` with integer communicator handles captured at `init`
 - `FTIMER_USE_MPI=ON` configure requires that the active `use mpi` path compile the `MPI_Type_match_size` and `MPI_ERRORS_RETURN` calls used for datatype validation
 - MPI summary reductions select MPI datatypes with `MPI_Type_match_size` for the actual `real(wp)` and `integer(int64)` storage sizes before reducing those buffers. If that validation API is present but the active MPI implementation cannot provide matching datatypes at runtime, `mpi_summary()` temporarily requests MPI error returns for the datatype lookup, fails with `FTIMER_ERR_UNKNOWN`, and leaves the MPI result empty instead of reducing through a mismatched fixed datatype.

--- a/src/ftimer_core_summary_bindings.F90
+++ b/src/ftimer_core_summary_bindings.F90
@@ -319,6 +319,7 @@ contains
       summary%end_date = ''
       summary%total_time = 0.0_wp
       summary%num_entries = 0
+      summary%has_active_timers = .false.
    end subroutine reset_summary
 
    subroutine reset_mpi_summary(summary)

--- a/src/ftimer_summary.F90
+++ b/src/ftimer_summary.F90
@@ -31,6 +31,7 @@ contains
          summary%num_entries = 0
          allocate (summary%entries(0))
       end if
+      summary%has_active_timers = summary_has_active_entries(summary)
       if (summary%num_entries <= 0) return
    end subroutine build_summary
 
@@ -41,24 +42,36 @@ contains
       character(len=64) :: fmt
       character(len=:), allocatable :: line
       character(len=:), allocatable :: padded
+      character(len=8) :: active_value
       integer :: i
       integer :: key_width
       integer :: line_width
       integer :: name_width
+      logical :: has_active_entries
 
       text = ''
+      has_active_entries = summary_has_active_entries(summary)
       key_width = metadata_key_width(metadata)
+      key_width = max(key_width, len('Active timers'))
       name_width = summary_name_width(summary)
-      line_width = summary_line_width(name_width)
+      line_width = summary_line_width(name_width, has_active_entries)
       allocate (character(len=line_width) :: line)
 
       write (line, '(f0.6)') summary%total_time
       call set_padded_text(padded, 'Total time (s)', key_width)
       call append_line(text, padded(1:key_width)//' : '//trim(line))
 
+      if (has_active_entries) then
+         active_value = 'yes'
+         call set_padded_text(padded, 'Active timers', key_width)
+         call append_line(text, padded(1:key_width)//' : '//trim(active_value))
+         call append_line(text, 'Snapshot note : active timers are included through the snapshot timestamp.')
+      end if
+
       if (present(metadata)) then
          do i = 1, size(metadata)
             if (len_trim(metadata(i)%key) <= 0) cycle
+            if (has_active_entries .and. metadata_key_is_reserved(metadata(i)%key)) cycle
             call set_padded_text(padded, trim(metadata(i)%key), key_width)
             call append_line(text, padded(1:key_width)//' : '//trim(metadata(i)%value))
          end do
@@ -67,18 +80,34 @@ contains
       call append_line(text, '')
       call set_padded_text(padded, 'Timer name', name_width)
       line = repeat(' ', len(line))
-      line(1:name_width + len('  Inclusive (s)     Self (s)    Calls   % Total')) = &
-         padded(1:name_width)//'  Inclusive (s)     Self (s)    Calls   % Total'
+      if (has_active_entries) then
+         line(1:name_width + len('  Inclusive (s)     Self (s)    Calls   % Total  Active')) = &
+            padded(1:name_width)//'  Inclusive (s)     Self (s)    Calls   % Total  Active'
+      else
+         line(1:name_width + len('  Inclusive (s)     Self (s)    Calls   % Total')) = &
+            padded(1:name_width)//'  Inclusive (s)     Self (s)    Calls   % Total'
+      end if
       call append_line(text, trim(line))
       call append_line(text, repeat('-', len_trim(line)))
 
-      write (fmt, '("(a",i0,",2x,f12.6,2x,f12.6,2x,i8,2x,f8.2)")') name_width
-      do i = 1, summary%num_entries
-         call set_padded_text(padded, display_name(summary%entries(i)), name_width)
-         write (line, fmt) padded(1:name_width), summary%entries(i)%inclusive_time, &
-            summary%entries(i)%self_time, summary%entries(i)%call_count, summary%entries(i)%pct_time
-         call append_line(text, trim(line))
-      end do
+      if (has_active_entries) then
+         write (fmt, '("(a",i0,",2x,f12.6,2x,f12.6,2x,i8,2x,f8.2,2x,a)")') name_width
+         do i = 1, summary%num_entries
+            call set_padded_text(padded, display_name(summary%entries(i)), name_width)
+            write (line, fmt) padded(1:name_width), summary%entries(i)%inclusive_time, &
+               summary%entries(i)%self_time, summary%entries(i)%call_count, summary%entries(i)%pct_time, &
+               active_text(summary%entries(i)%is_active)
+            call append_line(text, trim(line))
+         end do
+      else
+         write (fmt, '("(a",i0,",2x,f12.6,2x,f12.6,2x,i8,2x,f8.2)")') name_width
+         do i = 1, summary%num_entries
+            call set_padded_text(padded, display_name(summary%entries(i)), name_width)
+            write (line, fmt) padded(1:name_width), summary%entries(i)%inclusive_time, &
+               summary%entries(i)%self_time, summary%entries(i)%call_count, summary%entries(i)%pct_time
+            call append_line(text, trim(line))
+         end do
+      end if
    end subroutine format_summary
 
    subroutine format_mpi_summary(summary, text, metadata)
@@ -195,6 +224,7 @@ contains
       summary%end_date = ''
       summary%total_time = 0.0_wp
       summary%num_entries = 0
+      summary%has_active_timers = .false.
    end subroutine clear_summary
 
    subroutine populate_summary_entries(entries, num_entries, segments, total_time, end_time)
@@ -299,6 +329,7 @@ contains
          entries(position)%node_id = position
          entries(position)%inclusive_time = node_inclusive(node)
          entries(position)%call_count = node_call_count(node)
+         entries(position)%is_active = context_is_active(segments(node_segment(node)), node_ctx(node))
          if (entries(position)%call_count > 0) then
             entries(position)%avg_time = entries(position)%inclusive_time/ &
                                          real(entries(position)%call_count, wp)
@@ -535,6 +566,16 @@ contains
       count = segment%call_count(ctx)
    end function call_count_for_context
 
+   logical function context_is_active(segment, ctx) result(is_active)
+      type(ftimer_segment_t), intent(in) :: segment
+      integer, intent(in) :: ctx
+
+      is_active = .false.
+      if (.not. allocated(segment%is_running)) return
+      if (ctx > size(segment%is_running)) return
+      is_active = segment%is_running(ctx)
+   end function context_is_active
+
    real(wp) function inclusive_for_context(segment, ctx, end_time) result(total)
       type(ftimer_segment_t), intent(in) :: segment
       integer, intent(in) :: ctx
@@ -577,6 +618,30 @@ contains
       end if
    end function context_is_visible
 
+   logical function summary_has_active_entries(summary) result(has_active)
+      type(ftimer_summary_t), intent(in) :: summary
+      integer :: i
+
+      has_active = .false.
+      do i = 1, summary%num_entries
+         if (summary%entries(i)%is_active) then
+            has_active = .true.
+            return
+         end if
+      end do
+   end function summary_has_active_entries
+
+   function active_text(is_active) result(text)
+      logical, intent(in) :: is_active
+      character(len=3) :: text
+
+      if (is_active) then
+         text = 'yes'
+      else
+         text = 'no'
+      end if
+   end function active_text
+
    integer function metadata_key_width(metadata) result(width)
       type(ftimer_metadata_t), intent(in), optional :: metadata(:)
       integer :: i
@@ -588,6 +653,12 @@ contains
          width = max(width, len_trim(metadata(i)%key))
       end do
    end function metadata_key_width
+
+   logical function metadata_key_is_reserved(key) result(is_reserved)
+      character(len=*), intent(in) :: key
+
+      is_reserved = trim(key) == 'Active timers'
+   end function metadata_key_is_reserved
 
    subroutine set_padded_text(padded, text, width)
       character(len=:), allocatable, intent(out) :: padded
@@ -601,10 +672,15 @@ contains
       if (copy_len > 0) padded(1:copy_len) = text(1:copy_len)
    end subroutine set_padded_text
 
-   integer function summary_line_width(name_width) result(width)
+   integer function summary_line_width(name_width, show_active) result(width)
       integer, intent(in) :: name_width
+      logical, intent(in) :: show_active
 
-      width = name_width + 48
+      if (show_active) then
+         width = name_width + 56
+      else
+         width = name_width + 48
+      end if
    end function summary_line_width
 
    integer function mpi_summary_line_width(name_width) result(width)

--- a/src/ftimer_types.F90
+++ b/src/ftimer_types.F90
@@ -69,6 +69,7 @@ module ftimer_types
       ! Stable only within one produced summary object. Root nodes use parent_id = 0.
       integer :: node_id = 0
       integer :: parent_id = 0
+      logical :: is_active = .false.
    end type ftimer_summary_entry_t
 
    type :: ftimer_summary_t
@@ -77,6 +78,7 @@ module ftimer_types
       real(wp) :: total_time = 0.0_wp
       integer :: num_entries = 0
       type(ftimer_summary_entry_t), allocatable :: entries(:)
+      logical :: has_active_timers = .false.
    end type ftimer_summary_t
 
    type :: ftimer_mpi_summary_entry_t

--- a/tests/test_openmp_guards.pf
+++ b/tests/test_openmp_guards.pf
@@ -701,6 +701,7 @@ contains
 
       @assertEqual(rhs%num_entries, lhs%num_entries)
       @assertEqual(rhs%total_time, lhs%total_time)
+      @assertEqual(rhs%has_active_timers, lhs%has_active_timers)
       @assertTrue(summary_node_ids_unique(lhs))
       @assertTrue(summary_node_ids_unique(rhs))
 
@@ -717,6 +718,7 @@ contains
          @assertEqual(rhs%entries(i)%self_time, lhs%entries(i)%self_time)
          @assertEqual(rhs%entries(i)%call_count, lhs%entries(i)%call_count)
          @assertEqual(rhs%entries(i)%avg_time, lhs%entries(i)%avg_time)
+         @assertEqual(rhs%entries(i)%is_active, lhs%entries(i)%is_active)
          pct_diff = abs(lhs%entries(i)%pct_time - rhs%entries(i)%pct_time)
          @assertTrue(pct_diff < 1.0e-12_wp)
       end do

--- a/tests/test_procedural_api.pf
+++ b/tests/test_procedural_api.pf
@@ -196,6 +196,58 @@ contains
    end subroutine test_procedural_start_stop_matches_oop
 
    @test
+   subroutine test_procedural_active_get_summary_matches_oop()
+      type(ftimer_t) :: oop_timer
+      type(ftimer_summary_t) :: oop_summary
+      type(ftimer_summary_t) :: procedural_summary
+      integer :: ierr
+
+      call oop_timer%init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(oop_timer)
+
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+      call oop_timer%start("phase4_active", ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call ftimer_start("phase4_active", ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      fake_time = 2.25_wp
+      call oop_timer%get_summary(oop_summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call ftimer_get_summary(procedural_summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call assert_summary_equal(procedural_summary, oop_summary)
+      @assertTrue(procedural_summary%has_active_timers)
+      @assertTrue(procedural_summary%entries(1)%is_active)
+
+      fake_time = 4.5_wp
+      call oop_timer%stop("phase4_active", ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call ftimer_stop("phase4_active", ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call oop_timer%get_summary(oop_summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call ftimer_get_summary(procedural_summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call assert_summary_equal(procedural_summary, oop_summary)
+      @assertFalse(procedural_summary%has_active_timers)
+      @assertFalse(procedural_summary%entries(1)%is_active)
+      @assertEqual(4.5_wp, procedural_summary%entries(1)%inclusive_time)
+
+      call oop_timer%finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_procedural_active_get_summary_matches_oop
+
+   @test
    subroutine test_procedural_lookup_start_id_stop_id_matches_oop()
       type(ftimer_t) :: oop_timer
       type(ftimer_summary_t) :: oop_summary
@@ -591,6 +643,7 @@ contains
 
       @assertEqual(rhs%num_entries, lhs%num_entries)
       @assertEqual(rhs%total_time, lhs%total_time)
+      @assertEqual(rhs%has_active_timers, lhs%has_active_timers)
       @assertTrue(summary_node_ids_unique(lhs))
       @assertTrue(summary_node_ids_unique(rhs))
 
@@ -607,6 +660,7 @@ contains
          @assertEqual(rhs%entries(i)%self_time, lhs%entries(i)%self_time)
          @assertEqual(rhs%entries(i)%call_count, lhs%entries(i)%call_count)
          @assertEqual(rhs%entries(i)%avg_time, lhs%entries(i)%avg_time)
+         @assertEqual(rhs%entries(i)%is_active, lhs%entries(i)%is_active)
          pct_diff = abs(lhs%entries(i)%pct_time - rhs%entries(i)%pct_time)
          @assertTrue(pct_diff < 1.0e-12_wp)
       end do

--- a/tests/test_summary.pf
+++ b/tests/test_summary.pf
@@ -1,11 +1,15 @@
 module test_summary
+   use, intrinsic :: iso_c_binding, only: c_ptr
    use pfunit
    use ftimer_core, only: ftimer_t
    use ftimer_summary, only: build_summary, format_summary
-   use ftimer_types, only: FTIMER_SUCCESS, ftimer_call_stack_t, ftimer_metadata_t, ftimer_segment_t, &
-                           ftimer_summary_entry_t, ftimer_summary_t, wp
+   use ftimer_types, only: FTIMER_EVENT_START, FTIMER_EVENT_STOP, FTIMER_MISMATCH_REPAIR, FTIMER_SUCCESS, &
+                           ftimer_call_stack_t, ftimer_metadata_t, ftimer_segment_t, ftimer_summary_entry_t, &
+                           ftimer_summary_t, wp
    use test_support, only: attach_mock_clock, build_stack, fake_time, read_unit_text
    implicit none
+
+   integer, save :: snapshot_callback_count = 0
 
 contains
 
@@ -58,6 +62,7 @@ contains
 
       @assertEqual(3, entry_count)
       @assertEqual(15.0_wp, total_time)
+      @assertFalse(summary%has_active_timers)
       @assertTrue(trimmed_start > 0)
       @assertTrue(trimmed_end > 0)
       @assertTrue(first_name_matches)
@@ -106,7 +111,26 @@ contains
       @assertEqual(40.0_wp, entry%pct_time)
       @assertEqual(0, entry%node_id)
       @assertEqual(0, entry%parent_id)
+      @assertFalse(entry%is_active)
    end subroutine test_summary_entry_positional_ctor_keeps_legacy_order
+
+   @test
+   subroutine test_summary_positional_ctor_keeps_legacy_order()
+      type(ftimer_summary_entry_t), allocatable :: entries(:)
+      type(ftimer_summary_t) :: summary
+
+      allocate (entries(1))
+      entries(1)%name = 'work'
+
+      summary = ftimer_summary_t('start', 'end', 3.0_wp, 1, entries)
+
+      @assertEqual('start', trim(summary%start_date))
+      @assertEqual('end', trim(summary%end_date))
+      @assertEqual(3.0_wp, summary%total_time)
+      @assertEqual(1, summary%num_entries)
+      @assertEqual('work', trim(summary%entries(1)%name))
+      @assertFalse(summary%has_active_timers)
+   end subroutine test_summary_positional_ctor_keeps_legacy_order
 
    @test
    subroutine test_print_summary_writes_expected_text_with_metadata()
@@ -150,6 +174,57 @@ contains
 
       @assertTrue(texts_match)
    end subroutine test_print_summary_writes_expected_text_with_metadata
+
+   @test
+   subroutine test_active_snapshot_does_not_mutate_runtime_or_fire_callbacks()
+      type(ftimer_t) :: timer
+      type(ftimer_summary_t) :: active_summary
+      type(ftimer_summary_t) :: final_summary
+      character(len=:), allocatable :: text
+      integer :: ierr
+      integer :: unit
+      logical :: row_marked_active
+
+      call reset_snapshot_callback_count()
+      call timer%init(ierr=ierr)
+      call attach_mock_clock(timer)
+      call timer%set_callback(count_snapshot_callback, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call timer%start("A", ierr=ierr)
+      @assertEqual(1, snapshot_callback_count)
+
+      fake_time = 2.0_wp
+      call timer%get_summary(active_summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      @assertEqual(1, snapshot_callback_count)
+
+      open (newunit=unit, status='scratch', action='readwrite')
+      fake_time = 3.0_wp
+      call timer%print_summary(unit=unit, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      @assertEqual(1, snapshot_callback_count)
+      close (unit)
+
+      call format_summary(active_summary, text)
+      row_marked_active = index(text, 'A               2.000000      2.000000         1    100.00  yes') > 0
+
+      @assertTrue(active_summary%has_active_timers)
+      @assertTrue(active_summary%entries(1)%is_active)
+      @assertTrue(row_marked_active)
+
+      fake_time = 5.0_wp
+      call timer%stop("A", ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      @assertEqual(2, snapshot_callback_count)
+
+      call timer%get_summary(final_summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      @assertFalse(final_summary%has_active_timers)
+      @assertFalse(final_summary%entries(1)%is_active)
+      @assertEqual(5.0_wp, final_summary%entries(1)%inclusive_time)
+      @assertEqual(5.0_wp, final_summary%entries(1)%self_time)
+   end subroutine test_active_snapshot_does_not_mutate_runtime_or_fire_callbacks
 
    @test
    subroutine test_print_summary_handles_deep_hierarchy()
@@ -210,6 +285,10 @@ contains
    subroutine test_get_summary_surfaces_backward_clock_deltas()
       type(ftimer_t) :: timer
       type(ftimer_summary_t) :: summary
+      character(len=:), allocatable :: text
+      logical :: active_line_present
+      logical :: active_note_present
+      logical :: active_row_present
       integer :: ierr
 
       call timer%init(ierr=ierr)
@@ -222,9 +301,226 @@ contains
       @assertEqual(FTIMER_SUCCESS, ierr)
       @assertEqual(-1.0_wp, summary%total_time)
       @assertEqual(1, summary%num_entries)
+      @assertTrue(summary%has_active_timers)
+      @assertTrue(summary%entries(1)%is_active)
       @assertEqual(-1.0_wp, summary%entries(1)%inclusive_time)
       @assertEqual(-1.0_wp, summary%entries(1)%self_time)
+
+      call format_summary(summary, text)
+      active_line_present = index(text, 'Active timers  : yes') > 0
+      active_note_present = index(text, 'Snapshot note : active timers are included through the snapshot timestamp.') > 0
+      active_row_present = index(text, 'yes') > 0
+
+      @assertTrue(active_line_present)
+      @assertTrue(active_note_present)
+      @assertTrue(active_row_present)
    end subroutine test_get_summary_surfaces_backward_clock_deltas
+
+   @test
+   subroutine test_active_nested_snapshot_preserves_tree_and_self_time()
+      type(ftimer_t) :: timer
+      type(ftimer_summary_t) :: summary
+      integer :: ierr
+
+      call timer%init(ierr=ierr)
+      call attach_mock_clock(timer)
+
+      call timer%start("outer", ierr=ierr)
+      fake_time = 2.0_wp
+      call timer%start("inner", ierr=ierr)
+      fake_time = 5.0_wp
+      call timer%get_summary(summary, ierr=ierr)
+
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      @assertTrue(summary%has_active_timers)
+      @assertEqual(2, summary%num_entries)
+      @assertEqual('outer', trim(summary%entries(1)%name))
+      @assertEqual('inner', trim(summary%entries(2)%name))
+      @assertTrue(summary%entries(1)%is_active)
+      @assertTrue(summary%entries(2)%is_active)
+      @assertEqual(5.0_wp, summary%entries(1)%inclusive_time)
+      @assertEqual(3.0_wp, summary%entries(2)%inclusive_time)
+      @assertEqual(2.0_wp, summary%entries(1)%self_time)
+      @assertEqual(3.0_wp, summary%entries(2)%self_time)
+      call assert_entry_parent(summary, 1, 0)
+      call assert_entry_parent(summary, 2, 1)
+   end subroutine test_active_nested_snapshot_preserves_tree_and_self_time
+
+   @test
+   subroutine test_active_snapshot_marks_mixed_active_and_stopped_rows()
+      type(ftimer_t) :: timer
+      type(ftimer_summary_t) :: summary
+      character(len=:), allocatable :: text
+      logical :: active_row_present
+      logical :: stopped_row_present
+      integer :: ierr
+
+      call timer%init(ierr=ierr)
+      call attach_mock_clock(timer)
+
+      call timer%start("stopped", ierr=ierr)
+      fake_time = 1.0_wp
+      call timer%stop("stopped", ierr=ierr)
+      fake_time = 2.0_wp
+      call timer%start("running", ierr=ierr)
+      fake_time = 5.0_wp
+      call timer%get_summary(summary, ierr=ierr)
+
+      call format_summary(summary, text)
+      stopped_row_present = index(text, 'stopped         1.000000      1.000000         1     20.00  no') > 0
+      active_row_present = index(text, 'running         3.000000      3.000000         1     60.00  yes') > 0
+
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      @assertTrue(summary%has_active_timers)
+      @assertFalse(summary%entries(1)%is_active)
+      @assertTrue(summary%entries(2)%is_active)
+      @assertTrue(stopped_row_present)
+      @assertTrue(active_row_present)
+   end subroutine test_active_snapshot_marks_mixed_active_and_stopped_rows
+
+   @test
+   subroutine test_repair_snapshot_marks_zero_call_active_context()
+      type(ftimer_t) :: timer
+      type(ftimer_summary_t) :: summary
+      character(len=:), allocatable :: text
+      integer :: child_b_idx
+      integer :: ierr
+      integer :: root_b_idx
+      logical :: continuation_row_present
+
+      call timer%init(mismatch_mode=FTIMER_MISMATCH_REPAIR, ierr=ierr)
+      call attach_mock_clock(timer)
+
+      call timer%start("A", ierr=ierr)
+      fake_time = 1.0_wp
+      call timer%start("B", ierr=ierr)
+      fake_time = 2.0_wp
+      call timer%stop("A", ierr=ierr)
+      fake_time = 5.0_wp
+      call timer%get_summary(summary, ierr=ierr)
+
+      child_b_idx = find_summary_entry(summary, "B", 1)
+      root_b_idx = find_summary_entry(summary, "B", 0)
+      call format_summary(summary, text)
+      continuation_row_present = index(text, 'B               3.000000      3.000000         0     60.00  yes') > 0
+
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      @assertTrue(summary%has_active_timers)
+      @assertTrue(child_b_idx > 0)
+      @assertTrue(root_b_idx > 0)
+      @assertFalse(summary%entries(child_b_idx)%is_active)
+      @assertTrue(summary%entries(root_b_idx)%is_active)
+      @assertEqual(1, summary%entries(child_b_idx)%call_count)
+      @assertEqual(0, summary%entries(root_b_idx)%call_count)
+      @assertEqual(0.0_wp, summary%entries(root_b_idx)%avg_time)
+      @assertTrue(continuation_row_present)
+   end subroutine test_repair_snapshot_marks_zero_call_active_context
+
+   @test
+   subroutine test_format_summary_derives_active_header_from_entries()
+      type(ftimer_summary_t) :: summary
+      character(len=:), allocatable :: text
+      logical :: active_header_present
+      logical :: active_row_present
+
+      summary%total_time = 2.0_wp
+      summary%num_entries = 1
+      summary%has_active_timers = .false.
+      allocate (summary%entries(1))
+      summary%entries(1)%name = 'manual'
+      summary%entries(1)%inclusive_time = 2.0_wp
+      summary%entries(1)%self_time = 2.0_wp
+      summary%entries(1)%call_count = 1
+      summary%entries(1)%pct_time = 100.0_wp
+      summary%entries(1)%is_active = .true.
+
+      call format_summary(summary, text)
+      active_header_present = index(text, 'Active timers  : yes') > 0
+      active_row_present = index(text, 'manual          2.000000      2.000000         1    100.00  yes') > 0
+
+      @assertTrue(active_header_present)
+      @assertTrue(active_row_present)
+   end subroutine test_format_summary_derives_active_header_from_entries
+
+   @test
+   subroutine test_format_summary_ignores_stale_top_level_active_flag()
+      type(ftimer_summary_t) :: summary
+      character(len=:), allocatable :: text
+      logical :: active_header_present
+      logical :: active_column_present
+
+      summary%total_time = 2.0_wp
+      summary%num_entries = 1
+      summary%has_active_timers = .true.
+      allocate (summary%entries(1))
+      summary%entries(1)%name = 'manual'
+      summary%entries(1)%inclusive_time = 2.0_wp
+      summary%entries(1)%self_time = 2.0_wp
+      summary%entries(1)%call_count = 1
+      summary%entries(1)%pct_time = 100.0_wp
+      summary%entries(1)%is_active = .false.
+
+      call format_summary(summary, text)
+      active_header_present = index(text, 'Active timers') > 0
+      active_column_present = index(text, 'Active') > 0
+
+      @assertFalse(active_header_present)
+      @assertFalse(active_column_present)
+   end subroutine test_format_summary_ignores_stale_top_level_active_flag
+
+   @test
+   subroutine test_format_summary_ignores_empty_stale_top_level_active_flag()
+      type(ftimer_summary_t) :: summary
+      character(len=:), allocatable :: text
+      logical :: active_header_present
+      logical :: active_column_present
+
+      summary%total_time = 2.0_wp
+      summary%num_entries = 0
+      summary%has_active_timers = .true.
+      allocate (summary%entries(0))
+
+      call format_summary(summary, text)
+      active_header_present = index(text, 'Active timers') > 0
+      active_column_present = index(text, 'Active') > 0
+
+      @assertFalse(active_header_present)
+      @assertFalse(active_column_present)
+   end subroutine test_format_summary_ignores_empty_stale_top_level_active_flag
+
+   @test
+   subroutine test_format_summary_skips_active_status_metadata_collision()
+      type(ftimer_metadata_t) :: metadata(2)
+      type(ftimer_summary_t) :: summary
+      character(len=:), allocatable :: text
+      logical :: active_header_present
+      logical :: conflicting_header_present
+      logical :: user_metadata_present
+
+      summary%total_time = 2.0_wp
+      summary%num_entries = 1
+      summary%has_active_timers = .true.
+      allocate (summary%entries(1))
+      summary%entries(1)%name = 'manual'
+      summary%entries(1)%inclusive_time = 2.0_wp
+      summary%entries(1)%self_time = 2.0_wp
+      summary%entries(1)%call_count = 1
+      summary%entries(1)%pct_time = 100.0_wp
+      summary%entries(1)%is_active = .true.
+      metadata(1)%key = 'Active timers'
+      metadata(1)%value = 'no'
+      metadata(2)%key = 'Case'
+      metadata(2)%value = 'Unit'
+
+      call format_summary(summary, text, metadata)
+      active_header_present = index(text, 'Active timers  : yes') > 0
+      conflicting_header_present = index(text, 'Active timers  : no') > 0
+      user_metadata_present = index(text, 'Case           : Unit') > 0
+
+      @assertTrue(active_header_present)
+      @assertFalse(conflicting_header_present)
+      @assertTrue(user_metadata_present)
+   end subroutine test_format_summary_skips_active_status_metadata_collision
 
    @test
    subroutine test_get_summary_keeps_same_timer_distinct_across_parents()
@@ -465,6 +761,37 @@ contains
       text = text//'A              10.000000      3.000000         1    100.00'//new_line('a')
       text = text//'  B             7.000000      7.000000         1     70.00'//new_line('a')
    end function expected_summary_output
+
+   subroutine count_snapshot_callback(timer_id, context_idx, event, timestamp, user_data)
+      integer, intent(in) :: timer_id
+      integer, intent(in) :: context_idx
+      integer, intent(in) :: event
+      real(wp), intent(in) :: timestamp
+      type(c_ptr), intent(in) :: user_data
+
+      if ((event == FTIMER_EVENT_START) .or. (event == FTIMER_EVENT_STOP)) then
+         snapshot_callback_count = snapshot_callback_count + 1
+      end if
+   end subroutine count_snapshot_callback
+
+   subroutine reset_snapshot_callback_count()
+      snapshot_callback_count = 0
+   end subroutine reset_snapshot_callback_count
+
+   integer function find_summary_entry(summary, name, depth) result(idx)
+      type(ftimer_summary_t), intent(in) :: summary
+      character(len=*), intent(in) :: name
+      integer, intent(in) :: depth
+      integer :: i
+
+      idx = 0
+      do i = 1, summary%num_entries
+         if ((trim(summary%entries(i)%name) == name) .and. (summary%entries(i)%depth == depth)) then
+            idx = i
+            return
+         end if
+      end do
+   end function find_summary_entry
 
    integer function count_lines(text) result(count)
       character(len=*), intent(in) :: text


### PR DESCRIPTION
Closes #155

## Summary
- define local get_summary/print_summary/write_summary as live snapshot APIs that can also serve final reports once all timers are stopped
- expose active local snapshot state through summary%has_active_timers and per-entry is_active
- mark active state in formatted local reports and update docs/tests around the new contract

## Validation
- cmake --build build-pf
- ctest --test-dir build-pf --output-on-failure -R ftimer_serial_tests
- git diff --check
- cmake --build build-smoke
- ctest --test-dir build-smoke --output-on-failure