### PR TITLE
[codex] Clarify installed API surface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,3 +193,8 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/fTimerConfigVersion.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/fTimer
 )
+
+install(FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/docs/installed-api.md
+  DESTINATION ${CMAKE_INSTALL_DOCDIR}
+)

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The supported downstream contract is the installed package export. New adopters 
 
 The downstream example under [`tests/install-consumer/`](tests/install-consumer/) is also part of the smoke path. It shows the supported installed-package happy path with `find_package(fTimer CONFIG REQUIRED)`, `use ftimer`, `use ftimer_types`, scoped timing, and summary retrieval from an installed prefix.
 
-The supported source-level module surface is intentionally narrow: `ftimer`, `ftimer_core`, and `ftimer_types`. Some install trees may still contain compiler module artifacts for implementation modules such as `ftimer_clock`, `ftimer_summary`, and `ftimer_mpi`, but those are internal implementation details, not stable user-facing API. The current validated toolchain matrix does not require any extra compiler-specific companion artifacts in the installed include tree. If a future compiler proves that such artifacts are truly required for downstream consumption, they should be added deliberately and documented as an explicit exception rather than leaked accidentally.
+The supported source-level module surface is intentionally narrow: `ftimer`, `ftimer_core`, and `ftimer_types`. The installed include tree is a curated compiler module artifact set and currently includes `ftimer_clock.mod`, `ftimer_summary.mod`, and `ftimer_mpi.mod` so consumers get a coherent Fortran module set. Those implementation modules are not stable import targets. The installed package includes `share/doc/fTimer/installed-api.md` with the same stability contract, and the smoke tests verify both the exact artifact set and that installed note.
 
 ## Compile-Out / No-Op Instrumentation Pattern
 

--- a/cmake/install_ftimer_modules.cmake.in
+++ b/cmake/install_ftimer_modules.cmake.in
@@ -1,10 +1,13 @@
-# Install the intentional public module surface rather than copying the entire
-# compiler module output directory wholesale.
+# Install the curated module artifact set needed by downstream package
+# consumers rather than copying the entire compiler module output directory
+# wholesale. Some installed artifacts belong to internal implementation
+# modules; see the installed API stability note for the supported import
+# contract.
 
 set(ftimer_install_module_dir "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@/ftimer")
 file(MAKE_DIRECTORY "${ftimer_install_module_dir}")
 
-set(ftimer_public_module_names
+set(ftimer_installed_module_artifact_names
   ftimer
   ftimer_clock
   ftimer_core
@@ -13,11 +16,11 @@ set(ftimer_public_module_names
   ftimer_types
 )
 
-foreach(ftimer_module_name IN LISTS ftimer_public_module_names)
+foreach(ftimer_module_name IN LISTS ftimer_installed_module_artifact_names)
   set(ftimer_module_file "@FTIMER_PUBLIC_MODULE_DIR@/${ftimer_module_name}.mod")
   if(NOT EXISTS "${ftimer_module_file}")
     message(FATAL_ERROR
-      "Expected public module artifact '${ftimer_module_file}' was not generated before install."
+      "Expected installed module artifact '${ftimer_module_file}' was not generated before install."
     )
   endif()
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -146,7 +146,7 @@ The public surface on current `main` is split between:
 - the OOP API through `type(ftimer_t)` from `use ftimer_core`
 - shared types and constants from `use ftimer_types`
 
-The supported source-level module surface is intentionally limited to those three modules. Install trees may still contain compiler module artifacts for implementation modules such as `ftimer_clock`, `ftimer_summary`, and `ftimer_mpi`, but those are internal implementation details rather than stable external integration points.
+The supported source-level module surface is intentionally limited to those three modules. The installed include tree is a curated compiler module artifact set; it currently includes `ftimer_clock.mod`, `ftimer_summary.mod`, and `ftimer_mpi.mod` so downstream builds see a coherent Fortran module set, but those implementation modules are not stable import targets. The installed package also carries `share/doc/fTimer/installed-api.md`, and the installed-consumer smoke test checks that this note matches the artifact contract.
 
 The currently exported procedural entry points are:
 

--- a/docs/installed-api.md
+++ b/docs/installed-api.md
@@ -1,0 +1,15 @@
+# fTimer Installed API Stability
+
+Stable source-level modules: `ftimer`, `ftimer_core`, `ftimer_types`.
+
+The supported source-level import surface is intentionally narrow:
+
+- `use ftimer` for the procedural API and default timer instance
+- `use ftimer_core` for `type(ftimer_t)` and its OOP methods
+- `use ftimer_types` for shared constants, status codes, callback interfaces, and summary types
+
+Installed implementation module artifacts: `ftimer_clock.mod`, `ftimer_summary.mod`, `ftimer_mpi.mod`.
+
+Those implementation module files may be present in the installed include tree because Fortran consumers need a coherent compiler module artifact set when they import the supported modules above. They are not stable import targets, and their installed visibility does not promote the corresponding source modules into supported API. Downstream code should not import `ftimer_clock`, `ftimer_summary`, or `ftimer_mpi` directly unless it is deliberately accepting implementation-detail coupling.
+
+The exact installed module artifact set is curated and smoke-tested. Extra compiler-specific companion artifacts should be added only when a validated compiler requires them for downstream package consumption, and each such exception should be documented explicitly.

--- a/tests/check_installed_package_consumer.cmake
+++ b/tests/check_installed_package_consumer.cmake
@@ -5,6 +5,7 @@ set(consumer_build_dir "${TEST_BINARY_DIR}/consumer-build")
 set(consumer_source_dir "${REPO_ROOT}/tests/install-consumer")
 set(test_name "${TEST_NAME}")
 set(installed_module_dir "${install_prefix}/include/ftimer")
+set(installed_api_note_path "${install_prefix}/share/doc/fTimer/installed-api.md")
 
 if(test_name STREQUAL "")
   set(test_name "ftimer_installed_package_consumer")
@@ -97,7 +98,7 @@ if(NOT producer_install_result EQUAL 0)
   message(FATAL_ERROR "Failed to install the producer package.")
 endif()
 
-set(expected_installed_modules
+set(expected_installed_module_artifacts
   ftimer.mod
   ftimer_clock.mod
   ftimer_core.mod
@@ -106,25 +107,45 @@ set(expected_installed_modules
   ftimer_types.mod
 )
 
-file(GLOB installed_module_paths LIST_DIRECTORIES FALSE "${installed_module_dir}/*")
-set(installed_module_names)
-foreach(installed_module_path IN LISTS installed_module_paths)
-  get_filename_component(installed_module_name "${installed_module_path}" NAME)
-  list(APPEND installed_module_names "${installed_module_name}")
+file(GLOB installed_module_artifact_paths LIST_DIRECTORIES FALSE "${installed_module_dir}/*")
+set(installed_module_artifact_names)
+foreach(installed_module_artifact_path IN LISTS installed_module_artifact_paths)
+  get_filename_component(installed_module_artifact_name "${installed_module_artifact_path}" NAME)
+  list(APPEND installed_module_artifact_names "${installed_module_artifact_name}")
 endforeach()
 
-list(SORT expected_installed_modules)
-list(SORT installed_module_names)
+list(SORT expected_installed_module_artifacts)
+list(SORT installed_module_artifact_names)
 
-if(NOT installed_module_names STREQUAL expected_installed_modules)
-  list(JOIN expected_installed_modules ", " expected_installed_modules_text)
-  list(JOIN installed_module_names ", " installed_module_names_text)
+if(NOT installed_module_artifact_names STREQUAL expected_installed_module_artifacts)
+  list(JOIN expected_installed_module_artifacts ", " expected_installed_module_artifacts_text)
+  list(JOIN installed_module_artifact_names ", " installed_module_artifact_names_text)
   message(FATAL_ERROR
-    "Installed module surface mismatch.\n"
-    "Expected: ${expected_installed_modules_text}\n"
-    "Actual: ${installed_module_names_text}"
+    "Installed module artifact set mismatch.\n"
+    "Expected: ${expected_installed_module_artifacts_text}\n"
+    "Actual: ${installed_module_artifact_names_text}"
   )
 endif()
+
+if(NOT EXISTS "${installed_api_note_path}")
+  message(FATAL_ERROR
+    "Installed API stability note was not found at '${installed_api_note_path}'."
+  )
+endif()
+
+file(READ "${installed_api_note_path}" installed_api_note)
+foreach(required_note_text IN ITEMS
+  "Stable source-level modules: `ftimer`, `ftimer_core`, `ftimer_types`"
+  "Installed implementation module artifacts: `ftimer_clock.mod`, `ftimer_summary.mod`, `ftimer_mpi.mod`"
+  "not stable import targets"
+)
+  string(FIND "${installed_api_note}" "${required_note_text}" note_text_position)
+  if(note_text_position EQUAL -1)
+    message(FATAL_ERROR
+      "Installed API stability note is missing required text: ${required_note_text}"
+    )
+  endif()
+endforeach()
 
 set(consumer_configure_args
   -S "${consumer_source_dir}"

--- a/tests/check_installed_package_consumer.cmake
+++ b/tests/check_installed_package_consumer.cmake
@@ -133,19 +133,13 @@ if(NOT EXISTS "${installed_api_note_path}")
   )
 endif()
 
+file(READ "${REPO_ROOT}/docs/installed-api.md" expected_installed_api_note)
 file(READ "${installed_api_note_path}" installed_api_note)
-foreach(required_note_text IN ITEMS
-  "Stable source-level modules: `ftimer`, `ftimer_core`, `ftimer_types`"
-  "Installed implementation module artifacts: `ftimer_clock.mod`, `ftimer_summary.mod`, `ftimer_mpi.mod`"
-  "not stable import targets"
-)
-  string(FIND "${installed_api_note}" "${required_note_text}" note_text_position)
-  if(note_text_position EQUAL -1)
-    message(FATAL_ERROR
-      "Installed API stability note is missing required text: ${required_note_text}"
-    )
-  endif()
-endforeach()
+if(NOT installed_api_note STREQUAL expected_installed_api_note)
+  message(FATAL_ERROR
+    "Installed API stability note does not match docs/installed-api.md."
+  )
+endif()
 
 set(consumer_configure_args
   -S "${consumer_source_dir}"


### PR DESCRIPTION
## Summary
- install a package API stability note that separates stable source-level imports from installed module artifacts
- rename install/test wording from public module surface to curated module artifact set
- align README and design docs with the installed package contract

## Why
Closes #156.

The installed include tree intentionally carries `ftimer_clock.mod`, `ftimer_summary.mod`, and `ftimer_mpi.mod`, but the supported source-level import surface remains `ftimer`, `ftimer_core`, and `ftimer_types`. The package now installs that warning directly, and the smoke consumer check verifies it.

## Validation
- `ctest --test-dir build-smoke --output-on-failure`