### PR TITLE
Define no-op instrumentation facade pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ fTimer currently supports these usage paths:
 - Pure-MPI builds on the validated `use mpi` path that use `MPI_Wtime()`, produce global MPI summaries on every participating rank, and can emit communicator-level text and CSV reports
 - A narrow OpenMP carve-out: master-thread-only timer guards for timing a parallel region as a whole
 - Downstream consumption through `find_package(fTimer CONFIG REQUIRED)`
+- Application-owned instrumentation facades that can select either the real fTimer implementation or a dependency-free no-op implementation at build time
 
 Important limitations are documented later in this README. The short version is that serial and pure-MPI are the core supported stories on current `main`; OpenMP support is intentionally limited to the documented master-thread-only model.
 
@@ -147,6 +148,50 @@ The downstream example under [`tests/install-consumer/`](tests/install-consumer/
 
 The supported source-level module surface is intentionally narrow: `ftimer`, `ftimer_core`, and `ftimer_types`. Some install trees may still contain compiler module artifacts for implementation modules such as `ftimer_clock`, `ftimer_summary`, and `ftimer_mpi`, but those are internal implementation details, not stable user-facing API. The current validated toolchain matrix does not require any extra compiler-specific companion artifacts in the installed include tree. If a future compiler proves that such artifacts are truly required for downstream consumption, they should be added deliberately and documented as an explicit exception rather than leaked accidentally.
 
+## Compile-Out / No-Op Instrumentation Pattern
+
+For production builds that should keep timing calls in source but remove fTimer overhead and dependencies, the recommended pattern is an application-owned facade module with two implementations selected by the application's build system:
+
+- an enabled implementation that delegates to `use ftimer`
+- a disabled implementation with the same application-facing procedures, but no `use ftimer`, no fTimer link dependency, and no timer state
+
+This keeps normal fTimer users away from preprocessor macros, keeps fTimer's core semantics unconditional, and lets each application decide which calls should remain unconditional in disabled builds.
+
+For example, application code can depend only on its own facade:
+
+```fortran
+program my_app
+   use my_timing, only: timing_finalize, timing_init, timing_start, timing_stop
+   implicit none
+
+   call timing_init()
+   call timing_start("advance")
+   ! application work
+   call timing_stop("advance")
+   call timing_finalize()
+end program my_app
+```
+
+Then CMake can select one facade source:
+
+```cmake
+option(MY_APP_ENABLE_TIMING "Enable fTimer instrumentation" ON)
+
+if(MY_APP_ENABLE_TIMING)
+  find_package(fTimer CONFIG REQUIRED)
+  target_sources(my_app PRIVATE my_timing_enabled.F90)
+  target_link_libraries(my_app PRIVATE fTimer::ftimer)
+else()
+  target_sources(my_app PRIVATE my_timing_disabled.F90)
+endif()
+```
+
+The disabled facade should make instrumentation entry points silent no-ops. If an `ierr` argument is present, set it to `0`, matching `FTIMER_SUCCESS`; if `ierr` is absent, do not write to stderr. Disabled wrappers should not validate names, maintain a stack, create summaries, write timing files, fire callbacks, or enter MPI collectives. If a dependency-free build is required, keep fTimer summary types out of unconditional application code; expose application-level report helpers or simple status/count values instead.
+
+fTimer intentionally does not install a drop-in no-op `ftimer` module. Providing a second module with the same public name as the real library is easy to misconfigure and can hide which semantics are active. The supported strategy is to put the build switch at the application facade boundary.
+
+The repository includes a worked example under `examples/instrumentation_facade_*.F90`. The smoke test builds and runs both `instrumentation_facade_enabled`, which links fTimer and records one timer, and `instrumentation_facade_disabled`, which does not link fTimer and verifies that the same timing calls compile and execute as no-ops.
+
 ## API Surface
 
 The public API supports two styles:
@@ -187,6 +232,7 @@ Operational notes:
 
 - `examples/basic_usage.F90`: serial start/stop plus summary retrieval and formatted output
 - `examples/nested_timers.F90`: nested timers and metadata headers
+- `examples/instrumentation_facade_*.F90`: enabled and disabled application-owned timing facade implementations that demonstrate the supported compile-out/no-op pattern
 - `examples/mpi_example.F90`: pure-MPI timing with a global MPI summary object and first-class MPI report output
 - `examples/openmp_example.F90`: the narrow OpenMP carve-out, where timers bracket the parallel region instead of running inside worker threads
 
@@ -250,6 +296,8 @@ make mpi
 make openmp
 make test
 ```
+
+The smoke-test path also runs the enabled and disabled instrumentation facade examples so the documented compile-out strategy stays buildable.
 
 Supported toolchain matrix:
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -52,6 +52,19 @@ wait on asynchronous offload work, or insert MPI barriers around timer regions.
 - Validation and lifecycle errors follow a warn-and-return contract: they leave timer state unchanged unless the caller explicitly selected a repair-capable mismatch mode
 - Error codes and their meanings
 
+## Compile-Out / No-Op Instrumentation Pattern
+
+The fTimer runtime itself is not conditionally compiled into a no-op mode. Its core semantics remain unconditional: when an application links fTimer and calls `ftimer_start`, `ftimer_stop`, scoped guards, summary APIs, callbacks, or MPI reporting APIs, the normal runtime contracts in this document apply.
+
+Applications that need to leave timing calls in source while removing runtime overhead and fTimer dependencies in selected builds should use an application-owned facade module. The supported pattern is two facade implementations with the same application-facing interface:
+
+- an enabled facade that delegates to fTimer and links `fTimer::ftimer`
+- a disabled facade that does not `use ftimer`, does not link fTimer, and stores no timer state
+
+Disabled facade entry points are intentionally silent no-ops. If an `ierr` argument is present, the disabled facade should set it to `0`, matching `FTIMER_SUCCESS`; if `ierr` is absent, it should not write to stderr. Disabled calls do not validate timer names, maintain a nesting stack, create segments or summaries, write timing artifacts, fire callbacks, or enter MPI collectives.
+
+This disabled-facade behavior is an application integration contract, not an alternate fTimer runtime mode. To keep disabled builds dependency-free, applications should avoid exposing fTimer summary types or constants in unconditional source and should instead expose application-level report helpers, simple counters, or status values from the facade. fTimer intentionally does not provide an installed drop-in no-op module named `ftimer`, because that would make it too easy for a build to accidentally shadow the real library API.
+
 ## Timer Name / Summary Text Policy
 
 - Public timer creation/lookup paths right-trim trailing blanks, reject empty names, reject names that begin with a blank, and reject ASCII control characters. They do not silently truncate names and do not impose the legacy `FTIMER_NAME_LEN` value as a runtime name cap.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,6 +9,28 @@ endif()
 add_executable(nested_timers nested_timers.F90)
 target_link_libraries(nested_timers PRIVATE ftimer)
 
+add_executable(instrumentation_facade_enabled
+  instrumentation_facade_enabled.F90
+  instrumentation_facade_example.F90
+)
+set_target_properties(instrumentation_facade_enabled PROPERTIES
+  Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod/instrumentation_facade_enabled"
+)
+target_link_libraries(instrumentation_facade_enabled PRIVATE ftimer)
+
+add_executable(instrumentation_facade_disabled
+  instrumentation_facade_disabled.F90
+  instrumentation_facade_example.F90
+)
+set_target_properties(instrumentation_facade_disabled PROPERTIES
+  Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod/instrumentation_facade_disabled"
+)
+
+if(FTIMER_BUILD_SMOKE_TESTS)
+  add_test(NAME ftimer_instrumentation_facade_enabled_smoke COMMAND instrumentation_facade_enabled)
+  add_test(NAME ftimer_instrumentation_facade_disabled_smoke COMMAND instrumentation_facade_disabled)
+endif()
+
 if(FTIMER_USE_MPI)
   add_executable(mpi_example mpi_example.F90)
   target_link_libraries(mpi_example PRIVATE ftimer)

--- a/examples/instrumentation_facade_disabled.F90
+++ b/examples/instrumentation_facade_disabled.F90
@@ -1,0 +1,57 @@
+module example_instrumentation
+   implicit none
+   private
+
+   logical, parameter, public :: timing_enabled = .false.
+   integer, parameter, public :: timing_success = 0
+
+   public :: timing_init
+   public :: timing_finalize
+   public :: timing_start
+   public :: timing_stop
+   public :: timing_get_entry_count
+   public :: timing_print_summary
+
+contains
+
+   subroutine timing_init(ierr)
+      integer, intent(out), optional :: ierr
+
+      if (present(ierr)) ierr = timing_success
+   end subroutine timing_init
+
+   subroutine timing_finalize(ierr)
+      integer, intent(out), optional :: ierr
+
+      if (present(ierr)) ierr = timing_success
+   end subroutine timing_finalize
+
+   subroutine timing_start(name, ierr)
+      character(len=*), intent(in) :: name
+      integer, intent(out), optional :: ierr
+
+      if (present(ierr)) ierr = timing_success
+   end subroutine timing_start
+
+   subroutine timing_stop(name, ierr)
+      character(len=*), intent(in) :: name
+      integer, intent(out), optional :: ierr
+
+      if (present(ierr)) ierr = timing_success
+   end subroutine timing_stop
+
+   subroutine timing_get_entry_count(num_entries, ierr)
+      integer, intent(out) :: num_entries
+      integer, intent(out), optional :: ierr
+
+      num_entries = 0
+      if (present(ierr)) ierr = timing_success
+   end subroutine timing_get_entry_count
+
+   subroutine timing_print_summary(ierr)
+      integer, intent(out), optional :: ierr
+
+      if (present(ierr)) ierr = timing_success
+   end subroutine timing_print_summary
+
+end module example_instrumentation

--- a/examples/instrumentation_facade_enabled.F90
+++ b/examples/instrumentation_facade_enabled.F90
@@ -1,0 +1,64 @@
+module example_instrumentation
+   use ftimer, only: ftimer_finalize, ftimer_get_summary, ftimer_init, &
+                     ftimer_print_summary, ftimer_start, ftimer_stop
+   use ftimer_types, only: FTIMER_SUCCESS, ftimer_summary_t
+   implicit none
+   private
+
+   logical, parameter, public :: timing_enabled = .true.
+   integer, parameter, public :: timing_success = FTIMER_SUCCESS
+
+   public :: timing_init
+   public :: timing_finalize
+   public :: timing_start
+   public :: timing_stop
+   public :: timing_get_entry_count
+   public :: timing_print_summary
+
+contains
+
+   subroutine timing_init(ierr)
+      integer, intent(out), optional :: ierr
+
+      call ftimer_init(ierr=ierr)
+   end subroutine timing_init
+
+   subroutine timing_finalize(ierr)
+      integer, intent(out), optional :: ierr
+
+      call ftimer_finalize(ierr=ierr)
+   end subroutine timing_finalize
+
+   subroutine timing_start(name, ierr)
+      character(len=*), intent(in) :: name
+      integer, intent(out), optional :: ierr
+
+      call ftimer_start(name, ierr=ierr)
+   end subroutine timing_start
+
+   subroutine timing_stop(name, ierr)
+      character(len=*), intent(in) :: name
+      integer, intent(out), optional :: ierr
+
+      call ftimer_stop(name, ierr=ierr)
+   end subroutine timing_stop
+
+   subroutine timing_get_entry_count(num_entries, ierr)
+      integer, intent(out) :: num_entries
+      integer, intent(out), optional :: ierr
+      integer :: status
+      type(ftimer_summary_t) :: summary
+
+      num_entries = 0
+      call ftimer_get_summary(summary, ierr=status)
+      if (status == FTIMER_SUCCESS) num_entries = summary%num_entries
+      if (present(ierr)) ierr = status
+   end subroutine timing_get_entry_count
+
+   subroutine timing_print_summary(ierr)
+      integer, intent(out), optional :: ierr
+
+      call ftimer_print_summary(ierr=ierr)
+   end subroutine timing_print_summary
+
+end module example_instrumentation

--- a/examples/instrumentation_facade_example.F90
+++ b/examples/instrumentation_facade_example.F90
@@ -1,0 +1,42 @@
+program instrumentation_facade_example
+   use example_instrumentation, only: timing_enabled, timing_finalize, &
+                                      timing_get_entry_count, timing_init, &
+                                      timing_print_summary, timing_start, &
+                                      timing_stop, timing_success
+   implicit none
+   integer :: entry_count
+   integer :: ierr
+   integer :: i
+   real :: accumulator
+
+   call timing_init(ierr=ierr)
+   if (ierr /= timing_success) error stop 1
+
+   call timing_start("work", ierr=ierr)
+   if (ierr /= timing_success) error stop 2
+
+   accumulator = 0.0
+   do i = 1, 200000
+      accumulator = accumulator + real(i)
+   end do
+
+   call timing_stop("work", ierr=ierr)
+   if (ierr /= timing_success) error stop 3
+
+   call timing_get_entry_count(entry_count, ierr=ierr)
+   if (ierr /= timing_success) error stop 4
+
+   if (timing_enabled) then
+      if (entry_count /= 1) error stop 5
+      call timing_print_summary(ierr=ierr)
+      if (ierr /= timing_success) error stop 6
+   else
+      if (entry_count /= 0) error stop 7
+      print '(a)', "Instrumentation disabled: timing calls were no-ops."
+   end if
+
+   call timing_finalize(ierr=ierr)
+   if (ierr /= timing_success) error stop 8
+
+   if (accumulator < 0.0) print *, accumulator
+end program instrumentation_facade_example


### PR DESCRIPTION
## Summary

- Phase / issue: #159 (AUD-011)
- Scope: document the supported application-owned no-op facade strategy, add enabled/disabled facade examples, and wire both examples into smoke coverage.

Closes #159

## Checks

- [x] Linked to the relevant GitHub issue
- [x] Codex review routing has applied the expected automatic review labels, or I added any missing ones manually
- [x] Added any extra Codex review labels needed beyond the automatic set: none needed
- [x] Docs updated to match behavior changes
- [x] Tests or smoke-path coverage updated as appropriate
- [x] Workflow/bootstrap docs updated if repo process changed: not applicable; repo workflow did not change

## Notes

- Follow-up work: none identified
- Deferred items: none
- Review disposition: native Codex review is unavailable for this repo, so fresh-context manual fallback reviews covered software, docs-contract, and build-portability for head ae21f3a601f571f396ea321d0e9596ecad8d936e. No findings were reported.