### PR TITLE
Relax timer name and metadata storage before 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ end program quick_start
 
 Use `ftimer` for the procedural API and `ftimer_types` for shared types and constants such as `ftimer_summary_t`, `ftimer_mpi_summary_t`, `ftimer_metadata_t`, and `FTIMER_MISMATCH_*`.
 
-For metadata headers, construct `ftimer_metadata_t` values by assigning `%key` and `%value` directly. fTimer does not currently provide a helper constructor such as `ftimer_metadata(...)`.
+For metadata headers, construct `ftimer_metadata_t` values by assigning `%key` and `%value` directly. These fields use allocatable-length storage, so assigned strings are not silently capped at the legacy 64-character threshold. fTimer does not currently provide a helper constructor such as `ftimer_metadata(...)`; for formatted numeric metadata, write to a temporary character variable and then assign that string to `%value`.
 
 ## First Success
 
@@ -142,6 +142,7 @@ Operational notes:
 - `ierr` is now the last optional argument in both `init` signatures (`comm`, `mismatch_mode`, `ierr`), so a single positional integer binds to `comm`, not `ierr`. Keywords are recommended for readability.
 - `init`, `reset`, and `finalize` are correctness-first on active timers: with `ierr` they return `FTIMER_ERR_ACTIVE`; without `ierr` they warn and leave state unchanged. In `FTIMER_USE_OPENMP=ON` builds, that diagnostic contract applies on the master thread; worker-thread lifecycle calls remain silent no-ops. These paths do not force-stop active timers or synthesize summary data.
 - Stop-mismatch repair remains an explicit `mismatch_mode` choice (`FTIMER_MISMATCH_WARN` or `FTIMER_MISMATCH_REPAIR`); omitted-`ierr` alone does not opt a caller into recovery.
+- Timer names are right-trimmed and must be non-empty, must not begin with a blank, and must not contain ASCII control characters. fTimer does not silently truncate timer names and no longer rejects names solely for exceeding the legacy `FTIMER_NAME_LEN = 64` threshold.
 - Name-based `start`/`stop` remains the default ergonomic path. The runtime now uses internal mapped lookup for both resident timer names and per-segment parent-stack contexts, plus capacity-based growth, so that this default path avoids repeated resident-timer linear scans and context-list scans in steady state as the timer set and parent-stack variants grow.
 - `lookup()` plus `start_id()`/`stop_id()` remains an optional hot-path optimization when one call site times the same known region in a very tight loop.
 - Configure custom clocks through `set_clock()` and restore the build-default wall clock through `clear_clock()`. Direct mutation of raw runtime clock internals is not part of the supported API.
@@ -157,6 +158,7 @@ Operational notes:
 - In MPI text reports, `Avg %` means the arithmetic mean of each rank's local `% Total` for that timer, not `100*Avg Incl/Avg total time`.
 - Callbacks configured on `type(ftimer_t)` are lightweight intra-run hooks. They report normal start/stop events with runtime-local numeric ids; current `main` does not promise a stable semantic id-to-name/path mapping for profiler backends or durable cross-run tooling.
 - Import shared types and constants from `ftimer_types`; `use ftimer` does not re-export them.
+- `FTIMER_NAME_LEN` remains exported for source compatibility with early pre-1.0 consumers, but timer names, summary names, MPI summary names, and metadata key/value fields now use allocatable-length storage rather than that fixed width.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Operational notes:
 - Stop-mismatch repair remains an explicit `mismatch_mode` choice (`FTIMER_MISMATCH_WARN` or `FTIMER_MISMATCH_REPAIR`); omitted-`ierr` alone does not opt a caller into recovery.
 - Timer names are right-trimmed and must be non-empty, must not begin with a blank, and must not contain ASCII control characters. fTimer does not silently truncate timer names and no longer rejects names solely for exceeding the legacy `FTIMER_NAME_LEN = 64` threshold.
 - Name-based `start`/`stop` remains the default ergonomic path. The runtime now uses internal mapped lookup for both resident timer names and per-segment parent-stack contexts, plus capacity-based growth, so that this default path avoids repeated resident-timer linear scans and context-list scans in steady state as the timer set and parent-stack variants grow.
-- `lookup()` plus `start_id()`/`stop_id()` remains an optional hot-path optimization when one call site times the same known region in a very tight loop.
+- `lookup()` plus `start_id()`/`stop_id()` remains an optional hot-path optimization when one call site times the same known region in a very tight loop. That path is especially useful when a long scientific label would otherwise be validated and hashed on every name-based call.
 - Configure custom clocks through `set_clock()` and restore the build-default wall clock through `clear_clock()`. Direct mutation of raw runtime clock internals is not part of the supported API.
 - Clock changes are allowed before `init()` or before a run records timing data. After timing has started, `set_clock()` and `clear_clock()` return `FTIMER_ERR_ACTIVE` (or warn to stderr when `ierr` is omitted) and leave state unchanged. Use `reset()`, `init()`, or `finalize()` to begin a fresh run on a different clock.
 - Configure callbacks through `set_callback()` and `clear_callback()`. Callback configuration is rejected while timers are active, `clear_callback()` also clears callback `user_data`, and `finalize()` clears callback configuration.
@@ -158,7 +158,7 @@ Operational notes:
 - In MPI text reports, `Avg %` means the arithmetic mean of each rank's local `% Total` for that timer, not `100*Avg Incl/Avg total time`.
 - Callbacks configured on `type(ftimer_t)` are lightweight intra-run hooks. They report normal start/stop events with runtime-local numeric ids; current `main` does not promise a stable semantic id-to-name/path mapping for profiler backends or durable cross-run tooling.
 - Import shared types and constants from `ftimer_types`; `use ftimer` does not re-export them.
-- `FTIMER_NAME_LEN` remains exported for source compatibility with early pre-1.0 consumers, but timer names, summary names, MPI summary names, and metadata key/value fields now use allocatable-length storage rather than that fixed width.
+- `FTIMER_NAME_LEN` remains exported so code that only imports the constant still compiles, but timer names, summary names, MPI summary names, and metadata key/value fields now use allocatable-length storage rather than that fixed width. Pre-1.0 callers that treated those public components as preallocated fixed buffers, such as internal writes directly into `%value`, should write to a temporary string and assign the result.
 
 ## Examples
 
@@ -244,7 +244,7 @@ cmake --build build-bench --target ftimer_bench
 ./build-bench/bench/ftimer_bench
 ```
 
-This is useful for before/after regression checks when changing hot-path timing behavior. Compare the name-based lookup-scaling rows across resident timer counts to confirm the mapped default path stays much flatter than the old linear-scan baseline, and compare the context-scaling rows across larger `C` values to see how one hot timer behaves when it is reused under many distinct parent stacks. The flat name-based/id-based rows still help judge whether the optional cached-id path is worth it for one especially hot loop.
+This is useful for before/after regression checks when changing hot-path timing behavior. Compare the name-based lookup-scaling rows across resident timer counts to confirm the mapped default path stays much flatter than the old linear-scan baseline, and compare the context-scaling rows across larger `C` values to see how one hot timer behaves when it is reused under many distinct parent stacks. The long-name rows show the extra validation/hash cost for labels above the legacy threshold. The flat name-based/id-based rows still help judge whether the optional cached-id path is worth it for one especially hot loop.
 
 ## More Detail
 

--- a/bench/ftimer_bench.F90
+++ b/bench/ftimer_bench.F90
@@ -11,29 +11,34 @@
 !                                       lookup + stack push/pop + clock call
 !  2. Flat start/stop (id-based)     -- same path minus name normalization and
 !                                       mapped lookup; isolates stack cost
-!  3-7. Lookup scaling N=1/10/50/100/1000
+!  3-6. Long-name hot path L=64/256/1024
+!                                     -- one resident timer with long labels;
+!                                       name-based rows include full validation
+!                                       and hashing, id-based row shows cached
+!                                       lookup behavior for a long label
+!  7-11. Lookup scaling N=1/10/50/100/1000
 !                                     -- name-based; keeps the historical
 !                                       comparison points while also showing
 !                                       whether steady-state mapped lookup
 !                                       stays near-flat as the resident timer
 !                                       set grows into the larger regimes
-!  8-13. Context scaling C=1/10/50/100/500/1000
+! 12-17. Context scaling C=1/10/50/100/500/1000
 !                                     -- one hot timer reused under many parent
 !                                        stacks; name-based rows measure the
 !                                        default path under growing context
 !                                        counts and id-based rows isolate the
 !                                        per-segment parent-stack lookup
-! 14-17. Nesting depth 1/5/10/20     -- id-based; each cycle does D pushes +
+! 18-21. Nesting depth 1/5/10/20     -- id-based; each cycle does D pushes +
 !                                       D pops; shows stack bookkeeping cost
 !                                       scaling with nesting depth
-! 18-20. get_summary N=10/50/100     -- summary build scaling with timer count
-! 21-23. build_summary N=10/50/100   -- direct local summary construction on
+! 22-24. get_summary N=10/50/100     -- summary build scaling with timer count
+! 25-27. build_summary N=10/50/100   -- direct local summary construction on
 !                                       prebuilt flat segments; isolates the
 !                                       tree build/allocation work from the
 !                                       wrapper's timestamp capture
-! 24. raw date string formatting     -- date_and_time + string formatting,
+! 28. raw date string formatting     -- date_and_time + string formatting,
 !                                       matching the original per-call wrapper
-! 25. ftimer_date_string steady-state -- cached second-resolution date stamp
+! 29. ftimer_date_string steady-state -- cached second-resolution date stamp
 !                                        path used by get_summary/print/write
 !
 ! METRICS
@@ -70,6 +75,7 @@ program ftimer_bench
    implicit none
 
    integer, parameter :: REPS_HOT = 100000  ! flat and lookup scenarios
+   integer, parameter :: REPS_LONG_NAME = 50000
    integer, parameter :: REPS_NESTED = 10000   ! per nesting-depth scenario
    integer, parameter :: REPS_SUMMARY = 1000    ! per summary scenario (N=10, N=50)
    ! Reduced rep count for N=100: get_summary at 100 timers is ~40x slower than
@@ -94,6 +100,10 @@ program ftimer_bench
    ! --- Hot-path scenarios ---
    call bench_flat_name(REPS_HOT, count_rate)
    call bench_flat_id(REPS_HOT, count_rate)
+   call bench_long_name(REPS_LONG_NAME, 64, .false., count_rate)
+   call bench_long_name(REPS_LONG_NAME, 256, .false., count_rate)
+   call bench_long_name(REPS_LONG_NAME, 1024, .false., count_rate)
+   call bench_long_name(REPS_LONG_NAME, 1024, .true., count_rate)
 
    write (*, '(a)') ''
 
@@ -156,6 +166,7 @@ program ftimer_bench
    write (*, '(a)') '  - build_summary (direct) uses prebuilt flat segments and fixed dates.'
    write (*, '(a)') '  - raw date string = uncached date_and_time + formatting.'
    write (*, '(a)') '  - ftimer_date_string steady-state = cached path after warm-up.'
+   write (*, '(a)') '  - Long-name name-based rows include full per-call validation and hashing of the label.'
    write (*, '(a)') '  - name-based start/stop remains the default path; lookup/start_id/stop_id is the optional hot path.'
    write (*, '(a)') '  - All scenarios use the real wall-clock (no mock clock).'
    write (*, '(a)') '  - Timings include clock-call overhead inside start/stop.'
@@ -204,7 +215,47 @@ contains
       call print_result('flat start/stop (id-based)', reps, t0, t1, count_rate)
    end subroutine bench_flat_id
 
-   ! Scenarios 3-7: name-based lookup with N unique timers.
+   ! Scenarios 3-6: long-name start/stop with one steady-state resident timer.
+   ! The name-based rows include per-call validation and hashing across the full
+   ! label length. The id-based row shows the cached-id path after one lookup.
+   subroutine bench_long_name(reps, name_len, use_id, count_rate)
+      integer, intent(in) :: reps
+      integer, intent(in) :: name_len
+      logical, intent(in) :: use_id
+      integer(int64), intent(in) :: count_rate
+      integer(int64) :: t0, t1
+      character(len=:), allocatable :: tname
+      character(len=47) :: label
+      integer :: i, id
+
+      tname = repeat('l', name_len)
+
+      call ftimer_init()
+      id = ftimer_lookup(tname)
+      call system_clock(t0)
+      if (use_id) then
+         do i = 1, reps
+            call ftimer_start_id(id)
+            call ftimer_stop_id(id)
+         end do
+      else
+         do i = 1, reps
+            call ftimer_start(tname)
+            call ftimer_stop(tname)
+         end do
+      end if
+      call system_clock(t1)
+      call ftimer_finalize()
+
+      if (use_id) then
+         write (label, '("long name L=",i0," (id-based)")') name_len
+      else
+         write (label, '("long name L=",i0," (name-based)")') name_len
+      end if
+      call print_result(trim(label), reps, t0, t1, count_rate)
+   end subroutine bench_long_name
+
+   ! Scenarios 7-11: name-based lookup with N unique timers.
    ! Cycles through all N timers each outer rep. Each inner start/stop uses
    ! the same public name-based path as production code, but with a large
    ! resident timer set already registered. The 1/10/50 points preserve the

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -55,11 +55,11 @@ wait on asynchronous offload work, or insert MPI barriers around timer regions.
 ## Timer Name / Summary Text Policy
 
 - Public timer creation/lookup paths right-trim trailing blanks, reject empty names, reject names that begin with a blank, and reject ASCII control characters. They do not silently truncate names and do not impose the legacy `FTIMER_NAME_LEN` value as a runtime name cap.
-- Timer names, runtime segment names, local summary entry names, MPI summary entry names, and metadata key/value fields use allocatable-length character storage. The exported `FTIMER_NAME_LEN = 64` constant is retained as a pre-1.0 compatibility threshold for early callers that imported it, not as the current storage or validation limit.
+- Timer names, runtime segment names, local summary entry names, MPI summary entry names, and metadata key/value fields use allocatable-length character storage. The exported `FTIMER_NAME_LEN = 64` constant is retained so code that imports it still compiles, but it is not the current storage or validation limit. Pre-1.0 code that treated those components as fixed writable buffers, such as internal writes directly into metadata `%value`, must allocate or assign through a temporary string first.
 - Metadata entries with an unallocated or blank key are skipped by formatted reports. An unallocated metadata value is formatted as blank; assigned metadata values are formatted at their full trimmed length.
 - Name-based `start`/`stop` remains the default supported timing path; the runtime uses internal mapped lookup for both resident timer names and per-segment parent-stack contexts, plus capacity-based growth, so that this ergonomic path avoids repeated resident-timer linear scans, steady-state context-list scans, and one-slot-at-a-time whole-array growth as the timer set grows
 - Per-timer context selection remains fully context-sensitive accounting over the current parent stack for that timer; repeated reuse of one timer name under many distinct parent stacks now uses a per-segment parent-stack index in steady state rather than rescanning the full known-context list each time
-- `lookup()` plus `start_id()`/`stop_id()` remains an optional hot-path optimization for tight loops that repeatedly time the same known regions
+- `lookup()` plus `start_id()`/`stop_id()` remains an optional hot-path optimization for tight loops that repeatedly time the same known regions, especially when long labels would otherwise be validated and hashed on every name-based call
 - Formatted summary output does not emit unsafe raw summary-entry names literally
 - Escaped formatted-summary forms are stable: leading blanks render as `\x20`, backslashes render as `\\`, tab/newline/carriage return render as `\t`/`\n`/`\r`, other ASCII control characters render as `\xNN`, and blank/empty raw names render as `<blank>`
 
@@ -114,6 +114,7 @@ wait on asynchronous offload work, or insert MPI barriers around timer regions.
 - Extra timers, missing timers, renamed timers, and hierarchy/context mismatches fail the MPI summary with `FTIMER_ERR_MPI_INCON`; they do not fall back to a local summary object through the MPI API
 - When that descriptor preflight fails inside one communicator, the omitted-`ierr` diagnostic reports the disagreeing communicator-local ranks when possible
 - MPI descriptor matching is based on the local summary tree shape and names, not on raw local `node_id` values
+- The MPI descriptor preflight materializes deterministic length-prefixed path strings at summary time so names that differ only after the legacy 64-character threshold remain distinguishable. This is outside the start/stop hot path, but its memory and sort cost scales with summary entry count and encoded path length for very large timer trees.
 - Mismatched communicator choices across would-be participants are unsupported; this API has no safe cross-communicator rendezvous to detect that misuse without risking the same MPI deadlock it is trying to avoid
 
 ### Unsupported communicator mismatch example

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -54,7 +54,9 @@ wait on asynchronous offload work, or insert MPI barriers around timer regions.
 
 ## Timer Name / Summary Text Policy
 
-- Public timer creation/lookup paths right-trim trailing blanks, reject empty names, reject names longer than `FTIMER_NAME_LEN`, reject names that begin with a blank, and reject ASCII control characters
+- Public timer creation/lookup paths right-trim trailing blanks, reject empty names, reject names that begin with a blank, and reject ASCII control characters. They do not silently truncate names and do not impose the legacy `FTIMER_NAME_LEN` value as a runtime name cap.
+- Timer names, runtime segment names, local summary entry names, MPI summary entry names, and metadata key/value fields use allocatable-length character storage. The exported `FTIMER_NAME_LEN = 64` constant is retained as a pre-1.0 compatibility threshold for early callers that imported it, not as the current storage or validation limit.
+- Metadata entries with an unallocated or blank key are skipped by formatted reports. An unallocated metadata value is formatted as blank; assigned metadata values are formatted at their full trimmed length.
 - Name-based `start`/`stop` remains the default supported timing path; the runtime uses internal mapped lookup for both resident timer names and per-segment parent-stack contexts, plus capacity-based growth, so that this ergonomic path avoids repeated resident-timer linear scans, steady-state context-list scans, and one-slot-at-a-time whole-array growth as the timer set grows
 - Per-timer context selection remains fully context-sensitive accounting over the current parent stack for that timer; repeated reuse of one timer name under many distinct parent stacks now uses a per-segment parent-stack index in steady state rather than rescanning the full known-context list each time
 - `lookup()` plus `start_id()`/`stop_id()` remains an optional hot-path optimization for tight loops that repeatedly time the same known regions

--- a/examples/nested_timers.F90
+++ b/examples/nested_timers.F90
@@ -11,7 +11,7 @@ program nested_timers
    metadata(1)%key = "case"
    metadata(1)%value = "nested_timers"
    metadata(2)%key = "steps"
-   write (metadata(2)%value, '(i0)') 3
+   metadata(2)%value = "3"
 
    call ftimer_init()
    call ftimer_start("advance")

--- a/src/ftimer_core.F90
+++ b/src/ftimer_core.F90
@@ -1086,7 +1086,6 @@ contains
       integer :: code
       character(len=32) :: position_text
 
-      message = ''
       trimmed_len = len_trim(name)
 
       if (trimmed_len <= 0) then

--- a/src/ftimer_core.F90
+++ b/src/ftimer_core.F90
@@ -4,9 +4,9 @@ module ftimer_core
    use ftimer_clock, only: ftimer_date_string, ftimer_default_clock, ftimer_mpi_clock
    use ftimer_types, only: FTIMER_ERR_ACTIVE, FTIMER_ERR_IO, FTIMER_ERR_INVALID_NAME, FTIMER_ERR_MISMATCH, &
                            FTIMER_ERR_NOT_INIT, FTIMER_ERR_UNKNOWN, FTIMER_EVENT_START, FTIMER_EVENT_STOP, &
-                           FTIMER_MISMATCH_REPAIR, FTIMER_MISMATCH_STRICT, FTIMER_MISMATCH_WARN, FTIMER_NAME_LEN, &
-                           FTIMER_SUCCESS, ftimer_call_stack_t, ftimer_clock_func, ftimer_hook_proc, &
-                           ftimer_metadata_t, ftimer_mpi_summary_t, ftimer_segment_t, ftimer_summary_t, wp
+                           FTIMER_MISMATCH_REPAIR, FTIMER_MISMATCH_STRICT, FTIMER_MISMATCH_WARN, FTIMER_SUCCESS, &
+                           ftimer_call_stack_t, ftimer_clock_func, ftimer_hook_proc, ftimer_metadata_t, &
+                           ftimer_mpi_summary_t, ftimer_segment_t, ftimer_summary_t, wp
    implicit none
    private
 
@@ -340,21 +340,21 @@ contains
       integer, intent(out), optional :: ierr
       integer :: id
       integer :: status
-      character(len=FTIMER_NAME_LEN) :: normalized_name
-      character(len=160) :: message
+      integer :: trimmed_len
+      character(len=:), allocatable :: message
 
       if (.not. self%initialized) then
          call report_status(ierr, FTIMER_ERR_NOT_INIT, "ftimer start before init")
          return
       end if
 
-      call normalize_name(name, normalized_name, status, message)
+      call normalize_name(name, trimmed_len, status, message)
       if (status /= FTIMER_SUCCESS) then
          call report_status(ierr, status, message)
          return
       end if
 
-      id = self%find_or_create_segment(normalized_name)
+      id = self%find_or_create_segment(name(1:trimmed_len))
       call start_id_impl(self, id, ierr=ierr)
    end subroutine start_impl
 
@@ -374,23 +374,23 @@ contains
       integer, intent(out), optional :: ierr
       integer :: id
       integer :: status
-      character(len=FTIMER_NAME_LEN) :: normalized_name
-      character(len=160) :: message
+      integer :: trimmed_len
+      character(len=:), allocatable :: message
 
       if (.not. self%initialized) then
          call report_status(ierr, FTIMER_ERR_NOT_INIT, "ftimer stop before init")
          return
       end if
 
-      call normalize_name(name, normalized_name, status, message)
+      call normalize_name(name, trimmed_len, status, message)
       if (status /= FTIMER_SUCCESS) then
          call report_status(ierr, status, message)
          return
       end if
 
-      id = find_segment_index(self, normalized_name)
+      id = find_segment_index(self, name(1:trimmed_len))
       if (id <= 0) then
-         write (message, '(3a)') "ftimer stop on unknown timer: ", trim(normalized_name), ""
+         message = "ftimer stop on unknown timer: "//name(1:trimmed_len)
          call report_status(ierr, FTIMER_ERR_UNKNOWN, trim(message))
          return
       end if
@@ -456,7 +456,7 @@ contains
       class(ftimer_t), intent(inout) :: self
       integer, intent(in) :: id
       integer, intent(out), optional :: ierr
-      character(len=192) :: message
+      character(len=:), allocatable :: message
 
       if (.not. self%initialized) then
          call report_status(ierr, FTIMER_ERR_NOT_INIT, "ftimer stop_id before init")
@@ -479,8 +479,8 @@ contains
          return
       end if
 
-      write (message, '(5a)') "ftimer stop mismatch: requested ", trim(self%segments(id)%name), &
-         " but top of stack is ", trim(self%segments(self%call_stack%top())%name), ""
+      message = "ftimer stop mismatch: requested "//trim(self%segments(id)%name)// &
+                " but top of stack is "//trim(self%segments(self%call_stack%top())%name)
 
       select case (self%mismatch_mode)
       case (FTIMER_MISMATCH_STRICT)
@@ -524,8 +524,8 @@ contains
       character(len=*), intent(in) :: name
       integer, intent(out), optional :: ierr
       integer :: status
-      character(len=FTIMER_NAME_LEN) :: normalized_name
-      character(len=160) :: message
+      integer :: trimmed_len
+      character(len=:), allocatable :: message
 
       id = 0
       if (.not. self%initialized) then
@@ -533,13 +533,13 @@ contains
          return
       end if
 
-      call normalize_name(name, normalized_name, status, message)
+      call normalize_name(name, trimmed_len, status, message)
       if (status /= FTIMER_SUCCESS) then
          call report_status(ierr, status, message)
          return
       end if
 
-      id = self%find_or_create_segment(normalized_name)
+      id = self%find_or_create_segment(name(1:trimmed_len))
       if (present(ierr)) ierr = FTIMER_SUCCESS
    end function lookup_impl
 
@@ -1077,28 +1077,21 @@ contains
       has_active = self%call_stack%depth > 0
    end function has_active_timers
 
-   subroutine normalize_name(name, normalized_name, status, message)
+   subroutine normalize_name(name, trimmed_len, status, message)
       character(len=*), intent(in) :: name
-      character(len=FTIMER_NAME_LEN), intent(out) :: normalized_name
+      integer, intent(out) :: trimmed_len
       integer, intent(out) :: status
-      character(len=*), intent(out) :: message
+      character(len=:), allocatable, intent(out) :: message
       integer :: i
       integer :: code
-      integer :: trimmed_len
+      character(len=32) :: position_text
 
-      normalized_name = ''
       message = ''
       trimmed_len = len_trim(name)
 
       if (trimmed_len <= 0) then
          status = FTIMER_ERR_INVALID_NAME
          message = "ftimer timer name must not be empty"
-         return
-      end if
-
-      if (trimmed_len > FTIMER_NAME_LEN) then
-         status = FTIMER_ERR_INVALID_NAME
-         write (message, '(a,i0)') "ftimer timer name exceeds FTIMER_NAME_LEN=", FTIMER_NAME_LEN
          return
       end if
 
@@ -1112,12 +1105,12 @@ contains
          code = iachar(name(i:i))
          if ((code < 32) .or. (code == 127)) then
             status = FTIMER_ERR_INVALID_NAME
-            write (message, '(a,i0)') "ftimer timer name contains control character at position ", i
+            write (position_text, '(i0)') i
+            message = "ftimer timer name contains control character at position "//trim(position_text)
             return
          end if
       end do
 
-      normalized_name(1:trimmed_len) = name(1:trimmed_len)
       status = FTIMER_SUCCESS
    end subroutine normalize_name
 

--- a/src/ftimer_mpi.F90
+++ b/src/ftimer_mpi.F90
@@ -1,7 +1,7 @@
 module ftimer_mpi
    use, intrinsic :: iso_fortran_env, only: int64
    use ftimer_types, only: FTIMER_ERR_ACTIVE, FTIMER_ERR_MPI_INCON, FTIMER_ERR_NOT_IMPLEMENTED, &
-                           FTIMER_ERR_UNKNOWN, FTIMER_NAME_LEN, FTIMER_SUCCESS, ftimer_mpi_summary_t, &
+                           FTIMER_ERR_UNKNOWN, FTIMER_SUCCESS, ftimer_mpi_summary_t, ftimer_summary_entry_t, &
                            ftimer_summary_t, wp
 #ifdef FTIMER_USE_MPI
    use mpi
@@ -621,8 +621,8 @@ contains
       type(ftimer_summary_t), intent(in) :: summary
       character(len=:), allocatable, intent(out) :: descriptors(:)
       integer, allocatable, intent(out) :: permutation(:)
+      character(len=:), allocatable :: component
       character(len=:), allocatable :: path_strings(:)
-      character(len=FTIMER_NAME_LEN + 5) :: component
       integer :: component_len
       integer :: i
       integer :: max_len
@@ -657,7 +657,7 @@ contains
 
       do i = 1, summary%num_entries
          parent_id = summary%entries(i)%parent_id
-         component_len = descriptor_component_length(summary%entries(i)%name)
+         component_len = descriptor_component_length(summary_entry_name(summary%entries(i)))
          if (parent_id <= 0) then
             prefix_lengths(i) = component_len
          else
@@ -681,7 +681,8 @@ contains
 
       do i = 1, summary%num_entries
          parent_id = summary%entries(i)%parent_id
-         call encode_descriptor_component(summary%entries(i)%name, component, component_len)
+         call encode_descriptor_component(summary_entry_name(summary%entries(i)), component)
+         component_len = len(component)
          if (parent_id <= 0) then
             path_strings(i) = component(1:component_len)
          else
@@ -703,23 +704,47 @@ contains
    integer function descriptor_component_length(name) result(component_len)
       character(len=*), intent(in) :: name
 
-      component_len = 5 + len_trim(name)
+      component_len = decimal_digit_count(len_trim(name)) + 1 + len_trim(name)
    end function descriptor_component_length
 
-   subroutine encode_descriptor_component(name, component, component_len)
+   subroutine encode_descriptor_component(name, component)
       character(len=*), intent(in) :: name
-      character(len=*), intent(out) :: component
-      integer, intent(out) :: component_len
-      character(len=4) :: len_text
+      character(len=:), allocatable, intent(out) :: component
+      character(len=32) :: len_text
       integer :: trimmed_len
 
-      component = ''
       trimmed_len = len_trim(name)
-      component_len = descriptor_component_length(name)
 
-      write (len_text, '(i4.4)') trimmed_len
-      component(1:component_len) = len_text//':'//name(1:trimmed_len)
+      write (len_text, '(i0)') trimmed_len
+      if (trimmed_len > 0) then
+         component = trim(len_text)//':'//name(1:trimmed_len)
+      else
+         component = trim(len_text)//':'
+      end if
    end subroutine encode_descriptor_component
+
+   integer function decimal_digit_count(value) result(count)
+      integer, intent(in) :: value
+      integer :: remaining
+
+      count = 1
+      remaining = value
+      do while (remaining >= 10)
+         remaining = remaining/10
+         count = count + 1
+      end do
+   end function decimal_digit_count
+
+   function summary_entry_name(entry) result(name)
+      type(ftimer_summary_entry_t), intent(in) :: entry
+      character(len=:), allocatable :: name
+
+      if (allocated(entry%name)) then
+         name = entry%name
+      else
+         name = ''
+      end if
+   end function summary_entry_name
 
    subroutine sort_permutation_by_descriptor(descriptors, permutation)
       character(len=*), intent(in) :: descriptors(:)
@@ -759,9 +784,9 @@ contains
       do i = 1, size(permutation)
          trimmed_len = len_trim(descriptors(permutation(i)))
          do j = 1, trimmed_len
-            high_hash = hash_step(high_hash, int(iachar(descriptors(permutation(i))(j:j)), int64), &
+            high_hash = hash_step(high_hash, int(iachar(descriptors(permutation(i)) (j:j)), int64), &
                                   16777619_int64, 4294967291_int64)
-            low_hash = hash_step(low_hash, int(iachar(descriptors(permutation(i))(j:j)), int64), &
+            low_hash = hash_step(low_hash, int(iachar(descriptors(permutation(i)) (j:j)), int64), &
                                  65599_int64, 4294967279_int64)
          end do
          high_hash = hash_step(high_hash, 10_int64, 16777619_int64, 4294967291_int64)

--- a/src/ftimer_summary.F90
+++ b/src/ftimer_summary.F90
@@ -1,5 +1,5 @@
 module ftimer_summary
-   use ftimer_types, only: FTIMER_NAME_LEN, ftimer_call_stack_t, ftimer_metadata_t, ftimer_mpi_summary_entry_t, &
+   use ftimer_types, only: ftimer_call_stack_t, ftimer_metadata_t, ftimer_mpi_summary_entry_t, &
                            ftimer_mpi_summary_t, ftimer_segment_t, ftimer_summary_entry_t, ftimer_summary_t, wp
    implicit none
    private
@@ -70,10 +70,10 @@ contains
 
       if (present(metadata)) then
          do i = 1, size(metadata)
-            if (len_trim(metadata(i)%key) <= 0) cycle
-            if (has_active_entries .and. metadata_key_is_reserved(metadata(i)%key)) cycle
-            call set_padded_text(padded, trim(metadata(i)%key), key_width)
-            call append_line(text, padded(1:key_width)//' : '//trim(metadata(i)%value))
+            if (metadata_key_len(metadata(i)) <= 0) cycle
+            if (has_active_entries .and. metadata_key_is_reserved(metadata_key_text(metadata(i)))) cycle
+            call set_padded_text(padded, metadata_key_text(metadata(i)), key_width)
+            call append_line(text, padded(1:key_width)//' : '//metadata_value_text(metadata(i)))
          end do
       end if
 
@@ -166,9 +166,9 @@ contains
 
       if (present(metadata)) then
          do i = 1, size(metadata)
-            if (len_trim(metadata(i)%key) <= 0) cycle
-            call set_padded_text(padded, trim(metadata(i)%key), key_width)
-            call append_line(text, padded(1:key_width)//' : '//trim(metadata(i)%value))
+            if (metadata_key_len(metadata(i)) <= 0) cycle
+            call set_padded_text(padded, metadata_key_text(metadata(i)), key_width)
+            call append_line(text, padded(1:key_width)//' : '//metadata_value_text(metadata(i)))
          end do
       end if
 
@@ -542,7 +542,7 @@ contains
       character(len=:), allocatable :: name
       character(len=:), allocatable :: escaped_name
 
-      escaped_name = escaped_summary_name(entry%name)
+      escaped_name = escaped_summary_name(summary_entry_name(entry))
       name = repeat(' ', 2*entry%depth)//escaped_name
    end function display_name
 
@@ -650,7 +650,7 @@ contains
       if (.not. present(metadata)) return
 
       do i = 1, size(metadata)
-         width = max(width, len_trim(metadata(i)%key))
+         width = max(width, metadata_key_len(metadata(i)))
       end do
    end function metadata_key_width
 
@@ -718,9 +718,60 @@ contains
       character(len=:), allocatable :: name
       character(len=:), allocatable :: escaped_name
 
-      escaped_name = escaped_summary_name(entry%name)
+      escaped_name = escaped_summary_name(mpi_summary_entry_name(entry))
       name = repeat(' ', 2*entry%depth)//escaped_name
    end function display_mpi_name
+
+   function summary_entry_name(entry) result(name)
+      type(ftimer_summary_entry_t), intent(in) :: entry
+      character(len=:), allocatable :: name
+
+      if (allocated(entry%name)) then
+         name = entry%name
+      else
+         name = ''
+      end if
+   end function summary_entry_name
+
+   function mpi_summary_entry_name(entry) result(name)
+      type(ftimer_mpi_summary_entry_t), intent(in) :: entry
+      character(len=:), allocatable :: name
+
+      if (allocated(entry%name)) then
+         name = entry%name
+      else
+         name = ''
+      end if
+   end function mpi_summary_entry_name
+
+   integer function metadata_key_len(item) result(width)
+      type(ftimer_metadata_t), intent(in) :: item
+
+      width = 0
+      if (allocated(item%key)) width = len_trim(item%key)
+   end function metadata_key_len
+
+   function metadata_key_text(item) result(text)
+      type(ftimer_metadata_t), intent(in) :: item
+      character(len=:), allocatable :: text
+
+      if (allocated(item%key)) then
+         text = trim(item%key)
+      else
+         text = ''
+      end if
+   end function metadata_key_text
+
+   function metadata_value_text(item) result(text)
+      type(ftimer_metadata_t), intent(in) :: item
+      character(len=:), allocatable :: text
+
+      if (allocated(item%value)) then
+         text = trim(item%value)
+      else
+         text = ''
+      end if
+   end function metadata_value_text
 
    function escaped_summary_name(name) result(escaped)
       character(len=*), intent(in) :: name

--- a/src/ftimer_types.F90
+++ b/src/ftimer_types.F90
@@ -41,6 +41,8 @@ module ftimer_types
    integer, parameter :: FTIMER_ERR_INVALID_NAME = 8
 
    integer, parameter :: wp = selected_real_kind(15, 307)
+   ! Retained as the pre-1.0 fixed-width compatibility threshold. Runtime timer
+   ! names and metadata are allocatable-length strings and are not capped here.
    integer, parameter :: FTIMER_NAME_LEN = 64
 
    integer, parameter :: FTIMER_MISMATCH_STRICT = 1
@@ -54,12 +56,12 @@ module ftimer_types
    integer, parameter :: FTIMER_CONTEXT_LIST_INITIAL_CAPACITY = 4
 
    type :: ftimer_metadata_t
-      character(len=FTIMER_NAME_LEN) :: key = ''
-      character(len=FTIMER_NAME_LEN) :: value = ''
+      character(len=:), allocatable :: key
+      character(len=:), allocatable :: value
    end type ftimer_metadata_t
 
    type :: ftimer_summary_entry_t
-      character(len=FTIMER_NAME_LEN) :: name = ''
+      character(len=:), allocatable :: name
       integer :: depth = 0
       real(wp) :: inclusive_time = 0.0_wp
       real(wp) :: self_time = 0.0_wp
@@ -82,7 +84,7 @@ module ftimer_types
    end type ftimer_summary_t
 
    type :: ftimer_mpi_summary_entry_t
-      character(len=FTIMER_NAME_LEN) :: name = ''
+      character(len=:), allocatable :: name
       integer :: depth = 0
       real(wp) :: min_inclusive_time = 0.0_wp
       real(wp) :: max_inclusive_time = 0.0_wp
@@ -137,7 +139,7 @@ module ftimer_types
    end type ftimer_context_list_t
 
    type :: ftimer_segment_t
-      character(len=FTIMER_NAME_LEN) :: name = ''
+      character(len=:), allocatable :: name
       real(wp), allocatable :: time(:)
       real(wp), allocatable :: start_time(:)
       logical, allocatable :: is_running(:)

--- a/tests/install-consumer/main.F90
+++ b/tests/install-consumer/main.F90
@@ -2,6 +2,8 @@ program ftimer_installed_consumer
    use ftimer, only: ftimer_finalize, ftimer_get_summary, ftimer_init, ftimer_start, ftimer_stop
    use ftimer_types, only: ftimer_summary_t, wp
    implicit none
+   character(len=*), parameter :: consumer_name = &
+                                  "consumer_work_with_scientific_module_path_longer_than_the_legacy_sixty_four_character_threshold"
    integer :: ierr
    integer :: i
    real :: accumulator
@@ -10,7 +12,7 @@ program ftimer_installed_consumer
    call ftimer_init(ierr=ierr)
    if (ierr /= 0) error stop 1
 
-   call ftimer_start("consumer_work", ierr=ierr)
+   call ftimer_start(consumer_name, ierr=ierr)
    if (ierr /= 0) error stop 2
 
    accumulator = 0.0
@@ -18,13 +20,13 @@ program ftimer_installed_consumer
       accumulator = accumulator + real(i)
    end do
 
-   call ftimer_stop("consumer_work", ierr=ierr)
+   call ftimer_stop(consumer_name, ierr=ierr)
    if (ierr /= 0) error stop 3
 
    call ftimer_get_summary(summary, ierr=ierr)
    if (ierr /= 0) error stop 4
    if (summary%num_entries /= 1) error stop 5
-   if (trim(summary%entries(1)%name) /= "consumer_work") error stop 6
+   if (trim(summary%entries(1)%name) /= consumer_name) error stop 6
    if (summary%entries(1)%node_id <= 0) error stop 7
    if (summary%entries(1)%parent_id /= 0) error stop 8
    if (summary%entries(1)%call_count /= 1) error stop 9

--- a/tests/mpi/test_mpi_consistency.pf
+++ b/tests/mpi/test_mpi_consistency.pf
@@ -2,7 +2,8 @@ module test_mpi_consistency
    use pfunit
    use mpi
    use ftimer_core, only: ftimer_t
-   use ftimer_types, only: FTIMER_ERR_MPI_INCON, FTIMER_ERR_UNKNOWN, FTIMER_SUCCESS, ftimer_mpi_summary_t, wp
+   use ftimer_types, only: FTIMER_ERR_MPI_INCON, FTIMER_ERR_UNKNOWN, FTIMER_NAME_LEN, FTIMER_SUCCESS, &
+                           ftimer_mpi_summary_t, wp
    use test_support, only: attach_mock_clock, begin_stderr_capture, end_stderr_capture, fake_time
    implicit none
 
@@ -129,6 +130,45 @@ contains
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
    end subroutine test_mpi_summary_prefers_lowest_rank_for_extrema_ties
+
+   @test
+   subroutine test_mpi_summary_rejects_names_that_share_legacy_prefix(this)
+      class(mpi_consistency_case), intent(inout) :: this
+      type(ftimer_t) :: timer
+      type(ftimer_mpi_summary_t) :: summary
+      character(len=FTIMER_NAME_LEN) :: legacy_prefix
+      character(len=FTIMER_NAME_LEN + 8) :: timer_name
+      integer :: ierr
+      integer :: rank
+
+      rank = this%getProcessRank()
+      legacy_prefix = repeat('p', len(legacy_prefix))
+      if (rank == 0) then
+         timer_name = legacy_prefix//'rank0000'
+      else
+         timer_name = legacy_prefix//'rank0001'
+      end if
+
+      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(timer)
+
+      fake_time = 0.0_wp
+      call timer%start(timer_name, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      fake_time = 1.0_wp
+      call timer%stop(timer_name, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call timer%mpi_summary(summary, ierr=ierr)
+
+      @assertEqual(FTIMER_ERR_MPI_INCON, ierr)
+      @assertEqual(0, summary%num_ranks)
+      @assertEqual(0, summary%num_entries)
+
+      call timer%finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_mpi_summary_rejects_names_that_share_legacy_prefix
 
    @test
    subroutine test_mpi_summary_rejects_mpi_comm_null_before_collectives(this)

--- a/tests/mpi/test_mpi_summary.pf
+++ b/tests/mpi/test_mpi_summary.pf
@@ -4,7 +4,7 @@ module test_mpi_summary
    use ftimer, only: ftimer_default_instance, ftimer_finalize, ftimer_init, ftimer_mpi_summary, &
                      ftimer_print_mpi_summary, ftimer_start, ftimer_stop
    use ftimer_core, only: ftimer_t
-   use ftimer_types, only: FTIMER_ERR_ACTIVE, FTIMER_ERR_IO, FTIMER_SUCCESS, ftimer_metadata_t, &
+   use ftimer_types, only: FTIMER_ERR_ACTIVE, FTIMER_ERR_IO, FTIMER_NAME_LEN, FTIMER_SUCCESS, ftimer_metadata_t, &
                            ftimer_mpi_summary_t, wp
    use test_support, only: attach_mock_clock, fake_time, read_file_text, summary_node_ids_unique, summary_parent_index
    implicit none
@@ -214,6 +214,53 @@ contains
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
    end subroutine test_mpi_summary_uses_canonical_order_for_consistent_timer_sets
+
+   @test
+   subroutine test_mpi_summary_preserves_long_timer_names(this)
+      class(mpi_summary_case), intent(inout) :: this
+      type(ftimer_t) :: timer
+      type(ftimer_mpi_summary_t) :: summary
+      character(len=FTIMER_NAME_LEN + 32) :: root_name
+      character(len=FTIMER_NAME_LEN + 48) :: child_name
+      integer :: child_len
+      integer :: expected_child_len
+      integer :: expected_root_len
+      integer :: ierr
+      integer :: root_len
+      logical :: child_name_matches
+      logical :: root_name_matches
+
+      root_name = repeat('r', len(root_name))
+      child_name = repeat('c', len(child_name))
+      expected_root_len = len(root_name)
+      expected_child_len = len(child_name)
+
+      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(timer)
+
+      call build_long_named_timers(timer, this%getProcessRank(), root_name, child_name, ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      if (ierr /= FTIMER_SUCCESS) return
+
+      call timer%mpi_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      root_len = len_trim(summary%entries(1)%name)
+      child_len = len_trim(summary%entries(2)%name)
+      root_name_matches = trim(summary%entries(1)%name) == root_name
+      child_name_matches = trim(summary%entries(2)%name) == child_name
+
+      @assertEqual(expected_root_len, root_len)
+      @assertEqual(expected_child_len, child_len)
+      @assertTrue(root_name_matches)
+      @assertTrue(child_name_matches)
+      @assertEqual(0, summary_parent_index(summary, 1))
+      @assertEqual(1, summary_parent_index(summary, 2))
+
+      call timer%finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_mpi_summary_preserves_long_timer_names
 
    @test
    subroutine test_mpi_summary_handles_nested_reordered_sets(this)
@@ -512,6 +559,29 @@ contains
       fake_time = base_time + 2.5_wp + real(rank, wp)
       call timer%stop("outer", ierr=ierr)
    end subroutine build_large_timestamp_nested_timers
+
+   subroutine build_long_named_timers(timer, rank, root_name, child_name, ierr)
+      class(ftimer_t), intent(inout) :: timer
+      integer, intent(in) :: rank
+      character(len=*), intent(in) :: root_name
+      character(len=*), intent(in) :: child_name
+      integer, intent(out) :: ierr
+
+      fake_time = 0.0_wp
+      call timer%start(root_name, ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) return
+
+      fake_time = 1.0_wp + real(rank, wp)
+      call timer%start(child_name, ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) return
+
+      fake_time = 3.0_wp + real(rank, wp)
+      call timer%stop(child_name, ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) return
+
+      fake_time = 5.0_wp + real(rank, wp)
+      call timer%stop(root_name, ierr=ierr)
+   end subroutine build_long_named_timers
 
    subroutine build_nested_timers_procedural(rank, ierr)
       integer, intent(in) :: rank

--- a/tests/mpi/test_mpi_summary.pf
+++ b/tests/mpi/test_mpi_summary.pf
@@ -220,16 +220,22 @@ contains
       class(mpi_summary_case), intent(inout) :: this
       type(ftimer_t) :: timer
       type(ftimer_mpi_summary_t) :: summary
+      character(len=:), allocatable :: printed
+      character(len=*), parameter :: print_path = 'test_mpi_long_name_print_summary.txt'
       character(len=FTIMER_NAME_LEN + 32) :: root_name
       character(len=FTIMER_NAME_LEN + 48) :: child_name
       integer :: child_len
       integer :: expected_child_len
       integer :: expected_root_len
+      integer :: flags(2)
       integer :: ierr
+      integer :: rank
       integer :: root_len
+      integer :: unit
       logical :: child_name_matches
       logical :: root_name_matches
 
+      rank = this%getProcessRank()
       root_name = repeat('r', len(root_name))
       child_name = repeat('c', len(child_name))
       expected_root_len = len(root_name)
@@ -257,6 +263,31 @@ contains
       @assertTrue(child_name_matches)
       @assertEqual(0, summary_parent_index(summary, 1))
       @assertEqual(1, summary_parent_index(summary, 2))
+
+      flags = 0
+      if (rank == 0) then
+         call delete_if_exists(print_path)
+         open (newunit=unit, file=print_path, status='replace', action='write', iostat=ierr)
+         @assertEqual(0, ierr)
+         call timer%print_mpi_summary(unit=unit, ierr=ierr)
+         close (unit)
+      else
+         call timer%print_mpi_summary(ierr=ierr)
+      end if
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call MPI_Barrier(MPI_COMM_WORLD, ierr)
+      @assertEqual(MPI_SUCCESS, ierr)
+
+      if (rank == 0) then
+         printed = read_file_text(print_path)
+         if (index(printed, root_name) > 0) flags(1) = 1
+         if (index(printed, child_name) > 0) flags(2) = 1
+      end if
+      call MPI_Bcast(flags, size(flags), MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+      @assertEqual(MPI_SUCCESS, ierr)
+
+      @assertEqual(1, flags(1))
+      @assertEqual(1, flags(2))
 
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)

--- a/tests/mpi/test_mpi_summary.pf
+++ b/tests/mpi/test_mpi_summary.pf
@@ -397,7 +397,7 @@ contains
    subroutine test_mpi_print_summary_emits_global_report(this)
       class(mpi_summary_case), intent(inout) :: this
       type(ftimer_t) :: timer
-      type(ftimer_metadata_t) :: metadata(1)
+      type(ftimer_metadata_t) :: metadata(3)
       character(len=:), allocatable :: printed
       character(len=*), parameter :: expected_header = &
                                      'Timer name  Min Incl (s)  Min Rank  Avg Incl (s)  Max Incl (s)  Max Rank'// &
@@ -409,7 +409,7 @@ contains
                                      '  inner         4.000000         0      5.000000      6.000000'// &
                                      '         1   1.200      5.000000       1.000     41.67'
       character(len=*), parameter :: print_path = 'test_mpi_print_summary.txt'
-      integer :: flags(13)
+      integer :: flags(15)
       integer :: ierr
       integer :: rank
       integer :: unit
@@ -422,6 +422,8 @@ contains
 
       metadata(1)%key = 'Job'
       metadata(1)%value = 'mpi-report'
+      metadata(2)%value = 'orphan-mpi'
+      metadata(3)%key = 'BlankValue'
 
       call build_nested_timers(timer, rank, ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
@@ -455,6 +457,8 @@ contains
          if (index(printed, expected_header) > 0) flags(11) = 1
          if (index(printed, expected_inner_row) > 0) flags(12) = 1
          if (index(printed, wrong_ratio_inner_row) == 0) flags(13) = 1
+         if (index(printed, 'BlankValue') > 0) flags(14) = 1
+         if (index(printed, 'orphan-mpi') == 0) flags(15) = 1
       end if
       call MPI_Bcast(flags, size(flags), MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
       @assertEqual(MPI_SUCCESS, ierr)
@@ -472,6 +476,8 @@ contains
       @assertEqual(1, flags(11))
       @assertEqual(1, flags(12))
       @assertEqual(1, flags(13))
+      @assertEqual(1, flags(14))
+      @assertEqual(1, flags(15))
 
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)

--- a/tests/test_edge_cases.pf
+++ b/tests/test_edge_cases.pf
@@ -586,12 +586,15 @@ contains
       type(ftimer_t) :: timer
       type(ftimer_summary_t) :: summary
       type(ftimer_test_state_t) :: state
+      character(len=:), allocatable :: printed
       character(len=FTIMER_NAME_LEN + 48) :: long_name
       integer :: expected_len
       integer :: ierr
       integer :: id
       integer :: state_name_len
       integer :: summary_name_len
+      integer :: unit
+      logical :: printed_name_matches
       logical :: state_name_matches
       logical :: summary_name_matches
 
@@ -619,13 +622,82 @@ contains
       summary_name_len = len_trim(summary%entries(1)%name)
       state_name_matches = trim(state%segments(id)%name) == long_name
       summary_name_matches = trim(summary%entries(1)%name) == long_name
+      open (newunit=unit, status='scratch', action='readwrite')
+      call timer%print_summary(unit=unit, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      printed = read_unit_text(unit)
+      close (unit)
+      printed_name_matches = index(printed, long_name) > 0
 
       @assertEqual(expected_len, state_name_len)
       @assertEqual(expected_len, summary_name_len)
       @assertTrue(state_name_matches)
       @assertTrue(summary_name_matches)
+      @assertTrue(printed_name_matches)
       @assertEqual(2.0_wp, summary%entries(1)%inclusive_time)
    end subroutine test_long_name_above_legacy_len_round_trips
+
+   @test
+   subroutine test_names_that_share_legacy_prefix_remain_distinct()
+      type(ftimer_t) :: timer
+      type(ftimer_summary_t) :: summary
+      character(len=FTIMER_NAME_LEN) :: legacy_prefix
+      character(len=FTIMER_NAME_LEN + 8) :: first_name
+      character(len=FTIMER_NAME_LEN + 8) :: second_name
+      integer :: first_id
+      integer :: first_idx
+      integer :: ierr
+      integer :: second_id
+      integer :: second_idx
+      logical :: first_name_matches
+      logical :: second_name_matches
+
+      legacy_prefix = repeat('p', len(legacy_prefix))
+      first_name = legacy_prefix//'suffixA1'
+      second_name = legacy_prefix//'suffixB2'
+
+      call timer%init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(timer)
+
+      first_id = timer%lookup(first_name, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      second_id = timer%lookup(second_name, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      @assertTrue(first_id /= second_id)
+
+      fake_time = 0.0_wp
+      call timer%start(first_name, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      fake_time = 2.0_wp
+      call timer%stop(first_name, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call timer%start(second_name, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      fake_time = 5.0_wp
+      call timer%stop(second_name, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call timer%get_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      first_idx = find_summary_entry(summary, first_name, 0)
+      second_idx = find_summary_entry(summary, second_name, 0)
+      @assertTrue(first_idx > 0)
+      @assertTrue(second_idx > 0)
+
+      first_name_matches = trim(summary%entries(first_idx)%name) == first_name
+      second_name_matches = trim(summary%entries(second_idx)%name) == second_name
+
+      @assertTrue(first_name_matches)
+      @assertTrue(second_name_matches)
+      @assertEqual(2.0_wp, summary%entries(first_idx)%inclusive_time)
+      @assertEqual(3.0_wp, summary%entries(second_idx)%inclusive_time)
+
+      call timer%finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_names_that_share_legacy_prefix_remain_distinct
 
    @test
    subroutine test_lookup_rejects_control_chars_and_edge_whitespace()

--- a/tests/test_edge_cases.pf
+++ b/tests/test_edge_cases.pf
@@ -582,26 +582,50 @@ contains
    end subroutine test_reset_without_ierr_warns_and_leaves_state_unchanged
 
    @test
-   subroutine test_name_length_limit_accepts_exact_and_rejects_longer()
+   subroutine test_long_name_above_legacy_len_round_trips()
       type(ftimer_t) :: timer
-      character(len=FTIMER_NAME_LEN) :: exact_name
-      character(len=FTIMER_NAME_LEN + 1) :: long_name
+      type(ftimer_summary_t) :: summary
+      type(ftimer_test_state_t) :: state
+      character(len=FTIMER_NAME_LEN + 48) :: long_name
+      integer :: expected_len
       integer :: ierr
-      integer :: id_exact
-      integer :: id_long
+      integer :: id
+      integer :: state_name_len
+      integer :: summary_name_len
+      logical :: state_name_matches
+      logical :: summary_name_matches
 
-      exact_name = repeat("x", FTIMER_NAME_LEN)
-      long_name = repeat("y", FTIMER_NAME_LEN + 1)
+      long_name = repeat("x", len(long_name))
+      expected_len = len(long_name)
 
       call timer%init(ierr=ierr)
-      id_exact = timer%lookup(exact_name, ierr=ierr)
-      @assertEqual(FTIMER_SUCCESS, ierr)
-      @assertEqual(1, id_exact)
+      call attach_mock_clock(timer)
 
-      id_long = timer%lookup(long_name, ierr=ierr)
-      @assertEqual(FTIMER_ERR_INVALID_NAME, ierr)
-      @assertEqual(0, id_long)
-   end subroutine test_name_length_limit_accepts_exact_and_rejects_longer
+      id = timer%lookup(long_name, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      @assertEqual(1, id)
+
+      call timer%start(long_name, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      fake_time = 2.0_wp
+      call timer%stop(long_name, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call snapshot_timer(timer, state)
+      call timer%get_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      state_name_len = len_trim(state%segments(id)%name)
+      summary_name_len = len_trim(summary%entries(1)%name)
+      state_name_matches = trim(state%segments(id)%name) == long_name
+      summary_name_matches = trim(summary%entries(1)%name) == long_name
+
+      @assertEqual(expected_len, state_name_len)
+      @assertEqual(expected_len, summary_name_len)
+      @assertTrue(state_name_matches)
+      @assertTrue(summary_name_matches)
+      @assertEqual(2.0_wp, summary%entries(1)%inclusive_time)
+   end subroutine test_long_name_above_legacy_len_round_trips
 
    @test
    subroutine test_lookup_rejects_control_chars_and_edge_whitespace()

--- a/tests/test_summary.pf
+++ b/tests/test_summary.pf
@@ -561,6 +561,29 @@ contains
    end subroutine test_format_summary_preserves_metadata_above_legacy_len
 
    @test
+   subroutine test_format_summary_handles_unallocated_metadata_fields()
+      type(ftimer_metadata_t) :: metadata(3)
+      type(ftimer_summary_t) :: summary
+      character(len=:), allocatable :: text
+      logical :: blank_value_key_present
+      logical :: orphan_value_skipped
+
+      summary%total_time = 1.0_wp
+      summary%num_entries = 0
+      allocate (summary%entries(0))
+      metadata(2)%value = 'orphan-value'
+      metadata(3)%key = 'BlankValue'
+
+      call format_summary(summary, text, metadata)
+
+      blank_value_key_present = index(text, 'BlankValue') > 0
+      orphan_value_skipped = index(text, 'orphan-value') == 0
+
+      @assertTrue(blank_value_key_present)
+      @assertTrue(orphan_value_skipped)
+   end subroutine test_format_summary_handles_unallocated_metadata_fields
+
+   @test
    subroutine test_get_summary_keeps_same_timer_distinct_across_parents()
       type(ftimer_t) :: timer
       type(ftimer_summary_t) :: summary

--- a/tests/test_summary.pf
+++ b/tests/test_summary.pf
@@ -3,7 +3,8 @@ module test_summary
    use pfunit
    use ftimer_core, only: ftimer_t
    use ftimer_summary, only: build_summary, format_summary
-   use ftimer_types, only: FTIMER_EVENT_START, FTIMER_EVENT_STOP, FTIMER_MISMATCH_REPAIR, FTIMER_SUCCESS, &
+   use ftimer_types, only: FTIMER_EVENT_START, FTIMER_EVENT_STOP, FTIMER_MISMATCH_REPAIR, FTIMER_NAME_LEN, &
+                           FTIMER_SUCCESS, &
                            ftimer_call_stack_t, ftimer_metadata_t, ftimer_segment_t, ftimer_summary_entry_t, &
                            ftimer_summary_t, wp
    use test_support, only: attach_mock_clock, build_stack, fake_time, read_unit_text
@@ -521,6 +522,43 @@ contains
       @assertFalse(conflicting_header_present)
       @assertTrue(user_metadata_present)
    end subroutine test_format_summary_skips_active_status_metadata_collision
+
+   @test
+   subroutine test_format_summary_preserves_metadata_above_legacy_len()
+      type(ftimer_metadata_t) :: metadata(1)
+      type(ftimer_summary_t) :: summary
+      character(len=FTIMER_NAME_LEN + 24) :: long_key
+      character(len=FTIMER_NAME_LEN + 40) :: long_value
+      character(len=:), allocatable :: expected_line
+      character(len=:), allocatable :: text
+      integer :: expected_key_len
+      integer :: expected_value_len
+      integer :: stored_key_len
+      integer :: stored_value_len
+      logical :: long_metadata_present
+
+      long_key = repeat('k', len(long_key))
+      long_value = repeat('v', len(long_value))
+      expected_key_len = len(long_key)
+      expected_value_len = len(long_value)
+
+      summary%total_time = 1.0_wp
+      summary%num_entries = 0
+      allocate (summary%entries(0))
+      metadata(1)%key = long_key
+      metadata(1)%value = long_value
+
+      call format_summary(summary, text, metadata)
+
+      stored_key_len = len_trim(metadata(1)%key)
+      stored_value_len = len_trim(metadata(1)%value)
+      expected_line = long_key//' : '//long_value
+      long_metadata_present = index(text, expected_line) > 0
+
+      @assertEqual(expected_key_len, stored_key_len)
+      @assertEqual(expected_value_len, stored_value_len)
+      @assertTrue(long_metadata_present)
+   end subroutine test_format_summary_preserves_metadata_above_legacy_len
 
    @test
    subroutine test_get_summary_keeps_same_timer_distinct_across_parents()


### PR DESCRIPTION
## Summary

Closes #154.

Decision: move timer names, segment names, local/MPI summary entry names, and metadata key/value fields to allocatable-length character storage before the 1.0 data-model freeze. `FTIMER_NAME_LEN = 64` remains exported so imports still compile, but it is no longer a storage or validation cap. This is an intentional pre-1.0 data-model change: callers that used public character components as fixed writable buffers need to assign strings or write through a temporary first.

Implementation notes:
- preserve invalid-name safety: empty names, leading blanks, and ASCII control characters still return `FTIMER_ERR_INVALID_NAME`; trailing blanks are still right-trimmed
- avoid silent truncation for timer names and metadata values
- keep name-based hot paths allocation-light by validating against the caller string and allocating only when a new resident segment name is stored
- update MPI descriptor encoding to dynamic length-prefixed components so names that differ only after the legacy threshold remain deterministic across ranks
- document the compatibility and performance policy in `docs/semantics.md` and `README.md`, and update metadata examples for allocatable string assignment

## Validation

Final head `68bccc9`:
- `ctest --test-dir build-pf --output-on-failure -R ftimer_serial_tests`
- `ctest --test-dir build-mpi-tests --output-on-failure -R ftimer_mpi_tests`
- `ctest --test-dir build-smoke --output-on-failure`
- `fprettify --diff tests/test_summary.pf tests/mpi/test_mpi_summary.pf`
- `git diff --check`

Earlier on this branch after the implementation/performance patch:
- `ctest --test-dir build-pf --output-on-failure -R ftimer_serial_tests`
- `ctest --test-dir build-mpi-tests --output-on-failure -R ftimer_mpi_tests`
- `ctest --test-dir build-smoke --output-on-failure`
- `fprettify --diff src/ftimer_core.F90 tests/test_edge_cases.pf tests/mpi/test_mpi_summary.pf tests/mpi/test_mpi_consistency.pf bench/ftimer_bench.F90`
- `git diff --check`
- `./build-bench/bench/ftimer_bench`

Initial implementation validation also covered the broader touched-file formatting set including `src/ftimer_types.F90`, `src/ftimer_mpi.F90`, `src/ftimer_summary.F90`, `tests/test_edge_cases.pf`, `tests/test_summary.pf`, `tests/mpi/test_mpi_summary.pf`, `examples/nested_timers.F90`, and `tests/install-consumer/main.F90`.

## Performance Notes

Performance implication: short-name `start`/`stop` remains allocation-light and comparable to `main`; accepting long names moves unavoidable string-length work to the name-based call path and summary/report generation.

Shared-row comparison against a temporary clean `main` worktree using Release `ftimer_bench` with LLVMFlang 22.1.6:
- flat name-based start/stop: main 236.1 ns/op, branch 224.2 ns/op
- lookup scaling N=1000: main 238.3 ns/op, branch 220.4 ns/op
- context scaling C=1000 name-based: main 457.5 ns/op, branch 407.9 ns/op

Summary construction is measurably more expensive because each returned entry now owns an allocatable-length name:
- get_summary N=10: main 823.0 ns/op, branch 1188.0 ns/op
- get_summary N=50: main 2419.0 ns/op, branch 3928.0 ns/op
- get_summary N=100: main 3950.0 ns/op, branch 7885.0 ns/op

Current branch adds explicit long-name benchmark rows. On the post-implementation run:
- L=64 name-based: 663.8 ns/op
- L=256 name-based: 2515.7 ns/op
- L=1024 name-based: 10005.7 ns/op
- L=1024 id-based after one lookup: 51.8 ns/op

The practical guidance is now explicit in docs: name-based calls are ergonomic and preserve full labels, but tight loops with very long scientific labels should use `lookup()` plus `start_id()`/`stop_id()`. MPI descriptor preflight also materializes length-prefixed canonical paths at summary time, so its memory/sort cost scales with entry count and encoded path length; that preserves descriptor determinism and remains outside the start/stop hot path.