### PR TITLE
Fix #158: add procedural scoped guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ The call stack state CHANGES between start and stop — this is the most common 
 
 Current `main` is in Phase 6. The shared types/clock foundation, core timer runtime, local summary/report formatting, procedural convenience wrappers, MPI-reduced structured summaries, and limited OpenMP master-thread guards are implemented.
 
-During Phase 6, keep the library, examples, install package, smoke tests, and pFUnit suite buildable. Keep the diff phase-bounded: preserve procedural-wrapper parity with the OOP core, keep MPI summary behavior correct and explicit, preserve the limited master-thread-only OpenMP guard model, and keep current-state docs/examples honest. Do not pull fuller post-Phase-6 design work or broader OpenMP support forward.
+During Phase 6, keep the library, examples, install package, smoke tests, and pFUnit suite buildable. Keep the diff phase-bounded: preserve procedural-wrapper parity with the OOP core unless a tracked issue explicitly defers parity, keep MPI summary behavior correct and explicit, preserve the limited master-thread-only OpenMP guard model, and keep current-state docs/examples honest. Do not pull fuller post-Phase-6 design work or broader OpenMP support forward.
 
 Detailed repository operations and PR/review handling live in `docs/maintainer.md`. Use that file for GitHub workflow details; keep this file focused on coding/build/test behavior and the short mandatory PR summary below.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ The call stack state CHANGES between start and stop — this is the most common 
 
 Current `main` is in Phase 6. The shared types/clock foundation, core timer runtime, local summary/report formatting, procedural convenience wrappers, MPI-reduced structured summaries, and limited OpenMP master-thread guards are implemented.
 
-During Phase 6, keep the library, examples, install package, smoke tests, and pFUnit suite buildable. Keep the diff phase-bounded: preserve procedural-wrapper parity with the OOP core, keep MPI summary behavior correct and explicit, preserve the limited master-thread-only OpenMP guard model, and keep current-state docs/examples honest. Do not pull fuller post-Phase-6 design work or broader OpenMP support forward.
+During Phase 6, keep the library, examples, install package, smoke tests, and pFUnit suite buildable. Keep the diff phase-bounded: preserve procedural-wrapper parity with the OOP core unless a tracked issue explicitly defers parity, keep MPI summary behavior correct and explicit, preserve the limited master-thread-only OpenMP guard model, and keep current-state docs/examples honest. Do not pull fuller post-Phase-6 design work or broader OpenMP support forward.
 
 Detailed repository operations and PR/review handling live in `docs/maintainer.md`. Use that file for GitHub workflow details; keep this file focused on coding/build/test behavior and the short mandatory PR summary below.
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ For lexical blocks with early exits, the procedural API also provides a scalar s
 block
    use ftimer, only: ftimer_guard_t, ftimer_scope
    type(ftimer_guard_t) :: guard
+   integer :: ierr
 
    call ftimer_scope(guard, "work", ierr=ierr)
    if (ierr /= 0) error stop
@@ -142,7 +143,7 @@ cmake --build my_app/build
 
 The supported downstream contract is the installed package export. New adopters should not need to infer the intended consumption model from the test suite.
 
-The downstream example under [`tests/install-consumer/`](tests/install-consumer/) is also part of the smoke path. It shows the supported installed-package happy path with `find_package(fTimer CONFIG REQUIRED)`, `use ftimer_types`, timer start/stop calls, and summary retrieval from an installed prefix.
+The downstream example under [`tests/install-consumer/`](tests/install-consumer/) is also part of the smoke path. It shows the supported installed-package happy path with `find_package(fTimer CONFIG REQUIRED)`, `use ftimer`, `use ftimer_types`, scoped timing, and summary retrieval from an installed prefix.
 
 The supported source-level module surface is intentionally narrow: `ftimer`, `ftimer_core`, and `ftimer_types`. Some install trees may still contain compiler module artifacts for implementation modules such as `ftimer_clock`, `ftimer_summary`, and `ftimer_mpi`, but those are internal implementation details, not stable user-facing API. The current validated toolchain matrix does not require any extra compiler-specific companion artifacts in the installed include tree. If a future compiler proves that such artifacts are truly required for downstream consumption, they should be added deliberately and documented as an explicit exception rather than leaked accidentally.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ For a first release, the focus is a small, dependable core:
 - strict, stack-based start/stop timing by default
 - context-sensitive accounting for the same timer name under different parents
 - inclusive and self time in structured summaries with explicit tree linkage
+- a small procedural scoped guard for lexical blocks with early exits
 - procedural wrappers and an OOP core API
 - optional MPI global summaries plus first-class text and CSV report output
 - an installable CMake package for downstream projects
@@ -60,6 +61,22 @@ program quick_start
    call ftimer_finalize()
 end program quick_start
 ```
+
+For lexical blocks with early exits, the procedural API also provides a scalar scoped guard:
+
+```fortran
+block
+   use ftimer, only: ftimer_guard_t, ftimer_scope
+   type(ftimer_guard_t) :: guard
+
+   call ftimer_scope(guard, "work", ierr=ierr)
+   if (ierr /= 0) error stop
+
+   ! work that may return or exit the block early
+end block
+```
+
+The guard starts the named timer through the default procedural instance and stops that same activation when the guard leaves scope. Call `guard%stop(ierr=ierr)` when you need to observe the stop result before scope exit. For non-lexical lifetimes, cached-id hot paths, or complex ownership, prefer explicit `ftimer_start`/`ftimer_stop`.
 
 Use `ftimer` for the procedural API and `ftimer_types` for shared types and constants such as `ftimer_summary_t`, `ftimer_mpi_summary_t`, `ftimer_metadata_t`, and `FTIMER_MISMATCH_*`.
 
@@ -133,7 +150,7 @@ The supported source-level module surface is intentionally narrow: `ftimer`, `ft
 
 The public API supports two styles:
 
-- Procedural API from `use ftimer`, including `ftimer_init`, `ftimer_finalize`, `ftimer_start`, `ftimer_stop`, `ftimer_start_id`, `ftimer_stop_id`, `ftimer_lookup`, `ftimer_reset`, `ftimer_get_summary`, `ftimer_mpi_summary`, `ftimer_print_summary`, `ftimer_write_summary`, `ftimer_write_summary_csv`, `ftimer_print_mpi_summary`, `ftimer_write_mpi_summary`, `ftimer_write_mpi_summary_csv`, and `ftimer_default_instance`
+- Procedural API from `use ftimer`, including `ftimer_init`, `ftimer_finalize`, `ftimer_start`, `ftimer_stop`, `ftimer_scope`, `ftimer_guard_t`, `ftimer_start_id`, `ftimer_stop_id`, `ftimer_lookup`, `ftimer_reset`, `ftimer_get_summary`, `ftimer_mpi_summary`, `ftimer_print_summary`, `ftimer_write_summary`, `ftimer_write_summary_csv`, `ftimer_print_mpi_summary`, `ftimer_write_mpi_summary`, `ftimer_write_mpi_summary_csv`, and `ftimer_default_instance`
 - OOP API through `type(ftimer_t)` in `ftimer_core`, including the explicit configuration methods `set_clock`, `clear_clock`, `set_callback`, and `clear_callback`
 
 New users should start with the procedural API unless they already know they need instance-level control. Reach for `type(ftimer_t)` when you want multiple independent timer objects, want to avoid the default global instance, or need to manage clock or callback configuration on a specific timer object. Procedural callers that need those advanced controls can use `ftimer_default_instance%...` explicitly.
@@ -145,6 +162,8 @@ Operational notes:
 - Stop-mismatch repair remains an explicit `mismatch_mode` choice (`FTIMER_MISMATCH_WARN` or `FTIMER_MISMATCH_REPAIR`); omitted-`ierr` alone does not opt a caller into recovery.
 - Timer names are right-trimmed and must be non-empty, must not begin with a blank, and must not contain ASCII control characters. fTimer does not silently truncate timer names and no longer rejects names solely for exceeding the legacy `FTIMER_NAME_LEN = 64` threshold.
 - Name-based `start`/`stop` remains the default ergonomic path. The runtime now uses internal mapped lookup for both resident timer names and per-segment parent-stack contexts, plus capacity-based growth, so that this default path avoids repeated resident-timer linear scans and context-list scans in steady state as the timer set and parent-stack variants grow.
+- `ftimer_scope(guard, name, ierr)` is a small safety layer for scalar lexical-block timing on the default procedural instance. The guard may stop only the exact activation it started; if that activation was already stopped or displaced by other timer operations, `guard%stop(ierr)` returns `FTIMER_ERR_MISMATCH` and the finalizer warns when it cannot report `ierr`.
+- Scoped guards do not replace explicit `start`/`stop`. Guard assignment/copy is unsupported and does not copy or transfer active ownership; assignment involving an active guard warns and leaves ownership with the original guard. Guard arrays, saved/global guards, function-return guard constructors, cross-procedure lifetime patterns, and block-local finalization inside OpenMP parallel regions are unsupported. `ftimer_scope_id` and OOP scoped guards are deferred.
 - `lookup()` plus `start_id()`/`stop_id()` remains an optional hot-path optimization when one call site times the same known region in a very tight loop. That path is especially useful when a long scientific label would otherwise be validated and hashed on every name-based call.
 - Configure custom clocks through `set_clock()` and restore the build-default wall clock through `clear_clock()`. Direct mutation of raw runtime clock internals is not part of the supported API.
 - Clock changes are allowed before `init()` or before a run records timing data. After timing has started, `set_clock()` and `clear_clock()` return `FTIMER_ERR_ACTIVE` (or warn to stderr when `ierr` is omitted) and leave state unchanged. Use `reset()`, `init()`, or `finalize()` to begin a fresh run on a different clock.
@@ -159,7 +178,7 @@ Operational notes:
 - `print_mpi_summary()` and `write_mpi_summary()` are the first-class MPI reporting paths. They perform the collective MPI summary build and emit one abbreviated report from communicator root. The printed per-entry table is not a serialization of every `ftimer_mpi_summary_t` field; inspect `mpi_summary()` results for min/max self time, self imbalance, min/max call counts, min/max rank-local `% Total`, and explicit `node_id`/`parent_id` tree links.
 - `write_mpi_summary_csv()` and `ftimer_write_mpi_summary_csv()` perform the same collective MPI summary build and write one CSV artifact from communicator root. The CSV includes the complete reduced MPI entry fields, including explicit tree links and inclusive-time extrema ranks.
 - In MPI text reports, `Avg %` means the arithmetic mean of each rank's local `% Total` for that timer, not `100*Avg Incl/Avg total time`.
-- Callbacks configured on `type(ftimer_t)` are lightweight intra-run hooks. They report normal start/stop events with runtime-local numeric ids; current `main` does not promise a stable semantic id-to-name/path mapping for profiler backends or durable cross-run tooling.
+- Callbacks configured on `type(ftimer_t)` are lightweight intra-run hooks. They report normal start/stop events with runtime-local numeric ids; current `main` does not promise a stable semantic id-to-name/path mapping for profiler backends or durable cross-run tooling. Scoped guards produce only the normal underlying start/stop callback events; mutating timer state from callbacks during scoped guard start/stop is unsupported.
 - Import shared types and constants from `ftimer_types`; `use ftimer` does not re-export them.
 - `FTIMER_NAME_LEN` remains exported so code that only imports the constant still compiles, but timer names, summary names, MPI summary names, and metadata key/value fields now use allocatable-length storage rather than that fixed width. Pre-1.0 callers that treated those public components as preallocated fixed buffers, such as internal writes directly into `%value`, should write to a temporary string and assign the result.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -154,6 +154,8 @@ The currently exported procedural entry points are:
 - `ftimer_finalize`
 - `ftimer_start`
 - `ftimer_stop`
+- `ftimer_scope`
+- `ftimer_guard_t`
 - `ftimer_start_id`
 - `ftimer_stop_id`
 - `ftimer_lookup`
@@ -174,6 +176,8 @@ Important current-state API notes:
 - `init`, `reset`, and `finalize` treat active timers as an error in both API styles. With `ierr` they return `FTIMER_ERR_ACTIVE`; without `ierr` they warn and leave state untouched rather than force-stopping or cleaning up implicitly. In `FTIMER_USE_OPENMP=ON` builds, that lifecycle-diagnostic contract applies on the master thread; non-master lifecycle calls remain suppressed no-ops.
 - Repairing stop mismatches remains an explicit `mismatch_mode` decision; omitted `ierr` alone is not a recovery mode.
 - Name-based `start`/`stop` remains the default user path. `lookup()` plus `start_id()`/`stop_id()` is documented as an optional cached-id hot path rather than a separate primary workflow.
+- `ftimer_scope()` and `ftimer_guard_t` provide a small default-instance scoped guard for lexical blocks. There is no current OOP scoped guard API; that parity question is deferred separately.
+- `ftimer_core` exposes low-level scoped-activation helpers only so the procedural `ftimer` module can implement exact activation ownership without duplicating start/stop internals. They are implementation hooks, not a supported downstream API; callers should use `ftimer_scope()` or explicit `start`/`stop`.
 - `get_summary()` is the local structured summary path.
 - `ftimer_summary_t` entries now retain `name`/`depth` and also expose `node_id`/`parent_id` links that are stable only within one produced summary object.
 - `print_summary()` and `write_summary()` format local report text.

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -4,7 +4,7 @@
 
 This document describes the current runtime contract on `main`.
 
-Current `main` implements the Phase 2 core timer behavior, Phase 3 local summary/reporting behavior, Phase 4 procedural wrappers, Phase 5 MPI structured summaries, and the Phase 6 OpenMP guard behavior: stack-based start/stop timing, context-sensitive accounting, strict/warn/repair mismatch handling, `lookup`, `reset`, the `ierr` vs stderr error contract, `get_summary()`, `print_summary()`, `write_summary()`, `write_summary_csv()`, `mpi_summary()`, `print_mpi_summary()`, `write_mpi_summary()`, `write_mpi_summary_csv()`, self-time computation, callback suppression during repair, descriptor-hash MPI preflight, globally meaningful MPI min/avg/max summary fields on every participating rank, and limited master-thread-only OpenMP guards in `ftimer_core` when built with `FTIMER_USE_OPENMP=ON`. In non-MPI builds, `mpi_summary()` returns `FTIMER_ERR_NOT_IMPLEMENTED` with an empty MPI summary result.
+Current `main` implements the Phase 2 core timer behavior, Phase 3 local summary/reporting behavior, Phase 4 procedural wrappers, Phase 5 MPI structured summaries, and the Phase 6 OpenMP guard behavior: stack-based start/stop timing, context-sensitive accounting, strict/warn/repair mismatch handling, `lookup`, `reset`, the procedural `ftimer_scope` scoped guard, the `ierr` vs stderr error contract, `get_summary()`, `print_summary()`, `write_summary()`, `write_summary_csv()`, `mpi_summary()`, `print_mpi_summary()`, `write_mpi_summary()`, `write_mpi_summary_csv()`, self-time computation, callback suppression during repair, descriptor-hash MPI preflight, globally meaningful MPI min/avg/max summary fields on every participating rank, and limited master-thread-only OpenMP guards in `ftimer_core` when built with `FTIMER_USE_OPENMP=ON`. In non-MPI builds, `mpi_summary()` returns `FTIMER_ERR_NOT_IMPLEMENTED` with an empty MPI summary result.
 
 This contract is strongest for disciplined serial and pure-MPI wall-clock timing. The OpenMP path is a narrow master-thread-only carve-out for bracketing a parallel region as a whole, not a general hybrid-thread timing contract. Likewise, `on_event` is a lightweight intra-run hook, not a stable external-profiler integration API.
 
@@ -62,6 +62,23 @@ wait on asynchronous offload work, or insert MPI barriers around timer regions.
 - `lookup()` plus `start_id()`/`stop_id()` remains an optional hot-path optimization for tight loops that repeatedly time the same known regions, especially when long labels would otherwise be validated and hashed on every name-based call
 - Formatted summary output does not emit unsafe raw summary-entry names literally
 - Escaped formatted-summary forms are stable: leading blanks render as `\x20`, backslashes render as `\\`, tab/newline/carriage return render as `\t`/`\n`/`\r`, other ASCII control characters render as `\xNN`, and blank/empty raw names render as `<blank>`
+
+## Scoped Guard Contract
+
+- `ftimer_scope(guard, name, ierr)` is the only scoped guard constructor on current `main`
+- The public guard type is `ftimer_guard_t`, imported from `ftimer`
+- Scoped guards use the default procedural timer instance; there is no `type(ftimer_t)` scoped guard API on current `main`
+- `ftimer_scope` starts the named timer through the same validation, lookup, accounting, and callback path as normal name-based `start`
+- If `ftimer_scope` fails, the guard remains inactive. Finalization and `guard%stop(ierr)` are no-ops for inactive guards.
+- A guard owns exactly one activation token from its successful start. `guard%stop(ierr)` may stop only that exact activation while it is still the top of the stack.
+- If the guard's activation has already been stopped, repaired away, or replaced by another activation with the same timer name, `guard%stop(ierr)` returns `FTIMER_ERR_MISMATCH` and leaves timer state unchanged.
+- The guard finalizer attempts the same exact-activation stop without `ierr`. On mismatch or lifecycle errors, it warns to stderr and does not repair.
+- Scoped guard finalization does not force-stop arbitrary matching timer names, synthesize elapsed time, invoke mismatch repair, or hide errors silently.
+- `guard%stop(ierr)` is the supported way to observe finalizer-equivalent stop errors before scope exit.
+- Guard assignment/copy is unsupported and does not copy or transfer active ownership. Assignment involving an active guard warns to stderr and leaves active ownership with the original guard. Use one scalar guard variable per lexical block.
+- Guard arrays, saved/global guards, function-return guard constructors, and cross-procedure lifetime patterns are unsupported.
+- `ftimer_scope_id` is deferred; use explicit `lookup()` plus `start_id()`/`stop_id()` for cached-id hot paths.
+- The scoped guard is a safety layer for simple lexical blocks and early exits. Use explicit `start`/`stop` for non-lexical lifetimes, complex ownership, or timing that spans procedure boundaries.
 
 ## Reset Behavior
 
@@ -199,6 +216,7 @@ The silent worker-thread no-op model has specific, observable consequences that 
 - **Timing inside a parallel region captures only the master-thread timing window**: worker-thread work duration is not separately captured or aggregated into the timer's inclusive or self time.
 - **Supported pattern**: place `start`/`stop` calls outside the `!$omp parallel` block to time a parallel region as a whole. The master-thread timing window then spans the full wall-clock duration of the parallel work.
 - **Misleading pattern**: placing `start`/`stop` inside a parallel region with the expectation that each thread contributes timing data is not supported under this contract. Only the master thread's calls take effect; worker-thread contributions are silently absent.
+- **Scoped guard limitation**: block-local scoped guard finalization inside an OpenMP parallel region is unsupported. To time a parallel region, place explicit `start`/`stop` or a scoped guard outside the `!$omp parallel` block.
 
 ## Callback Contract
 
@@ -209,4 +227,6 @@ The silent worker-thread no-op model has specific, observable consequences that 
 - `on_event` is an optional lightweight intra-run hook for normal start/stop events on one timer instance
 - The current callback contract exposes numeric runtime identifiers only; it does not define a stable semantic mapping back to timer names or full context paths for external-profiler backends
 - Repair transitions do NOT fire callbacks
+- Scoped guards fire only the normal underlying start/stop events. They do not synthesize extra callback events during finalization.
+- Mutating timer state from callbacks during scoped guard start/stop is unsupported.
 - `user_data` remains opaque callback state, not a separate user-facing mutable runtime field

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -69,7 +69,8 @@ wait on asynchronous offload work, or insert MPI barriers around timer regions.
 - The public guard type is `ftimer_guard_t`, imported from `ftimer`
 - Scoped guards use the default procedural timer instance; there is no `type(ftimer_t)` scoped guard API on current `main`
 - `ftimer_scope` starts the named timer through the same validation, lookup, accounting, and callback path as normal name-based `start`
-- If `ftimer_scope` fails, the guard remains inactive. Finalization and `guard%stop(ierr)` are no-ops for inactive guards.
+- If `ftimer_scope` fails while initializing an inactive guard, the guard remains inactive. Finalization and `guard%stop(ierr)` are no-ops for inactive guards.
+- Calling `ftimer_scope` on an already-active guard returns `FTIMER_ERR_ACTIVE`, or warns when `ierr` is omitted, and leaves the existing active ownership unchanged.
 - A guard owns exactly one activation token from its successful start. `guard%stop(ierr)` may stop only that exact activation while it is still the top of the stack.
 - If the guard's activation has already been stopped, repaired away, or replaced by another activation with the same timer name, `guard%stop(ierr)` returns `FTIMER_ERR_MISMATCH` and leaves timer state unchanged.
 - The guard finalizer attempts the same exact-activation stop without `ierr`. On mismatch or lifecycle errors, it warns to stderr and does not repair.

--- a/src/ftimer.F90
+++ b/src/ftimer.F90
@@ -1,6 +1,6 @@
 module ftimer
    use, intrinsic :: iso_fortran_env, only: error_unit, int64
-   use ftimer_core, only: ftimer_start_scope_activation, ftimer_stop_scope_activation, ftimer_t
+   use ftimer_core, only: ftimer_internal_start_scope_activation, ftimer_internal_stop_scope_activation, ftimer_t
    use ftimer_types, only: FTIMER_ERR_ACTIVE, FTIMER_SUCCESS, ftimer_metadata_t, ftimer_mpi_summary_t, &
                            ftimer_summary_t
    implicit none
@@ -56,7 +56,7 @@ contains
       end if
 
       call clear_guard(guard)
-      call ftimer_start_scope_activation(ftimer_default_instance, name, id, activation_token, ierr=ierr)
+      call ftimer_internal_start_scope_activation(ftimer_default_instance, name, id, activation_token, ierr=ierr)
 
       if ((id <= 0) .or. (activation_token == 0_int64)) return
 
@@ -82,7 +82,7 @@ contains
          return
       end if
 
-      status = ftimer_stop_scope_activation(self%timer, self%timer_id, self%activation_token, ierr=ierr)
+      status = ftimer_internal_stop_scope_activation(self%timer, self%timer_id, self%activation_token, ierr=ierr)
       if (status == FTIMER_SUCCESS) call clear_guard(self)
    end subroutine ftimer_guard_stop
 

--- a/src/ftimer.F90
+++ b/src/ftimer.F90
@@ -1,13 +1,17 @@
 module ftimer
-   use ftimer_core, only: ftimer_t
-   use ftimer_types, only: ftimer_metadata_t, ftimer_mpi_summary_t, ftimer_summary_t
+   use, intrinsic :: iso_fortran_env, only: error_unit, int64
+   use ftimer_core, only: ftimer_start_scope_activation, ftimer_stop_scope_activation, ftimer_t
+   use ftimer_types, only: FTIMER_ERR_ACTIVE, FTIMER_SUCCESS, ftimer_metadata_t, ftimer_mpi_summary_t, &
+                           ftimer_summary_t
    implicit none
    private
 
+   public :: ftimer_guard_t
    public :: ftimer_init
    public :: ftimer_finalize
    public :: ftimer_start
    public :: ftimer_stop
+   public :: ftimer_scope
    public :: ftimer_start_id
    public :: ftimer_stop_id
    public :: ftimer_lookup
@@ -24,7 +28,101 @@ module ftimer
 
    type(ftimer_t), save, target :: ftimer_default_instance
 
+   type :: ftimer_guard_t
+      private
+      type(ftimer_t), pointer :: timer => null()
+      integer :: timer_id = 0
+      integer(int64) :: activation_token = 0_int64
+      logical :: active = .false.
+   contains
+      procedure, public :: stop => ftimer_guard_stop
+      final :: ftimer_guard_finalize
+      procedure, private :: assign => ftimer_guard_assign
+      generic, public :: assignment(=) => assign
+   end type ftimer_guard_t
+
 contains
+
+   subroutine ftimer_scope(guard, name, ierr)
+      type(ftimer_guard_t), intent(inout) :: guard
+      character(len=*), intent(in) :: name
+      integer, intent(out), optional :: ierr
+      integer :: id
+      integer(int64) :: activation_token
+
+      if (guard%active) then
+         call report_guard_status(ierr, FTIMER_ERR_ACTIVE, "ftimer_scope called with an active guard; state unchanged")
+         return
+      end if
+
+      call clear_guard(guard)
+      call ftimer_start_scope_activation(ftimer_default_instance, name, id, activation_token, ierr=ierr)
+
+      if ((id <= 0) .or. (activation_token == 0_int64)) return
+
+      guard%timer => ftimer_default_instance
+      guard%timer_id = id
+      guard%activation_token = activation_token
+      guard%active = .true.
+   end subroutine ftimer_scope
+
+   subroutine ftimer_guard_stop(self, ierr)
+      class(ftimer_guard_t), intent(inout) :: self
+      integer, intent(out), optional :: ierr
+      integer :: status
+
+      if (.not. self%active) then
+         if (present(ierr)) ierr = FTIMER_SUCCESS
+         return
+      end if
+
+      if (.not. associated(self%timer)) then
+         call clear_guard(self)
+         if (present(ierr)) ierr = FTIMER_SUCCESS
+         return
+      end if
+
+      status = ftimer_stop_scope_activation(self%timer, self%timer_id, self%activation_token, ierr=ierr)
+      if (status == FTIMER_SUCCESS) call clear_guard(self)
+   end subroutine ftimer_guard_stop
+
+   subroutine ftimer_guard_finalize(self)
+      type(ftimer_guard_t), intent(inout) :: self
+
+      call self%stop()
+   end subroutine ftimer_guard_finalize
+
+   subroutine ftimer_guard_assign(lhs, rhs)
+      class(ftimer_guard_t), intent(inout) :: lhs
+      type(ftimer_guard_t), intent(in) :: rhs
+
+      if (lhs%active .or. rhs%active) then
+         write (error_unit, '(a)') "ftimer guard assignment is unsupported; active ownership was not copied"
+      end if
+
+      if (.not. lhs%active) call clear_guard(lhs)
+   end subroutine ftimer_guard_assign
+
+   subroutine clear_guard(guard)
+      class(ftimer_guard_t), intent(inout) :: guard
+
+      nullify (guard%timer)
+      guard%timer_id = 0
+      guard%activation_token = 0_int64
+      guard%active = .false.
+   end subroutine clear_guard
+
+   subroutine report_guard_status(ierr, code, message)
+      integer, intent(out), optional :: ierr
+      integer, intent(in) :: code
+      character(len=*), intent(in) :: message
+
+      if (present(ierr)) then
+         ierr = code
+      else
+         write (error_unit, '(a)') trim(message)
+      end if
+   end subroutine report_guard_status
 
    subroutine ftimer_init(comm, mismatch_mode, ierr)
       integer, intent(in), optional :: comm

--- a/src/ftimer_core.F90
+++ b/src/ftimer_core.F90
@@ -11,8 +11,8 @@ module ftimer_core
    private
 
    public :: ftimer_t
-   public :: ftimer_start_scope_activation
-   public :: ftimer_stop_scope_activation
+   public :: ftimer_internal_start_scope_activation
+   public :: ftimer_internal_stop_scope_activation
 #ifdef FTIMER_BUILD_TESTS
    public :: ftimer_test_get_state
    public :: ftimer_test_state_t
@@ -157,7 +157,7 @@ module ftimer_core
 
 contains
 
-   subroutine ftimer_start_scope_activation(self, name, id, activation_token, ierr)
+   subroutine ftimer_internal_start_scope_activation(self, name, id, activation_token, ierr)
       class(ftimer_t), target, intent(inout) :: self
       character(len=*), intent(in) :: name
       integer, intent(out) :: id
@@ -169,19 +169,19 @@ contains
 !$omp master
       call start_scope_activation_impl(self, name, id, activation_token, ierr=ierr)
 !$omp end master
-   end subroutine ftimer_start_scope_activation
+   end subroutine ftimer_internal_start_scope_activation
 
-   integer function ftimer_stop_scope_activation(self, id, activation_token, ierr) result(status)
+   integer function ftimer_internal_stop_scope_activation(self, id, activation_token, ierr) result(status)
       class(ftimer_t), intent(inout) :: self
       integer, intent(in) :: id
       integer(int64), intent(in) :: activation_token
       integer, intent(out), optional :: ierr
 
-      status = FTIMER_SUCCESS
+      status = FTIMER_ERR_ACTIVE
 !$omp master
       status = stop_scope_activation_impl(self, id, activation_token, ierr=ierr)
 !$omp end master
-   end function ftimer_stop_scope_activation
+   end function ftimer_internal_stop_scope_activation
 
    subroutine init(self, comm, mismatch_mode, ierr)
       class(ftimer_t), intent(inout) :: self
@@ -632,7 +632,6 @@ contains
       if (allocated(self%call_stack%ids)) deallocate (self%call_stack%ids)
       if (allocated(self%call_stack%activation_tokens)) deallocate (self%call_stack%activation_tokens)
       self%call_stack%depth = 0
-      self%next_activation_token = 0_int64
       self%init_wtime = self%wtime()
       self%init_date = ftimer_date_string()
 

--- a/src/ftimer_core.F90
+++ b/src/ftimer_core.F90
@@ -818,7 +818,6 @@ contains
       if (allocated(self%call_stack%activation_tokens)) deallocate (self%call_stack%activation_tokens)
       self%call_stack%depth = 0
       self%num_segments = 0
-      self%next_activation_token = 0_int64
       self%init_wtime = 0.0_wp
       self%init_date = ''
       self%initialized = .false.

--- a/src/ftimer_core.F90
+++ b/src/ftimer_core.F90
@@ -11,6 +11,8 @@ module ftimer_core
    private
 
    public :: ftimer_t
+   public :: ftimer_start_scope_activation
+   public :: ftimer_stop_scope_activation
 #ifdef FTIMER_BUILD_TESTS
    public :: ftimer_test_get_state
    public :: ftimer_test_state_t
@@ -54,6 +56,7 @@ module ftimer_core
       integer, allocatable :: segment_name_slots(:)
       type(ftimer_context_index_t), allocatable :: segment_context_indices(:)
       integer :: num_segments = 0
+      integer(int64) :: next_activation_token = 0_int64
       real(wp) :: init_wtime = 0.0_wp
       character(len=40) :: init_date = ''
       logical :: initialized = .false.
@@ -153,6 +156,32 @@ module ftimer_core
    end interface
 
 contains
+
+   subroutine ftimer_start_scope_activation(self, name, id, activation_token, ierr)
+      class(ftimer_t), target, intent(inout) :: self
+      character(len=*), intent(in) :: name
+      integer, intent(out) :: id
+      integer(int64), intent(out) :: activation_token
+      integer, intent(out), optional :: ierr
+
+      id = 0
+      activation_token = 0_int64
+!$omp master
+      call start_scope_activation_impl(self, name, id, activation_token, ierr=ierr)
+!$omp end master
+   end subroutine ftimer_start_scope_activation
+
+   integer function ftimer_stop_scope_activation(self, id, activation_token, ierr) result(status)
+      class(ftimer_t), intent(inout) :: self
+      integer, intent(in) :: id
+      integer(int64), intent(in) :: activation_token
+      integer, intent(out), optional :: ierr
+
+      status = FTIMER_SUCCESS
+!$omp master
+      status = stop_scope_activation_impl(self, id, activation_token, ierr=ierr)
+!$omp end master
+   end function ftimer_stop_scope_activation
 
    subroutine init(self, comm, mismatch_mode, ierr)
       class(ftimer_t), intent(inout) :: self
@@ -352,14 +381,17 @@ contains
 !$omp end master
    end subroutine start
 
-   subroutine start_impl(self, name, ierr)
+   subroutine start_impl(self, name, ierr, activation_token)
       class(ftimer_t), intent(inout) :: self
       character(len=*), intent(in) :: name
       integer, intent(out), optional :: ierr
+      integer(int64), intent(out), optional :: activation_token
       integer :: id
       integer :: status
       integer :: trimmed_len
       character(len=:), allocatable :: message
+
+      if (present(activation_token)) activation_token = 0_int64
 
       if (.not. self%initialized) then
          call report_status(ierr, FTIMER_ERR_NOT_INIT, "ftimer start before init")
@@ -373,7 +405,7 @@ contains
       end if
 
       id = self%find_or_create_segment(name(1:trimmed_len))
-      call start_id_impl(self, id, ierr=ierr)
+      call start_id_impl(self, id, ierr=ierr, activation_token=activation_token)
    end subroutine start_impl
 
    subroutine stop(self, name, ierr)
@@ -426,12 +458,16 @@ contains
 !$omp end master
    end subroutine start_id
 
-   subroutine start_id_impl(self, id, ierr)
+   subroutine start_id_impl(self, id, ierr, activation_token)
       class(ftimer_t), intent(inout) :: self
       integer, intent(in) :: id
       integer, intent(out), optional :: ierr
+      integer(int64), intent(out), optional :: activation_token
       integer :: ctx
+      integer(int64) :: token
       real(wp) :: now
+
+      if (present(activation_token)) activation_token = 0_int64
 
       if (.not. self%initialized) then
          call report_status(ierr, FTIMER_ERR_NOT_INIT, "ftimer start_id before init")
@@ -446,7 +482,8 @@ contains
       ctx = find_or_create_segment_context(self, id, self%call_stack)
       call ensure_context_storage(self%segments(id), ctx)
 
-      call self%call_stack%push(id)
+      token = create_activation_token(self)
+      call self%call_stack%push(id, token)
       now = self%wtime()
       if (needs_init_wtime_rebase(self)) self%init_wtime = now
       self%segments(id)%start_time(ctx) = now
@@ -457,6 +494,7 @@ contains
          call self%on_event(id, ctx, FTIMER_EVENT_START, now, self%user_data)
       end if
 
+      if (present(activation_token)) activation_token = token
       if (present(ierr)) ierr = FTIMER_SUCCESS
    end subroutine start_id_impl
 
@@ -592,7 +630,9 @@ contains
          if (allocated(self%segments(i)%call_count)) self%segments(i)%call_count = 0
       end do
       if (allocated(self%call_stack%ids)) deallocate (self%call_stack%ids)
+      if (allocated(self%call_stack%activation_tokens)) deallocate (self%call_stack%activation_tokens)
       self%call_stack%depth = 0
+      self%next_activation_token = 0_int64
       self%init_wtime = self%wtime()
       self%init_date = ftimer_date_string()
 
@@ -607,6 +647,7 @@ contains
       integer :: restart_ctx
       integer :: unwind_count
       integer :: i
+      integer(int64) :: restart_token
       real(wp) :: now
 
       if (.not. stack_contains(self%call_stack, idx)) return
@@ -629,11 +670,78 @@ contains
       do i = unwind_count, 1, -1
          restart_ctx = find_or_create_segment_context(self, unwound_ids(i), self%call_stack)
          call ensure_context_storage(self%segments(unwound_ids(i)), restart_ctx)
-         call self%call_stack%push(unwound_ids(i))
+         restart_token = create_activation_token(self)
+         call self%call_stack%push(unwound_ids(i), restart_token)
          self%segments(unwound_ids(i))%start_time(restart_ctx) = now
          self%segments(unwound_ids(i))%is_running(restart_ctx) = .true.
       end do
    end subroutine repair_mismatch
+
+   subroutine start_scope_activation_impl(self, name, id, activation_token, ierr)
+      class(ftimer_t), intent(inout) :: self
+      character(len=*), intent(in) :: name
+      integer, intent(out) :: id
+      integer(int64), intent(out) :: activation_token
+      integer, intent(out), optional :: ierr
+
+      id = 0
+      activation_token = 0_int64
+
+      call start_impl(self, name, ierr=ierr, activation_token=activation_token)
+      if (activation_token == 0_int64) return
+
+      if (self%call_stack%depth > 0) then
+         id = self%call_stack%top()
+      end if
+   end subroutine start_scope_activation_impl
+
+   integer function stop_scope_activation_impl(self, id, activation_token, ierr) result(status)
+      class(ftimer_t), intent(inout) :: self
+      integer, intent(in) :: id
+      integer(int64), intent(in) :: activation_token
+      integer, intent(out), optional :: ierr
+      character(len=:), allocatable :: message
+      integer :: top_id
+
+      if (.not. self%initialized) then
+         status = FTIMER_ERR_NOT_INIT
+         call report_status(ierr, status, "ftimer scoped guard stop before init")
+         return
+      end if
+
+      if ((id < 1) .or. (id > self%num_segments)) then
+         status = FTIMER_ERR_UNKNOWN
+         call report_status(ierr, status, "ftimer scoped guard stop with unknown timer id")
+         return
+      end if
+
+      if (self%call_stack%depth <= 0) then
+         status = FTIMER_ERR_MISMATCH
+         call report_status(ierr, status, "ftimer scoped guard stop mismatch on empty call stack")
+         return
+      end if
+
+      top_id = self%call_stack%top()
+      if (top_id /= id) then
+         message = "ftimer scoped guard stop mismatch: owned "//trim(self%segments(id)%name)// &
+                   " but top of stack is "//trim(self%segments(top_id)%name)
+         status = FTIMER_ERR_MISMATCH
+         call report_status(ierr, status, trim(message))
+         return
+      end if
+
+      if (self%call_stack%top_token() /= activation_token) then
+         message = "ftimer scoped guard stop mismatch: activation no longer matches timer "// &
+                   trim(self%segments(id)%name)
+         status = FTIMER_ERR_MISMATCH
+         call report_status(ierr, status, trim(message))
+         return
+      end if
+
+      call stop_segment_with_now(self, id, self%wtime(), fire_callback=.true.)
+      status = FTIMER_SUCCESS
+      if (present(ierr)) ierr = FTIMER_SUCCESS
+   end function stop_scope_activation_impl
 
    real(wp) function wtime(self) result(now)
       class(ftimer_t), intent(in) :: self
@@ -644,6 +752,17 @@ contains
          now = ftimer_default_clock()
       end if
    end function wtime
+
+   integer(int64) function create_activation_token(self) result(activation_token)
+      class(ftimer_t), intent(inout) :: self
+
+      if (self%next_activation_token >= huge(self%next_activation_token)) then
+         self%next_activation_token = 0_int64
+      end if
+
+      self%next_activation_token = self%next_activation_token + 1_int64
+      activation_token = self%next_activation_token
+   end function create_activation_token
 
    integer function find_or_create_segment(self, name) result(idx)
       class(ftimer_t), intent(inout) :: self
@@ -697,8 +816,10 @@ contains
       if (allocated(self%segment_name_slots)) deallocate (self%segment_name_slots)
       if (allocated(self%segment_context_indices)) deallocate (self%segment_context_indices)
       if (allocated(self%call_stack%ids)) deallocate (self%call_stack%ids)
+      if (allocated(self%call_stack%activation_tokens)) deallocate (self%call_stack%activation_tokens)
       self%call_stack%depth = 0
       self%num_segments = 0
+      self%next_activation_token = 0_int64
       self%init_wtime = 0.0_wp
       self%init_date = ''
       self%initialized = .false.

--- a/src/ftimer_types.F90
+++ b/src/ftimer_types.F90
@@ -1,5 +1,6 @@
 module ftimer_types
    use, intrinsic :: iso_c_binding, only: c_ptr
+   use, intrinsic :: iso_fortran_env, only: int64
    implicit none
    private
 
@@ -122,10 +123,12 @@ module ftimer_types
    type :: ftimer_call_stack_t
       integer :: depth = 0
       integer, allocatable :: ids(:)
+      integer(int64), allocatable :: activation_tokens(:)
    contains
       procedure :: push => ftimer_call_stack_push
       procedure :: pop => ftimer_call_stack_pop
       procedure :: top => ftimer_call_stack_top
+      procedure :: top_token => ftimer_call_stack_top_token
       procedure :: equals => ftimer_call_stack_equals
       procedure :: copy => ftimer_call_stack_copy
    end type ftimer_call_stack_t
@@ -167,37 +170,51 @@ module ftimer_types
 
 contains
 
-   subroutine ftimer_call_stack_push(self, id)
+   subroutine ftimer_call_stack_push(self, id, activation_token)
       class(ftimer_call_stack_t), intent(inout) :: self
       integer, intent(in) :: id
+      integer(int64), intent(in), optional :: activation_token
       integer, allocatable :: new_ids(:)
+      integer(int64), allocatable :: new_tokens(:)
       integer :: new_capacity
 
       if (.not. allocated(self%ids)) then
          allocate (self%ids(FTIMER_CALL_STACK_INITIAL_CAPACITY))
+         allocate (self%activation_tokens(FTIMER_CALL_STACK_INITIAL_CAPACITY))
       else if (self%depth >= size(self%ids)) then
          new_capacity = max(FTIMER_CALL_STACK_INITIAL_CAPACITY, 2*size(self%ids))
          allocate (new_ids(new_capacity))
+         allocate (new_tokens(new_capacity))
          if (self%depth > 0) then
             new_ids(1:self%depth) = self%ids(1:self%depth)
+            new_tokens(1:self%depth) = self%activation_tokens(1:self%depth)
          end if
          call move_alloc(new_ids, self%ids)
+         call move_alloc(new_tokens, self%activation_tokens)
       end if
 
       self%depth = self%depth + 1
       self%ids(self%depth) = id
+      if (present(activation_token)) then
+         self%activation_tokens(self%depth) = activation_token
+      else
+         self%activation_tokens(self%depth) = 0_int64
+      end if
    end subroutine ftimer_call_stack_push
 
-   integer function ftimer_call_stack_pop(self) result(id)
+   integer function ftimer_call_stack_pop(self, activation_token) result(id)
       class(ftimer_call_stack_t), intent(inout) :: self
+      integer(int64), intent(out), optional :: activation_token
 
       id = 0
+      if (present(activation_token)) activation_token = 0_int64
       if (self%depth <= 0) then
          self%depth = 0
          return
       end if
 
       id = self%ids(self%depth)
+      if (present(activation_token)) activation_token = self%activation_tokens(self%depth)
       self%depth = self%depth - 1
    end function ftimer_call_stack_pop
 
@@ -208,6 +225,14 @@ contains
       if (self%depth <= 0) return
       id = self%ids(self%depth)
    end function ftimer_call_stack_top
+
+   integer(int64) function ftimer_call_stack_top_token(self) result(activation_token)
+      class(ftimer_call_stack_t), intent(in) :: self
+
+      activation_token = 0_int64
+      if (self%depth <= 0) return
+      activation_token = self%activation_tokens(self%depth)
+   end function ftimer_call_stack_top_token
 
    logical function ftimer_call_stack_equals(self, other) result(is_equal)
       class(ftimer_call_stack_t), intent(in) :: self
@@ -229,12 +254,16 @@ contains
 
       self%depth = other%depth
       if (allocated(self%ids)) deallocate (self%ids)
+      if (allocated(self%activation_tokens)) deallocate (self%activation_tokens)
 
       if (other%depth > 0) then
          allocate (self%ids(other%depth))
+         allocate (self%activation_tokens(other%depth))
          self%ids = other%ids(1:other%depth)
+         self%activation_tokens = other%activation_tokens(1:other%depth)
       else if (allocated(other%ids)) then
          allocate (self%ids(0))
+         allocate (self%activation_tokens(0))
       end if
    end subroutine ftimer_call_stack_copy
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,6 +91,7 @@ if(FTIMER_BUILD_TESTS)
     test_file_output.pf
     test_callbacks.pf
     test_procedural_api.pf
+    test_scoped_guard.pf
   )
 
   if(FTIMER_USE_OPENMP)

--- a/tests/install-consumer/main.F90
+++ b/tests/install-consumer/main.F90
@@ -1,5 +1,5 @@
 program ftimer_installed_consumer
-   use ftimer, only: ftimer_finalize, ftimer_get_summary, ftimer_init, ftimer_start, ftimer_stop
+   use ftimer, only: ftimer_finalize, ftimer_get_summary, ftimer_guard_t, ftimer_init, ftimer_scope
    use ftimer_types, only: ftimer_summary_t, wp
    implicit none
    character(len=*), parameter :: consumer_name = &
@@ -12,28 +12,29 @@ program ftimer_installed_consumer
    call ftimer_init(ierr=ierr)
    if (ierr /= 0) error stop 1
 
-   call ftimer_start(consumer_name, ierr=ierr)
-   if (ierr /= 0) error stop 2
+   scoped_consumer_work: block
+      type(ftimer_guard_t) :: guard
 
-   accumulator = 0.0
-   do i = 1, 200000
-      accumulator = accumulator + real(i)
-   end do
+      call ftimer_scope(guard, consumer_name, ierr=ierr)
+      if (ierr /= 0) error stop 2
 
-   call ftimer_stop(consumer_name, ierr=ierr)
-   if (ierr /= 0) error stop 3
+      accumulator = 0.0
+      do i = 1, 200000
+         accumulator = accumulator + real(i)
+      end do
+   end block scoped_consumer_work
 
    call ftimer_get_summary(summary, ierr=ierr)
-   if (ierr /= 0) error stop 4
-   if (summary%num_entries /= 1) error stop 5
-   if (trim(summary%entries(1)%name) /= consumer_name) error stop 6
-   if (summary%entries(1)%node_id <= 0) error stop 7
-   if (summary%entries(1)%parent_id /= 0) error stop 8
-   if (summary%entries(1)%call_count /= 1) error stop 9
-   if (summary%entries(1)%inclusive_time < 0.0_wp) error stop 10
+   if (ierr /= 0) error stop 3
+   if (summary%num_entries /= 1) error stop 4
+   if (trim(summary%entries(1)%name) /= consumer_name) error stop 5
+   if (summary%entries(1)%node_id <= 0) error stop 6
+   if (summary%entries(1)%parent_id /= 0) error stop 7
+   if (summary%entries(1)%call_count /= 1) error stop 8
+   if (summary%entries(1)%inclusive_time < 0.0_wp) error stop 9
 
    call ftimer_finalize(ierr=ierr)
-   if (ierr /= 0) error stop 11
+   if (ierr /= 0) error stop 10
 
    if (accumulator < 0.0) print *, accumulator
 end program ftimer_installed_consumer

--- a/tests/test_openmp_guards.pf
+++ b/tests/test_openmp_guards.pf
@@ -181,6 +181,57 @@ contains
    end subroutine test_non_master_scope_is_noop
 
    @test
+   subroutine test_non_master_stop_does_not_clear_active_scope_guard()
+      type(ftimer_guard_t) :: guard
+      type(ftimer_test_state_t) :: state
+      integer :: ierr
+      integer :: local_ierr
+      integer :: thread_num
+      integer :: worker_stop_ierr
+      logical :: thread_seen(2)
+
+      call omp_set_dynamic(.false.)
+
+      worker_stop_ierr = -1
+      thread_seen = .false.
+
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+      call ftimer_scope(guard, "shared_scope", ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+!$omp parallel num_threads(2) default(shared) private(local_ierr, thread_num)
+      thread_num = omp_get_thread_num()
+      if (thread_num + 1 <= size(thread_seen)) thread_seen(thread_num + 1) = .true.
+
+      if (thread_num /= 0) then
+         local_ierr = NOOP_IERR_SENTINEL
+         call guard%stop(ierr=local_ierr)
+         worker_stop_ierr = local_ierr
+      end if
+!$omp end parallel
+
+      call snapshot_timer(ftimer_default_instance, state)
+
+      @assertTrue(thread_seen(1))
+      @assertTrue(thread_seen(2))
+      @assertEqual(NOOP_IERR_SENTINEL, worker_stop_ierr)
+      @assertEqual(1, state%num_segments)
+      @assertEqual(1, state%call_stack%depth)
+      @assertEqual(1, state%call_stack%top())
+
+      fake_time = 3.0_wp
+      call guard%stop(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call snapshot_timer(ftimer_default_instance, state)
+      @assertEqual(0, state%call_stack%depth)
+
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_non_master_stop_does_not_clear_active_scope_guard
+
+   @test
    subroutine test_non_master_config_calls_are_noops()
       type(ftimer_t) :: timer
       type(ftimer_test_state_t) :: state

--- a/tests/test_openmp_guards.pf
+++ b/tests/test_openmp_guards.pf
@@ -3,7 +3,8 @@ module test_openmp_guards
    use omp_lib, only: omp_get_thread_num, omp_set_dynamic
    use pfunit
    use ftimer, only: ftimer_default_instance, ftimer_finalize, ftimer_get_summary, ftimer_init, &
-                     ftimer_lookup, ftimer_start, ftimer_start_id, ftimer_stop, ftimer_stop_id
+                     ftimer_guard_t, ftimer_lookup, ftimer_scope, ftimer_start, ftimer_start_id, ftimer_stop, &
+                     ftimer_stop_id
    use ftimer_core, only: ftimer_t, ftimer_test_state_t
    use ftimer_types, only: FTIMER_ERR_INVALID_NAME, FTIMER_SUCCESS, ftimer_summary_t, wp
    use test_support, only: attach_mock_clock, fake_time, scaled_mock_clock, snapshot_timer, &
@@ -46,6 +47,37 @@ contains
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
    end subroutine test_serial_start_stop_unchanged_when_openmp_enabled
+
+   @test
+   subroutine test_serial_scoped_guard_unchanged_when_openmp_enabled()
+      type(ftimer_summary_t) :: summary
+      integer :: ierr
+      logical :: names_match
+
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+      serial_scope: block
+         type(ftimer_guard_t) :: guard
+
+         call ftimer_scope(guard, "serial_scope", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = 2.0_wp
+      end block serial_scope
+
+      call ftimer_get_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      @assertEqual(1, summary%num_entries)
+      names_match = trim(summary%entries(1)%name) == 'serial_scope'
+      @assertTrue(names_match)
+      @assertEqual(2.0_wp, summary%entries(1)%inclusive_time)
+      @assertEqual(1, summary%entries(1)%call_count)
+
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_serial_scoped_guard_unchanged_when_openmp_enabled
 
    @test
    subroutine test_non_master_start_stop_are_noops()
@@ -95,6 +127,58 @@ contains
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
    end subroutine test_non_master_start_stop_are_noops
+
+   @test
+   subroutine test_non_master_scope_is_noop()
+      type(ftimer_test_state_t) :: state
+      integer :: ierr
+      integer :: local_ierr
+      integer :: thread_num
+      integer :: worker_scope_ierr
+      integer :: worker_stop_ierr
+      logical :: thread_seen(2)
+
+      call omp_set_dynamic(.false.)
+
+      worker_scope_ierr = -1
+      worker_stop_ierr = -1
+      thread_seen = .false.
+
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+!$omp parallel num_threads(2) default(shared) private(local_ierr, thread_num)
+      thread_num = omp_get_thread_num()
+      if (thread_num + 1 <= size(thread_seen)) thread_seen(thread_num + 1) = .true.
+
+      if (thread_num /= 0) then
+         worker_scope: block
+            type(ftimer_guard_t) :: guard
+
+            local_ierr = NOOP_IERR_SENTINEL
+            call ftimer_scope(guard, "worker_scope", ierr=local_ierr)
+            worker_scope_ierr = local_ierr
+
+            local_ierr = NOOP_IERR_SENTINEL
+            call guard%stop(ierr=local_ierr)
+            worker_stop_ierr = local_ierr
+         end block worker_scope
+      end if
+!$omp end parallel
+
+      call snapshot_timer(ftimer_default_instance, state)
+
+      @assertTrue(thread_seen(1))
+      @assertTrue(thread_seen(2))
+      @assertEqual(NOOP_IERR_SENTINEL, worker_scope_ierr)
+      @assertEqual(FTIMER_SUCCESS, worker_stop_ierr)
+      @assertEqual(0, state%num_segments)
+      @assertEqual(0, state%call_stack%depth)
+
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_non_master_scope_is_noop
 
    @test
    subroutine test_non_master_config_calls_are_noops()

--- a/tests/test_scoped_guard.pf
+++ b/tests/test_scoped_guard.pf
@@ -1,0 +1,319 @@
+module test_scoped_guard
+   use, intrinsic :: iso_c_binding, only: c_ptr
+   use pfunit
+   use ftimer, only: ftimer_default_instance, ftimer_finalize, ftimer_get_summary, ftimer_guard_t, ftimer_init, &
+                     ftimer_scope, ftimer_start, ftimer_stop
+   use ftimer_core, only: ftimer_test_state_t
+   use ftimer_types, only: FTIMER_ERR_INVALID_NAME, FTIMER_ERR_MISMATCH, FTIMER_EVENT_START, FTIMER_EVENT_STOP, &
+                           FTIMER_SUCCESS, ftimer_call_stack_t, ftimer_summary_t, wp
+   use test_support, only: attach_mock_clock, begin_stderr_capture, end_stderr_capture, fake_time, &
+                           find_context_idx, snapshot_timer
+   implicit none
+
+   integer, parameter :: max_scope_events = 8
+   integer, save :: scope_callback_count = 0
+   integer, save :: scope_callback_timer_ids(max_scope_events) = 0
+   integer, save :: scope_callback_contexts(max_scope_events) = 0
+   integer, save :: scope_callback_events(max_scope_events) = 0
+   real(wp), save :: scope_callback_timestamps(max_scope_events) = 0.0_wp
+
+contains
+
+   @test
+   subroutine test_scope_explicit_stop_records_time()
+      type(ftimer_guard_t) :: guard
+      type(ftimer_summary_t) :: summary
+      integer :: ierr
+      logical :: names_match
+
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+      call ftimer_scope(guard, "scoped", ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      fake_time = 2.5_wp
+      call guard%stop(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call ftimer_get_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      names_match = trim(summary%entries(1)%name) == 'scoped'
+      @assertTrue(names_match)
+      @assertEqual(1, summary%num_entries)
+      @assertEqual(2.5_wp, summary%entries(1)%inclusive_time)
+      @assertEqual(1, summary%entries(1)%call_count)
+      @assertFalse(summary%entries(1)%is_active)
+
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_scope_explicit_stop_records_time
+
+   @test
+   subroutine test_scope_finalizer_balances_block_timer()
+      type(ftimer_summary_t) :: summary
+      integer :: ierr
+
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+      lexical_scope: block
+         type(ftimer_guard_t) :: guard
+
+         call ftimer_scope(guard, "lexical", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = 3.0_wp
+      end block lexical_scope
+
+      call ftimer_get_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      @assertEqual(1, summary%num_entries)
+      @assertEqual(3.0_wp, summary%entries(1)%inclusive_time)
+      @assertFalse(summary%has_active_timers)
+
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_scope_finalizer_balances_block_timer
+
+   @test
+   subroutine test_scope_finalizer_balances_early_exit_block()
+      type(ftimer_summary_t) :: summary
+      integer :: ierr
+
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+      early_scope: block
+         type(ftimer_guard_t) :: guard
+
+         call ftimer_scope(guard, "early", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = 4.0_wp
+         exit early_scope
+      end block early_scope
+
+      call ftimer_get_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      @assertEqual(1, summary%num_entries)
+      @assertEqual(4.0_wp, summary%entries(1)%inclusive_time)
+      @assertFalse(summary%has_active_timers)
+
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_scope_finalizer_balances_early_exit_block
+
+   @test
+   subroutine test_failed_scope_start_leaves_guard_inactive()
+      type(ftimer_summary_t) :: summary
+      character(len=:), allocatable :: stderr_text
+      integer :: capture_ierr
+      integer :: ierr
+      integer :: saved_fd
+      logical :: is_silent
+
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+      call begin_stderr_capture('test_failed_scope_start_leaves_guard_inactive.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      invalid_scope: block
+         type(ftimer_guard_t) :: guard
+
+         call ftimer_scope(guard, " ", ierr=ierr)
+         @assertEqual(FTIMER_ERR_INVALID_NAME, ierr)
+         fake_time = 1.0_wp
+         call guard%stop(ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+      end block invalid_scope
+
+      call end_stderr_capture('test_failed_scope_start_leaves_guard_inactive.err', saved_fd, stderr_text, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      call ftimer_get_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      is_silent = len_trim(stderr_text) == 0
+      @assertTrue(is_silent)
+      @assertEqual(0, summary%num_entries)
+      @assertFalse(summary%has_active_timers)
+
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_failed_scope_start_leaves_guard_inactive
+
+   @test
+   subroutine test_scope_assignment_does_not_copy_active_ownership()
+      type(ftimer_summary_t) :: summary
+      character(len=:), allocatable :: stderr_text
+      integer :: capture_ierr
+      integer :: ierr
+      integer :: saved_fd
+      logical :: has_warning
+
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+      call begin_stderr_capture('test_scope_assignment_does_not_copy_active_ownership.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      assignment_scope: block
+         type(ftimer_guard_t) :: owner
+         type(ftimer_guard_t) :: copy
+
+         call ftimer_scope(owner, "assigned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         copy = owner
+         fake_time = 6.0_wp
+      end block assignment_scope
+
+      call end_stderr_capture('test_scope_assignment_does_not_copy_active_ownership.err', saved_fd, stderr_text, &
+                              capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      call ftimer_get_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      has_warning = index(stderr_text, 'ftimer guard assignment is unsupported') > 0
+      @assertTrue(has_warning)
+      @assertEqual(1, summary%num_entries)
+      @assertEqual(6.0_wp, summary%entries(1)%inclusive_time)
+      @assertFalse(summary%has_active_timers)
+
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_scope_assignment_does_not_copy_active_ownership
+
+   @test
+   subroutine test_scope_stop_rejects_stale_same_name_activation()
+      type(ftimer_test_state_t) :: state
+      character(len=:), allocatable :: stderr_text
+      integer :: capture_ierr
+      type(ftimer_call_stack_t) :: root_stack
+      integer :: ctx
+      integer :: ierr
+      integer :: saved_fd
+      logical :: has_warning
+
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+      call begin_stderr_capture('test_scope_stop_rejects_stale_same_name_activation.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      stale_scope: block
+         type(ftimer_guard_t) :: guard
+
+         call ftimer_scope(guard, "owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = 1.0_wp
+         call ftimer_stop("owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         call ftimer_start("owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+
+         fake_time = 2.0_wp
+         call guard%stop(ierr=ierr)
+         @assertEqual(FTIMER_ERR_MISMATCH, ierr)
+
+         call snapshot_timer(ftimer_default_instance, state)
+         ctx = find_context_idx(state, 1, root_stack)
+         @assertEqual(1, state%call_stack%depth)
+         @assertEqual(1, state%call_stack%top())
+         @assertTrue(state%segments(1)%is_running(ctx))
+         @assertEqual(1.0_wp, state%segments(1)%time(ctx))
+         @assertEqual(2, state%segments(1)%call_count(ctx))
+
+         call ftimer_stop("owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+      end block stale_scope
+
+      call end_stderr_capture('test_scope_stop_rejects_stale_same_name_activation.err', saved_fd, stderr_text, &
+                              capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      has_warning = index(stderr_text, 'ftimer scoped guard stop mismatch') > 0
+      @assertTrue(has_warning)
+
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_scope_stop_rejects_stale_same_name_activation
+
+   @test
+   subroutine test_scope_callbacks_match_normal_start_stop_events()
+      type(ftimer_guard_t) :: explicit_guard
+      integer :: ierr
+
+      call reset_scope_callback_log()
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+      call ftimer_default_instance%set_callback(record_scope_callback, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call ftimer_scope(explicit_guard, "explicit", ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      fake_time = 2.0_wp
+      call explicit_guard%stop(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      finalized_scope: block
+         type(ftimer_guard_t) :: final_guard
+
+         call ftimer_scope(final_guard, "finalized", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = 5.0_wp
+      end block finalized_scope
+
+      @assertEqual(4, scope_callback_count)
+      @assertEqual(FTIMER_EVENT_START, scope_callback_events(1))
+      @assertEqual(FTIMER_EVENT_STOP, scope_callback_events(2))
+      @assertEqual(FTIMER_EVENT_START, scope_callback_events(3))
+      @assertEqual(FTIMER_EVENT_STOP, scope_callback_events(4))
+      @assertEqual(1, scope_callback_timer_ids(1))
+      @assertEqual(1, scope_callback_timer_ids(2))
+      @assertEqual(2, scope_callback_timer_ids(3))
+      @assertEqual(2, scope_callback_timer_ids(4))
+      @assertEqual(1, scope_callback_contexts(1))
+      @assertEqual(1, scope_callback_contexts(2))
+      @assertEqual(1, scope_callback_contexts(3))
+      @assertEqual(1, scope_callback_contexts(4))
+      @assertEqual(0.0_wp, scope_callback_timestamps(1))
+      @assertEqual(2.0_wp, scope_callback_timestamps(2))
+      @assertEqual(2.0_wp, scope_callback_timestamps(3))
+      @assertEqual(5.0_wp, scope_callback_timestamps(4))
+
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_scope_callbacks_match_normal_start_stop_events
+
+   subroutine record_scope_callback(timer_id, context_idx, event, timestamp, user_data)
+      integer, intent(in) :: timer_id
+      integer, intent(in) :: context_idx
+      integer, intent(in) :: event
+      real(wp), intent(in) :: timestamp
+      type(c_ptr), intent(in) :: user_data
+      integer :: slot
+
+      if (scope_callback_count >= max_scope_events) error stop 1
+
+      slot = scope_callback_count + 1
+      scope_callback_count = slot
+      scope_callback_timer_ids(slot) = timer_id
+      scope_callback_contexts(slot) = context_idx
+      scope_callback_events(slot) = event
+      scope_callback_timestamps(slot) = timestamp
+   end subroutine record_scope_callback
+
+   subroutine reset_scope_callback_log()
+      scope_callback_count = 0
+      scope_callback_timer_ids = 0
+      scope_callback_contexts = 0
+      scope_callback_events = 0
+      scope_callback_timestamps = 0.0_wp
+   end subroutine reset_scope_callback_log
+
+end module test_scoped_guard

--- a/tests/test_scoped_guard.pf
+++ b/tests/test_scoped_guard.pf
@@ -2,7 +2,7 @@ module test_scoped_guard
    use, intrinsic :: iso_c_binding, only: c_ptr
    use pfunit
    use ftimer, only: ftimer_default_instance, ftimer_finalize, ftimer_get_summary, ftimer_guard_t, ftimer_init, &
-                     ftimer_scope, ftimer_start, ftimer_stop
+                     ftimer_reset, ftimer_scope, ftimer_start, ftimer_stop
    use ftimer_core, only: ftimer_test_state_t
    use ftimer_types, only: FTIMER_ERR_INVALID_NAME, FTIMER_ERR_MISMATCH, FTIMER_EVENT_START, FTIMER_EVENT_STOP, &
                            FTIMER_SUCCESS, ftimer_call_stack_t, ftimer_summary_t, wp
@@ -146,9 +146,11 @@ contains
 
    @test
    subroutine test_scope_assignment_does_not_copy_active_ownership()
-      type(ftimer_summary_t) :: summary
       character(len=:), allocatable :: stderr_text
       integer :: capture_ierr
+      type(ftimer_test_state_t) :: state
+      type(ftimer_call_stack_t) :: root_stack
+      integer :: ctx
       integer :: ierr
       integer :: saved_fd
       logical :: has_warning
@@ -167,24 +169,141 @@ contains
          call ftimer_scope(owner, "assigned", ierr=ierr)
          @assertEqual(FTIMER_SUCCESS, ierr)
          copy = owner
+         fake_time = 2.0_wp
+         call copy%stop(ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+
+         call snapshot_timer(ftimer_default_instance, state)
+         ctx = find_context_idx(state, 1, root_stack)
+         @assertEqual(1, state%call_stack%depth)
+         @assertTrue(state%segments(1)%is_running(ctx))
+
          fake_time = 6.0_wp
+         call owner%stop(ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
       end block assignment_scope
 
       call end_stderr_capture('test_scope_assignment_does_not_copy_active_ownership.err', saved_fd, stderr_text, &
                               capture_ierr)
       @assertEqual(0, capture_ierr)
 
-      call ftimer_get_summary(summary, ierr=ierr)
-      @assertEqual(FTIMER_SUCCESS, ierr)
+      call snapshot_timer(ftimer_default_instance, state)
+      ctx = find_context_idx(state, 1, root_stack)
       has_warning = index(stderr_text, 'ftimer guard assignment is unsupported') > 0
       @assertTrue(has_warning)
-      @assertEqual(1, summary%num_entries)
-      @assertEqual(6.0_wp, summary%entries(1)%inclusive_time)
-      @assertFalse(summary%has_active_timers)
+      @assertEqual(0, state%call_stack%depth)
+      @assertEqual(6.0_wp, state%segments(1)%time(ctx))
 
       call ftimer_finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
    end subroutine test_scope_assignment_does_not_copy_active_ownership
+
+   @test
+   subroutine test_scope_rejects_stale_activation_after_reset()
+      type(ftimer_test_state_t) :: state
+      character(len=:), allocatable :: stderr_text
+      integer :: capture_ierr
+      type(ftimer_call_stack_t) :: root_stack
+      integer :: ctx
+      integer :: ierr
+      integer :: saved_fd
+      logical :: has_warning
+
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+      call begin_stderr_capture('test_scope_rejects_stale_activation_after_reset.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      stale_after_reset: block
+         type(ftimer_guard_t) :: guard
+
+         call ftimer_scope(guard, "reset_owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = 1.0_wp
+         call ftimer_stop("reset_owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+
+         call ftimer_reset(ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+
+         call ftimer_start("reset_owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = 2.0_wp
+
+         call guard%stop(ierr=ierr)
+         @assertEqual(FTIMER_ERR_MISMATCH, ierr)
+
+         call snapshot_timer(ftimer_default_instance, state)
+         ctx = find_context_idx(state, 1, root_stack)
+         @assertEqual(1, state%call_stack%depth)
+         @assertEqual(1, state%call_stack%top())
+         @assertTrue(state%segments(1)%is_running(ctx))
+         @assertEqual(0.0_wp, state%segments(1)%time(ctx))
+
+         call ftimer_stop("reset_owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+      end block stale_after_reset
+
+      call end_stderr_capture('test_scope_rejects_stale_activation_after_reset.err', saved_fd, stderr_text, &
+                              capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      has_warning = index(stderr_text, 'ftimer scoped guard stop mismatch') > 0
+      @assertTrue(has_warning)
+
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_scope_rejects_stale_activation_after_reset
+
+   @test
+   subroutine test_scope_rejects_owned_activation_below_child()
+      type(ftimer_test_state_t) :: state
+      integer :: ierr
+      integer, parameter :: expected_timer_ids(4) = [1, 2, 2, 1]
+      integer, parameter :: expected_events(4) = [FTIMER_EVENT_START, FTIMER_EVENT_START, &
+                                                  FTIMER_EVENT_STOP, FTIMER_EVENT_STOP]
+      real(wp), parameter :: expected_timestamps(4) = [0.0_wp, 1.0_wp, 3.0_wp, 4.0_wp]
+
+      call reset_scope_callback_log()
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+      call ftimer_default_instance%set_callback(record_scope_callback, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      below_child: block
+         type(ftimer_guard_t) :: outer
+
+         call ftimer_scope(outer, "outer", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = 1.0_wp
+         call ftimer_start("child", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+
+         fake_time = 2.0_wp
+         call outer%stop(ierr=ierr)
+         @assertEqual(FTIMER_ERR_MISMATCH, ierr)
+
+         call snapshot_timer(ftimer_default_instance, state)
+         @assertEqual(2, state%call_stack%depth)
+         @assertEqual(2, state%call_stack%top())
+         @assertEqual(2, scope_callback_count)
+
+         fake_time = 3.0_wp
+         call ftimer_stop("child", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = 4.0_wp
+         call outer%stop(ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+      end block below_child
+
+      call assert_scope_callback_trace(4, expected_timer_ids, expected_events, expected_timestamps)
+
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_scope_rejects_owned_activation_below_child
 
    @test
    subroutine test_scope_stop_rejects_stale_same_name_activation()
@@ -315,5 +434,21 @@ contains
       scope_callback_events = 0
       scope_callback_timestamps = 0.0_wp
    end subroutine reset_scope_callback_log
+
+   subroutine assert_scope_callback_trace(expected_count, expected_timer_ids, expected_events, expected_timestamps)
+      integer, intent(in) :: expected_count
+      integer, intent(in) :: expected_timer_ids(:)
+      integer, intent(in) :: expected_events(:)
+      real(wp), intent(in) :: expected_timestamps(:)
+      integer :: i
+
+      @assertEqual(expected_count, scope_callback_count)
+
+      do i = 1, expected_count
+         @assertEqual(expected_timer_ids(i), scope_callback_timer_ids(i))
+         @assertEqual(expected_events(i), scope_callback_events(i))
+         @assertEqual(expected_timestamps(i), scope_callback_timestamps(i))
+      end do
+   end subroutine assert_scope_callback_trace
 
 end module test_scoped_guard

--- a/tests/test_scoped_guard.pf
+++ b/tests/test_scoped_guard.pf
@@ -258,6 +258,129 @@ contains
    end subroutine test_scope_rejects_stale_activation_after_reset
 
    @test
+   subroutine test_scope_rejects_stale_activation_after_finalize_init()
+      type(ftimer_test_state_t) :: state
+      character(len=:), allocatable :: stderr_text
+      integer :: capture_ierr
+      type(ftimer_call_stack_t) :: root_stack
+      integer :: ctx
+      integer :: ierr
+      integer :: saved_fd
+      logical :: has_warning
+
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+      call begin_stderr_capture('test_scope_rejects_stale_activation_after_finalize_init.err', saved_fd, &
+                                capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      stale_after_finalize: block
+         type(ftimer_guard_t) :: guard
+
+         call ftimer_scope(guard, "lifecycle_owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = 1.0_wp
+         call ftimer_stop("lifecycle_owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+
+         call ftimer_finalize(ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         call ftimer_init(ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         call attach_mock_clock(ftimer_default_instance)
+
+         call ftimer_start("lifecycle_owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = 2.0_wp
+
+         call guard%stop(ierr=ierr)
+         @assertEqual(FTIMER_ERR_MISMATCH, ierr)
+
+         call snapshot_timer(ftimer_default_instance, state)
+         ctx = find_context_idx(state, 1, root_stack)
+         @assertEqual(1, state%call_stack%depth)
+         @assertEqual(1, state%call_stack%top())
+         @assertTrue(state%segments(1)%is_running(ctx))
+         @assertEqual(0.0_wp, state%segments(1)%time(ctx))
+
+         call ftimer_stop("lifecycle_owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+      end block stale_after_finalize
+
+      call end_stderr_capture('test_scope_rejects_stale_activation_after_finalize_init.err', saved_fd, stderr_text, &
+                              capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      has_warning = index(stderr_text, 'ftimer scoped guard stop mismatch') > 0
+      @assertTrue(has_warning)
+
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_scope_rejects_stale_activation_after_finalize_init
+
+   @test
+   subroutine test_scope_rejects_stale_activation_after_reinit()
+      type(ftimer_test_state_t) :: state
+      character(len=:), allocatable :: stderr_text
+      integer :: capture_ierr
+      type(ftimer_call_stack_t) :: root_stack
+      integer :: ctx
+      integer :: ierr
+      integer :: saved_fd
+      logical :: has_warning
+
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+      call begin_stderr_capture('test_scope_rejects_stale_activation_after_reinit.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      stale_after_reinit: block
+         type(ftimer_guard_t) :: guard
+
+         call ftimer_scope(guard, "reinit_owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = 1.0_wp
+         call ftimer_stop("reinit_owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+
+         call ftimer_init(ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         call attach_mock_clock(ftimer_default_instance)
+
+         call ftimer_start("reinit_owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = 2.0_wp
+
+         call guard%stop(ierr=ierr)
+         @assertEqual(FTIMER_ERR_MISMATCH, ierr)
+
+         call snapshot_timer(ftimer_default_instance, state)
+         ctx = find_context_idx(state, 1, root_stack)
+         @assertEqual(1, state%call_stack%depth)
+         @assertEqual(1, state%call_stack%top())
+         @assertTrue(state%segments(1)%is_running(ctx))
+         @assertEqual(0.0_wp, state%segments(1)%time(ctx))
+
+         call ftimer_stop("reinit_owned", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+      end block stale_after_reinit
+
+      call end_stderr_capture('test_scope_rejects_stale_activation_after_reinit.err', saved_fd, stderr_text, &
+                              capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      has_warning = index(stderr_text, 'ftimer scoped guard stop mismatch') > 0
+      @assertTrue(has_warning)
+
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_scope_rejects_stale_activation_after_reinit
+
+   @test
    subroutine test_scope_rejects_owned_activation_below_child()
       type(ftimer_test_state_t) :: state
       integer :: ierr


### PR DESCRIPTION
Fixes #158

## Summary
- Add scalar procedural ftimer_guard_t plus ftimer_scope(guard, name, ierr) for default-instance lexical-block timing.
- Track internal activation tokens so guards can stop only the exact activation they started; stale same-name activations return FTIMER_ERR_MISMATCH.
- Document deferred ftimer_scope_id/OOP scoped guards, unsupported lifetime patterns, finalizer warnings, and callback policy.
- Add pFUnit, OpenMP, and installed-consumer coverage for the new API.

## Deliberate deferrals
- ftimer_scope_id is deferred to keep the first public surface small.
- OOP scoped guard parity remains deferred to #178.

## Validation
- cmake --build build-serial-tests --target ftimer_serial_tests
- ctest --test-dir build-serial-tests --output-on-failure
- cmake --build build-openmp --target ftimer_serial_tests
- ctest --test-dir build-openmp --output-on-failure
- cmake -B build-smoke
- cmake --build build-smoke
- ctest --test-dir build-smoke --output-on-failure
- find src -name '*.F90' -exec fprettify --diff {} +
- find tests -name '*.pf' -exec fprettify --diff {} +
- find tests -name '*.F90' -exec fprettify --diff {} +
- find examples -name '*.F90' -exec fprettify --diff {} +
- git diff --check