### PR TITLE
[codex] Document hybrid OpenMP timing decision for #160

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Use a separate build directory for each compiler or mode. Reconfiguring the same
 - All ranks that participate in `mpi_summary()` must agree on the communicator captured by `init`. If would-be participants diverge onto different communicators, the library cannot safely discover that mistake after the split; the practical failure mode is a hang, not a clean local fallback.
 - `FTIMER_USE_OPENMP=ON` enables only limited master-thread-only guards. Worker-thread timer calls inside an OpenMP parallel region are silent no-ops. To time a parallel region as a whole, place `start`/`stop` outside the `!$omp parallel` block.
 - The OpenMP path does not make fTimer thread-safe, does not provide thread-local timer instances, and should not be read as a general hybrid MPI+OpenMP timing model.
+- Future real hybrid MPI+OpenMP timing is deferred pending concrete adopter demand; see [`docs/openmp-hybrid-strategy-decision.md`](docs/openmp-hybrid-strategy-decision.md).
 - `on_event` remains a lightweight intra-run hook, not a serious profiler-backend integration contract with stable semantic timer identity.
 - If `FTIMER_USE_MPI=OFF`, `mpi_summary()` returns `FTIMER_ERR_NOT_IMPLEMENTED` and leaves the MPI result empty.
 - Formatted local and MPI report output are separate paths: `print_summary()`/`write_summary()` are local, while `print_mpi_summary()`/`write_mpi_summary()` emit communicator-level MPI reports from root. MPI reports are deliberately abbreviated; `ftimer_mpi_summary_t` remains the complete structured data model.

--- a/docs/design.md
+++ b/docs/design.md
@@ -284,7 +284,7 @@ Future-facing ideas should stay clearly separated from the current architecture 
 
 - built-in hardware counter or power-measurement backends
 - richer export formats beyond summary CSV, such as JSON or trace/event formats
-- broader OpenMP support beyond the documented master-thread-only guard model
+- broader OpenMP support beyond the documented master-thread-only guard model, deferred pending concrete adopter demand in [`docs/openmp-hybrid-strategy-decision.md`](openmp-hybrid-strategy-decision.md)
 - stable semantic callback identity or a stronger external-profiler integration contract
 - explicit reservation/preallocation APIs for known timer sets, if profiling shows the new internal capacity strategy is still not enough for an adopter workload
 

--- a/docs/openmp-hybrid-strategy-decision.md
+++ b/docs/openmp-hybrid-strategy-decision.md
@@ -1,0 +1,111 @@
+> **When to read this:** When revisiting whether fTimer should support real
+> hybrid MPI+OpenMP timing beyond the current master-thread-only OpenMP
+> carve-out.
+
+# Hybrid OpenMP Timing Strategy Decision
+
+Issue #160 asked whether fTimer should ever support real hybrid MPI+OpenMP
+timing beyond the documented master-thread-only carve-out.
+
+## Decision
+
+Real hybrid MPI+OpenMP timing is deferred pending concrete adopter demand. It is
+not planned for the current release path, but it is not rejected forever.
+
+The current `FTIMER_USE_OPENMP=ON` behavior stays unchanged: timer operations in
+OpenMP parallel regions run only on the master thread, and worker-thread calls
+remain silent no-ops. fTimer should not add partial worker-thread timing until a
+future issue defines an explicit opt-in API, aggregation model, summary data
+contract, migration story, and test plan.
+
+No child implementation issues are opened from #160 because implementation is
+not planned yet. If a real adopter need turns this into planned work later, use
+the potential breakdown below to split that work before code changes begin.
+
+## Evidence
+
+The current implementation and documentation are internally consistent:
+
+- `src/ftimer_core.F90` guards timer lifecycle, start/stop, lookup, reset, clock,
+  callback, and scoped-activation entry points with `!$omp master`.
+- `tests/test_openmp_guards.pf` verifies that worker-thread calls do not create
+  segments, do not increment call counts, do not clear active scoped guards, and
+  leave caller-provided `ierr` values unchanged.
+- `tests/test_openmp_guards.pf` also verifies that all-thread `start`/`stop`
+  calls record only the master-thread invocation and that procedural wrappers
+  match the OOP behavior.
+- `docs/semantics.md`, `README.md`, and `examples/openmp_example.F90` describe
+  OpenMP support as a narrow region-bracketing carve-out, not per-thread timing.
+- Issue #120 and PR #131 resolved the previous product-positioning concern by
+  narrowing current `main` around disciplined serial and pure-MPI timing.
+
+## Rationale
+
+Hybrid MPI+OpenMP codes are common, but adding credible worker-thread timing is
+not a small extension of the existing guard model. The current runtime has one
+mutable timer stack per `ftimer_t`, context-sensitive accounting tied to that
+stack, callback events tied to runtime-local timer/context ids, and MPI summary
+reductions that assume each rank has a well-defined local summary tree.
+
+Real threaded timing would need to answer questions that the current contract
+intentionally avoids:
+
+- whether each OpenMP thread owns a private stack, a private timer instance, or
+  a synchronized view of one shared instance
+- how per-thread inclusive, self, and call-count data are represented in local
+  and MPI summaries
+- whether default reports show per-thread rows, aggregate rows, or both
+- how thread participation and missing-thread data differ from real zero work
+- what callback events mean when many threads start the same semantic timer
+- how much synchronization overhead is acceptable in hot timing paths
+- whether the current worker-thread no-op behavior remains the default for
+  compatibility
+
+Without an adopter-backed use case, choosing those answers now would risk a
+large API and data-model commitment for a capability outside fTimer's strongest
+current niche.
+
+## Reconsideration Gate
+
+Revisit this decision when there is a concrete adopter or benchmark that needs
+timing inside OpenMP parallel regions and can state which data they expect. A
+useful request should include:
+
+- representative instrumentation patterns inside parallel regions
+- expected local summary shape and call-count semantics
+- expected MPI aggregation behavior in hybrid runs
+- acceptable overhead constraints
+- compatibility expectations for existing master-thread-only builds
+
+Until that evidence exists, keep the documented master-thread-only carve-out and
+do not infer worker-thread timing from `FTIMER_USE_OPENMP=ON`.
+
+## Potential Work Breakdown If Support Becomes Planned
+
+If the reconsideration gate is met, split the work before implementation:
+
+- Define the opt-in hybrid API and compatibility model. Decide whether worker
+  timing is a new mode, a new timer type, a new summary entry point, or a new
+  explicit thread-local instance pattern.
+- Define the hybrid summary data contract. Specify per-thread participation,
+  aggregation, call-count semantics, self-time rules, and MPI reduction behavior.
+- Prototype the core concurrency model. Compare thread-local stacks plus
+  post-region aggregation against a synchronized shared instance and document
+  the overhead and correctness tradeoffs.
+- Add deterministic OpenMP tests. Preserve the existing worker no-op tests for
+  the default mode, then add opt-in tests for worker-only timers, all-thread
+  timers, nested per-thread stacks, callbacks, and summary generation.
+- Update user-facing docs and examples. Keep the current region-bracketing
+  example, add a clearly separate hybrid example, and explain migration risks.
+
+## Non-Goals
+
+This decision does not change current OpenMP semantics, make `ftimer_t`
+thread-safe, add thread-local timer instances, reinterpret worker-thread no-ops
+as errors, or add a hidden aggregation fallback to existing summaries.
+
+## Validation
+
+Issue #160 is investigation-only. Because this change records a strategic
+decision without changing runtime behavior, validation is limited to Markdown
+diff checks.

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -220,6 +220,7 @@ enforcement should pass `ierr` and check it.
 - Suppressed non-master calls are skipped before normal validation, emit no stderr warning, and leave any caller-provided `ierr` unchanged
 - The OpenMP guards do not broaden support for concurrent access to other APIs; summary/report generation and other shared access remain unsupported in threaded regions
 - Thread-local timer instances, fuller concurrent timing support, and any `suppress_in_parallel` control remain deferred
+- Future real hybrid MPI+OpenMP timing is deferred pending concrete adopter demand; see [`docs/openmp-hybrid-strategy-decision.md`](openmp-hybrid-strategy-decision.md)
 
 ### Consequences for timing data
 


### PR DESCRIPTION
## Summary
- record the AUD-012 strategic decision that real hybrid MPI+OpenMP timing is deferred pending concrete adopter demand
- keep the current `FTIMER_USE_OPENMP=ON` master-thread-only worker no-op contract unchanged
- link the decision record from README, semantics, and architecture deferred-work docs

## Decision
Hybrid MPI+OpenMP timing is not planned for the current release path, but it is not rejected forever. Future support should only start after an adopter-backed issue defines the opt-in API, data model, aggregation semantics, migration story, and tests.

No child implementation issues are opened from this pass because support is deferred, not planned.

## Validation
- `git diff --cached --check`
- `ctest --test-dir build-openmp-tests --output-on-failure` (9/9 passed)

Fixes #160