### PR TITLE
Add MPI preflight collective-shape coverage

### DIFF
--- a/src/ftimer_mpi.F90
+++ b/src/ftimer_mpi.F90
@@ -27,11 +27,18 @@ module ftimer_mpi
    integer :: test_preflight_mismatch_flag_allgather_count = 0
    integer :: test_preflight_summary_reduction_count = 0
    integer, allocatable :: test_preflight_mismatch_flags(:)
-   ! Test builds route preflight Allgather calls through this wrapper and
-   ! mark the first summary reduction phase so runtime tests can assert the
-   ! descriptor-preflight collective shape.
-#define MPI_Allgather ftimer_test_mpi_allgather
+   logical :: test_preflight_after_descriptor_check = .false.
 #endif
+#endif
+
+#ifdef FTIMER_USE_MPI
+   interface ftimer_mpi_allreduce
+      module procedure ftimer_mpi_allreduce_integer_scalar
+      module procedure ftimer_mpi_allreduce_integer_array
+      module procedure ftimer_mpi_allreduce_int64_array
+      module procedure ftimer_mpi_allreduce_real_scalar
+      module procedure ftimer_mpi_allreduce_real_array
+   end interface
 #endif
 
 contains
@@ -124,7 +131,7 @@ contains
       local_active = 0
       if (local_has_active_timers) local_active = 1
 
-      call MPI_Allreduce(local_active, any_active, 1, MPI_INTEGER, MPI_MAX, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_active, any_active, 1, MPI_INTEGER, MPI_MAX, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          status = FTIMER_ERR_UNKNOWN
          return
@@ -199,6 +206,9 @@ contains
 
       call clear_mpi_summary(summary)
       if (present(diagnostic)) diagnostic = ''
+#ifdef FTIMER_BUILD_TESTS
+      test_preflight_after_descriptor_check = .false.
+#endif
 
       call get_mpi_summary_comm_info(comm, active_comm, rank, nprocs, status)
       if (status /= FTIMER_SUCCESS) return
@@ -206,7 +216,7 @@ contains
       call resolve_mpi_summary_datatypes(mpi_wp_type, mpi_int64_type, status, diagnostic)
       datatypes_ready = 0
       if (status == FTIMER_SUCCESS) datatypes_ready = 1
-      call MPI_Allreduce(datatypes_ready, all_datatypes_ready, 1, MPI_INTEGER, MPI_MIN, active_comm, mpierr)
+      call ftimer_mpi_allreduce(datatypes_ready, all_datatypes_ready, 1, MPI_INTEGER, MPI_MIN, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          status = FTIMER_ERR_UNKNOWN
          return
@@ -233,20 +243,23 @@ contains
       local_hash_mismatch = 0
       if (any(local_hashes /= reference_hashes)) local_hash_mismatch = 1
 
-      call MPI_Allreduce(local_hash_mismatch, any_hash_mismatch, 1, MPI_INTEGER, MPI_MAX, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_hash_mismatch, any_hash_mismatch, 1, MPI_INTEGER, MPI_MAX, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          status = FTIMER_ERR_UNKNOWN
          return
       end if
 
       hashes_match = any_hash_mismatch == 0
+#ifdef FTIMER_BUILD_TESTS
+      test_preflight_after_descriptor_check = .true.
+#endif
 
       if (.not. hashes_match) then
          ! Descriptor consistency is only meaningful after ranks have already
          ! agreed to enter the same communicator collective. Communicator
          ! disagreement across would-be participants is documented as unsupported.
          allocate (mismatch_flags(nprocs))
-         call MPI_Allgather(local_hash_mismatch, 1, MPI_INTEGER, mismatch_flags, 1, MPI_INTEGER, active_comm, mpierr)
+         call ftimer_mpi_allgather(local_hash_mismatch, 1, MPI_INTEGER, mismatch_flags, 1, MPI_INTEGER, active_comm, mpierr)
          if (mpierr /= MPI_SUCCESS) then
             status = FTIMER_ERR_UNKNOWN
             return
@@ -256,23 +269,19 @@ contains
          return
       end if
 
-#ifdef FTIMER_BUILD_TESTS
-      call ftimer_test_note_mpi_summary_reductions()
-#endif
-
-      call MPI_Allreduce(local_summary%total_time, min_total_time, 1, mpi_wp_type, MPI_MIN, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_summary%total_time, min_total_time, 1, mpi_wp_type, MPI_MIN, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          status = FTIMER_ERR_UNKNOWN
          return
       end if
 
-      call MPI_Allreduce(local_summary%total_time, max_total_time, 1, mpi_wp_type, MPI_MAX, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_summary%total_time, max_total_time, 1, mpi_wp_type, MPI_MAX, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          status = FTIMER_ERR_UNKNOWN
          return
       end if
 
-      call MPI_Allreduce(local_summary%total_time, sum_total_time, 1, mpi_wp_type, MPI_SUM, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_summary%total_time, sum_total_time, 1, mpi_wp_type, MPI_SUM, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          status = FTIMER_ERR_UNKNOWN
          return
@@ -280,7 +289,7 @@ contains
 
       local_min_total_rank = huge(local_min_total_rank)
       if (local_summary%total_time == min_total_time) local_min_total_rank = rank
-      call MPI_Allreduce(local_min_total_rank, min_total_time_rank, 1, MPI_INTEGER, MPI_MIN, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_min_total_rank, min_total_time_rank, 1, MPI_INTEGER, MPI_MIN, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          status = FTIMER_ERR_UNKNOWN
          return
@@ -288,7 +297,7 @@ contains
 
       local_max_total_rank = huge(local_max_total_rank)
       if (local_summary%total_time == max_total_time) local_max_total_rank = rank
-      call MPI_Allreduce(local_max_total_rank, max_total_time_rank, 1, MPI_INTEGER, MPI_MIN, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_max_total_rank, max_total_time_rank, 1, MPI_INTEGER, MPI_MIN, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          status = FTIMER_ERR_UNKNOWN
          return
@@ -343,14 +352,14 @@ contains
          local_pct(i) = local_summary%entries(local_idx)%pct_time
       end do
 
-      call MPI_Allreduce(local_inclusive, min_inclusive, entry_count, mpi_wp_type, MPI_MIN, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_inclusive, min_inclusive, entry_count, mpi_wp_type, MPI_MIN, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          call clear_mpi_summary(summary)
          status = FTIMER_ERR_UNKNOWN
          return
       end if
 
-      call MPI_Allreduce(local_inclusive, max_inclusive, entry_count, mpi_wp_type, MPI_MAX, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_inclusive, max_inclusive, entry_count, mpi_wp_type, MPI_MAX, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          call clear_mpi_summary(summary)
          status = FTIMER_ERR_UNKNOWN
@@ -364,84 +373,86 @@ contains
          if (local_inclusive(i) == max_inclusive(i)) local_max_inclusive_ranks(i) = rank
       end do
 
-      call MPI_Allreduce(local_min_inclusive_ranks, min_inclusive_ranks, entry_count, MPI_INTEGER, MPI_MIN, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_min_inclusive_ranks, min_inclusive_ranks, entry_count, MPI_INTEGER, MPI_MIN, &
+                                active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          call clear_mpi_summary(summary)
          status = FTIMER_ERR_UNKNOWN
          return
       end if
 
-      call MPI_Allreduce(local_max_inclusive_ranks, max_inclusive_ranks, entry_count, MPI_INTEGER, MPI_MIN, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_max_inclusive_ranks, max_inclusive_ranks, entry_count, MPI_INTEGER, MPI_MIN, &
+                                active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          call clear_mpi_summary(summary)
          status = FTIMER_ERR_UNKNOWN
          return
       end if
 
-      call MPI_Allreduce(local_inclusive, sum_inclusive, entry_count, mpi_wp_type, MPI_SUM, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_inclusive, sum_inclusive, entry_count, mpi_wp_type, MPI_SUM, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          call clear_mpi_summary(summary)
          status = FTIMER_ERR_UNKNOWN
          return
       end if
 
-      call MPI_Allreduce(local_self, min_self, entry_count, mpi_wp_type, MPI_MIN, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_self, min_self, entry_count, mpi_wp_type, MPI_MIN, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          call clear_mpi_summary(summary)
          status = FTIMER_ERR_UNKNOWN
          return
       end if
 
-      call MPI_Allreduce(local_self, max_self, entry_count, mpi_wp_type, MPI_MAX, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_self, max_self, entry_count, mpi_wp_type, MPI_MAX, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          call clear_mpi_summary(summary)
          status = FTIMER_ERR_UNKNOWN
          return
       end if
 
-      call MPI_Allreduce(local_self, sum_self, entry_count, mpi_wp_type, MPI_SUM, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_self, sum_self, entry_count, mpi_wp_type, MPI_SUM, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          call clear_mpi_summary(summary)
          status = FTIMER_ERR_UNKNOWN
          return
       end if
 
-      call MPI_Allreduce(local_pct, min_pct, entry_count, mpi_wp_type, MPI_MIN, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_pct, min_pct, entry_count, mpi_wp_type, MPI_MIN, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          call clear_mpi_summary(summary)
          status = FTIMER_ERR_UNKNOWN
          return
       end if
 
-      call MPI_Allreduce(local_pct, max_pct, entry_count, mpi_wp_type, MPI_MAX, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_pct, max_pct, entry_count, mpi_wp_type, MPI_MAX, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          call clear_mpi_summary(summary)
          status = FTIMER_ERR_UNKNOWN
          return
       end if
 
-      call MPI_Allreduce(local_pct, sum_pct, entry_count, mpi_wp_type, MPI_SUM, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_pct, sum_pct, entry_count, mpi_wp_type, MPI_SUM, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          call clear_mpi_summary(summary)
          status = FTIMER_ERR_UNKNOWN
          return
       end if
 
-      call MPI_Allreduce(local_calls, min_calls, entry_count, MPI_INTEGER, MPI_MIN, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_calls, min_calls, entry_count, MPI_INTEGER, MPI_MIN, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          call clear_mpi_summary(summary)
          status = FTIMER_ERR_UNKNOWN
          return
       end if
 
-      call MPI_Allreduce(local_calls, max_calls, entry_count, MPI_INTEGER, MPI_MAX, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_calls, max_calls, entry_count, MPI_INTEGER, MPI_MAX, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          call clear_mpi_summary(summary)
          status = FTIMER_ERR_UNKNOWN
          return
       end if
 
-      call MPI_Allreduce(local_sum_calls, sum_calls, entry_count, mpi_int64_type, MPI_SUM, active_comm, mpierr)
+      call ftimer_mpi_allreduce(local_sum_calls, sum_calls, entry_count, mpi_int64_type, MPI_SUM, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
          call clear_mpi_summary(summary)
          status = FTIMER_ERR_UNKNOWN
@@ -908,12 +919,117 @@ contains
       end if
    end subroutine mark_rank_list_truncated
 
+   subroutine ftimer_mpi_allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, mpierr)
+      integer, intent(in) :: sendbuf
+      integer, intent(in) :: sendcount
+      integer, intent(in) :: sendtype
+      integer, intent(out) :: recvbuf(*)
+      integer, intent(in) :: recvcount
+      integer, intent(in) :: recvtype
+      integer, intent(in) :: comm
+      integer, intent(out) :: mpierr
 #ifdef FTIMER_BUILD_TESTS
-#undef MPI_Allgather
+      integer :: nvalues
+      integer :: test_mpierr
+
+      test_preflight_allgather_count = test_preflight_allgather_count + 1
+      if ((sendcount == 1) .and. (recvcount == 1) .and. &
+          (sendtype == MPI_INTEGER) .and. (recvtype == MPI_INTEGER)) then
+         test_preflight_mismatch_flag_allgather_count = test_preflight_mismatch_flag_allgather_count + 1
+      end if
+#endif
+
+      call MPI_Allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, mpierr)
+#ifdef FTIMER_BUILD_TESTS
+      if ((mpierr == MPI_SUCCESS) .and. (sendcount == 1) .and. (recvcount == 1) .and. &
+          (sendtype == MPI_INTEGER) .and. (recvtype == MPI_INTEGER)) then
+         if (allocated(test_preflight_mismatch_flags)) deallocate (test_preflight_mismatch_flags)
+         call MPI_Comm_size(comm, nvalues, test_mpierr)
+         if (test_mpierr == MPI_SUCCESS) then
+            allocate (test_preflight_mismatch_flags(nvalues))
+            test_preflight_mismatch_flags = recvbuf(1:nvalues)
+         end if
+      end if
+#endif
+   end subroutine ftimer_mpi_allgather
+
+   subroutine ftimer_mpi_allreduce_integer_scalar(sendbuf, recvbuf, count, datatype, op, comm, mpierr)
+      integer, intent(in) :: sendbuf
+      integer, intent(out) :: recvbuf
+      integer, intent(in) :: count
+      integer, intent(in) :: datatype
+      integer, intent(in) :: op
+      integer, intent(in) :: comm
+      integer, intent(out) :: mpierr
+
+      call ftimer_test_note_summary_reduction_phase()
+      call MPI_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, mpierr)
+   end subroutine ftimer_mpi_allreduce_integer_scalar
+
+   subroutine ftimer_mpi_allreduce_integer_array(sendbuf, recvbuf, count, datatype, op, comm, mpierr)
+      integer, intent(in) :: sendbuf(:)
+      integer, intent(out) :: recvbuf(:)
+      integer, intent(in) :: count
+      integer, intent(in) :: datatype
+      integer, intent(in) :: op
+      integer, intent(in) :: comm
+      integer, intent(out) :: mpierr
+
+      call ftimer_test_note_summary_reduction_phase()
+      call MPI_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, mpierr)
+   end subroutine ftimer_mpi_allreduce_integer_array
+
+   subroutine ftimer_mpi_allreduce_int64_array(sendbuf, recvbuf, count, datatype, op, comm, mpierr)
+      integer(int64), intent(in) :: sendbuf(:)
+      integer(int64), intent(out) :: recvbuf(:)
+      integer, intent(in) :: count
+      integer, intent(in) :: datatype
+      integer, intent(in) :: op
+      integer, intent(in) :: comm
+      integer, intent(out) :: mpierr
+
+      call ftimer_test_note_summary_reduction_phase()
+      call MPI_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, mpierr)
+   end subroutine ftimer_mpi_allreduce_int64_array
+
+   subroutine ftimer_mpi_allreduce_real_scalar(sendbuf, recvbuf, count, datatype, op, comm, mpierr)
+      real(wp), intent(in) :: sendbuf
+      real(wp), intent(out) :: recvbuf
+      integer, intent(in) :: count
+      integer, intent(in) :: datatype
+      integer, intent(in) :: op
+      integer, intent(in) :: comm
+      integer, intent(out) :: mpierr
+
+      call ftimer_test_note_summary_reduction_phase()
+      call MPI_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, mpierr)
+   end subroutine ftimer_mpi_allreduce_real_scalar
+
+   subroutine ftimer_mpi_allreduce_real_array(sendbuf, recvbuf, count, datatype, op, comm, mpierr)
+      real(wp), intent(in) :: sendbuf(:)
+      real(wp), intent(out) :: recvbuf(:)
+      integer, intent(in) :: count
+      integer, intent(in) :: datatype
+      integer, intent(in) :: op
+      integer, intent(in) :: comm
+      integer, intent(out) :: mpierr
+
+      call ftimer_test_note_summary_reduction_phase()
+      call MPI_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, mpierr)
+   end subroutine ftimer_mpi_allreduce_real_array
+
+   subroutine ftimer_test_note_summary_reduction_phase()
+#ifdef FTIMER_BUILD_TESTS
+      if (test_preflight_after_descriptor_check) test_preflight_summary_reduction_count = 1
+#endif
+   end subroutine ftimer_test_note_summary_reduction_phase
+
+#ifdef FTIMER_BUILD_TESTS
    subroutine ftimer_test_reset_mpi_preflight_collectives()
       test_preflight_allgather_count = 0
       test_preflight_mismatch_flag_allgather_count = 0
       test_preflight_summary_reduction_count = 0
+      test_preflight_after_descriptor_check = .false.
       if (allocated(test_preflight_mismatch_flags)) deallocate (test_preflight_mismatch_flags)
    end subroutine ftimer_test_reset_mpi_preflight_collectives
 
@@ -939,39 +1055,6 @@ contains
       end if
    end subroutine ftimer_test_get_mpi_preflight_mismatch_flags
 
-   subroutine ftimer_test_note_mpi_summary_reductions()
-      test_preflight_summary_reduction_count = test_preflight_summary_reduction_count + 1
-   end subroutine ftimer_test_note_mpi_summary_reductions
-
-   subroutine ftimer_test_mpi_allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, mpierr)
-      integer, intent(in) :: sendbuf
-      integer, intent(in) :: sendcount
-      integer, intent(in) :: sendtype
-      integer, intent(out) :: recvbuf(*)
-      integer, intent(in) :: recvcount
-      integer, intent(in) :: recvtype
-      integer, intent(in) :: comm
-      integer, intent(out) :: mpierr
-      integer :: nvalues
-      integer :: test_mpierr
-
-      test_preflight_allgather_count = test_preflight_allgather_count + 1
-      if ((sendcount == 1) .and. (recvcount == 1) .and. &
-          (sendtype == MPI_INTEGER) .and. (recvtype == MPI_INTEGER)) then
-         test_preflight_mismatch_flag_allgather_count = test_preflight_mismatch_flag_allgather_count + 1
-      end if
-
-      call MPI_Allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, mpierr)
-      if ((mpierr == MPI_SUCCESS) .and. (sendcount == 1) .and. (recvcount == 1) .and. &
-          (sendtype == MPI_INTEGER) .and. (recvtype == MPI_INTEGER)) then
-         if (allocated(test_preflight_mismatch_flags)) deallocate (test_preflight_mismatch_flags)
-         call MPI_Comm_size(comm, nvalues, test_mpierr)
-         if (test_mpierr == MPI_SUCCESS) then
-            allocate (test_preflight_mismatch_flags(nvalues))
-            test_preflight_mismatch_flags = recvbuf(1:nvalues)
-         end if
-      end if
-   end subroutine ftimer_test_mpi_allgather
 #endif
 #endif
 

--- a/src/ftimer_mpi.F90
+++ b/src/ftimer_mpi.F90
@@ -13,6 +13,22 @@ module ftimer_mpi
    public :: check_mpi_summary_prereqs
    public :: ftimer_mpi_enabled
    public :: get_mpi_summary_comm_info
+#ifdef FTIMER_BUILD_TESTS
+#ifdef FTIMER_USE_MPI
+   public :: ftimer_test_get_mpi_preflight_collectives
+   public :: ftimer_test_reset_mpi_preflight_collectives
+#endif
+#endif
+
+#ifdef FTIMER_BUILD_TESTS
+#ifdef FTIMER_USE_MPI
+   integer :: test_preflight_allgather_count = 0
+   integer :: test_preflight_mismatch_flag_allgather_count = 0
+   ! Test builds route preflight Allgather calls through this wrapper so
+   ! runtime tests can assert the successful preflight collective shape.
+#define MPI_Allgather ftimer_test_mpi_allgather
+#endif
+#endif
 
 contains
 
@@ -883,6 +899,41 @@ contains
          rank_list = rank_list(1:available_len - 3)//'...'
       end if
    end subroutine mark_rank_list_truncated
+
+#ifdef FTIMER_BUILD_TESTS
+#undef MPI_Allgather
+   subroutine ftimer_test_reset_mpi_preflight_collectives()
+      test_preflight_allgather_count = 0
+      test_preflight_mismatch_flag_allgather_count = 0
+   end subroutine ftimer_test_reset_mpi_preflight_collectives
+
+   subroutine ftimer_test_get_mpi_preflight_collectives(allgather_count, mismatch_flag_allgather_count)
+      integer, intent(out) :: allgather_count
+      integer, intent(out) :: mismatch_flag_allgather_count
+
+      allgather_count = test_preflight_allgather_count
+      mismatch_flag_allgather_count = test_preflight_mismatch_flag_allgather_count
+   end subroutine ftimer_test_get_mpi_preflight_collectives
+
+   subroutine ftimer_test_mpi_allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, mpierr)
+      integer, intent(in) :: sendbuf
+      integer, intent(in) :: sendcount
+      integer, intent(in) :: sendtype
+      integer, intent(out) :: recvbuf(*)
+      integer, intent(in) :: recvcount
+      integer, intent(in) :: recvtype
+      integer, intent(in) :: comm
+      integer, intent(out) :: mpierr
+
+      test_preflight_allgather_count = test_preflight_allgather_count + 1
+      if ((sendcount == 1) .and. (recvcount == 1) .and. &
+          (sendtype == MPI_INTEGER) .and. (recvtype == MPI_INTEGER)) then
+         test_preflight_mismatch_flag_allgather_count = test_preflight_mismatch_flag_allgather_count + 1
+      end if
+
+      call MPI_Allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, mpierr)
+   end subroutine ftimer_test_mpi_allgather
+#endif
 #endif
 
    real(wp) function compute_imbalance(max_time, avg_time) result(imbalance)

--- a/src/ftimer_mpi.F90
+++ b/src/ftimer_mpi.F90
@@ -16,6 +16,7 @@ module ftimer_mpi
 #ifdef FTIMER_BUILD_TESTS
 #ifdef FTIMER_USE_MPI
    public :: ftimer_test_get_mpi_preflight_collectives
+   public :: ftimer_test_get_mpi_preflight_mismatch_flags
    public :: ftimer_test_reset_mpi_preflight_collectives
 #endif
 #endif
@@ -24,8 +25,11 @@ module ftimer_mpi
 #ifdef FTIMER_USE_MPI
    integer :: test_preflight_allgather_count = 0
    integer :: test_preflight_mismatch_flag_allgather_count = 0
-   ! Test builds route preflight Allgather calls through this wrapper so
-   ! runtime tests can assert the successful preflight collective shape.
+   integer :: test_preflight_summary_reduction_count = 0
+   integer, allocatable :: test_preflight_mismatch_flags(:)
+   ! Test builds route preflight Allgather calls through this wrapper and
+   ! mark the first summary reduction phase so runtime tests can assert the
+   ! descriptor-preflight collective shape.
 #define MPI_Allgather ftimer_test_mpi_allgather
 #endif
 #endif
@@ -251,6 +255,10 @@ contains
          status = FTIMER_ERR_MPI_INCON
          return
       end if
+
+#ifdef FTIMER_BUILD_TESTS
+      call ftimer_test_note_mpi_summary_reductions()
+#endif
 
       call MPI_Allreduce(local_summary%total_time, min_total_time, 1, mpi_wp_type, MPI_MIN, active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) then
@@ -905,15 +913,35 @@ contains
    subroutine ftimer_test_reset_mpi_preflight_collectives()
       test_preflight_allgather_count = 0
       test_preflight_mismatch_flag_allgather_count = 0
+      test_preflight_summary_reduction_count = 0
+      if (allocated(test_preflight_mismatch_flags)) deallocate (test_preflight_mismatch_flags)
    end subroutine ftimer_test_reset_mpi_preflight_collectives
 
-   subroutine ftimer_test_get_mpi_preflight_collectives(allgather_count, mismatch_flag_allgather_count)
+   subroutine ftimer_test_get_mpi_preflight_collectives(allgather_count, mismatch_flag_allgather_count, &
+                                                        summary_reduction_count)
       integer, intent(out) :: allgather_count
       integer, intent(out) :: mismatch_flag_allgather_count
+      integer, intent(out) :: summary_reduction_count
 
       allgather_count = test_preflight_allgather_count
       mismatch_flag_allgather_count = test_preflight_mismatch_flag_allgather_count
+      summary_reduction_count = test_preflight_summary_reduction_count
    end subroutine ftimer_test_get_mpi_preflight_collectives
+
+   subroutine ftimer_test_get_mpi_preflight_mismatch_flags(mismatch_flags)
+      integer, allocatable, intent(out) :: mismatch_flags(:)
+
+      if (allocated(test_preflight_mismatch_flags)) then
+         allocate (mismatch_flags(size(test_preflight_mismatch_flags)))
+         mismatch_flags = test_preflight_mismatch_flags
+      else
+         allocate (mismatch_flags(0))
+      end if
+   end subroutine ftimer_test_get_mpi_preflight_mismatch_flags
+
+   subroutine ftimer_test_note_mpi_summary_reductions()
+      test_preflight_summary_reduction_count = test_preflight_summary_reduction_count + 1
+   end subroutine ftimer_test_note_mpi_summary_reductions
 
    subroutine ftimer_test_mpi_allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, mpierr)
       integer, intent(in) :: sendbuf
@@ -924,6 +952,8 @@ contains
       integer, intent(in) :: recvtype
       integer, intent(in) :: comm
       integer, intent(out) :: mpierr
+      integer :: nvalues
+      integer :: test_mpierr
 
       test_preflight_allgather_count = test_preflight_allgather_count + 1
       if ((sendcount == 1) .and. (recvcount == 1) .and. &
@@ -932,6 +962,15 @@ contains
       end if
 
       call MPI_Allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, mpierr)
+      if ((mpierr == MPI_SUCCESS) .and. (sendcount == 1) .and. (recvcount == 1) .and. &
+          (sendtype == MPI_INTEGER) .and. (recvtype == MPI_INTEGER)) then
+         if (allocated(test_preflight_mismatch_flags)) deallocate (test_preflight_mismatch_flags)
+         call MPI_Comm_size(comm, nvalues, test_mpierr)
+         if (test_mpierr == MPI_SUCCESS) then
+            allocate (test_preflight_mismatch_flags(nvalues))
+            test_preflight_mismatch_flags = recvbuf(1:nvalues)
+         end if
+      end if
    end subroutine ftimer_test_mpi_allgather
 #endif
 #endif

--- a/tests/mpi/test_mpi_consistency.pf
+++ b/tests/mpi/test_mpi_consistency.pf
@@ -2,6 +2,8 @@ module test_mpi_consistency
    use pfunit
    use mpi
    use ftimer_core, only: ftimer_t
+   use ftimer_mpi, only: ftimer_test_get_mpi_preflight_collectives, &
+                         ftimer_test_reset_mpi_preflight_collectives
    use ftimer_types, only: FTIMER_ERR_MPI_INCON, FTIMER_ERR_UNKNOWN, FTIMER_NAME_LEN, FTIMER_SUCCESS, &
                            ftimer_mpi_summary_t, wp
    use test_support, only: attach_mock_clock, begin_stderr_capture, end_stderr_capture, fake_time
@@ -193,6 +195,68 @@ contains
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
    end subroutine test_mpi_summary_rejects_mpi_comm_null_before_collectives
+
+   @test
+   subroutine test_success_preflight_has_no_allgather(this)
+      class(mpi_consistency_case), intent(inout) :: this
+      type(ftimer_t) :: timer
+      type(ftimer_mpi_summary_t) :: summary
+      integer :: allgather_count
+      integer :: ierr
+      integer :: mismatch_flag_allgather_count
+
+      call ftimer_test_reset_mpi_preflight_collectives()
+
+      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(timer)
+
+      call build_tied_timer_set(timer, ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call timer%mpi_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call ftimer_test_get_mpi_preflight_collectives(allgather_count, mismatch_flag_allgather_count)
+
+      @assertEqual(0, allgather_count)
+      @assertEqual(0, mismatch_flag_allgather_count)
+
+      call timer%finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_success_preflight_has_no_allgather
+
+   @test
+   subroutine test_mismatch_preflight_allgathers_flags_only(this)
+      class(mpi_consistency_case), intent(inout) :: this
+      type(ftimer_t) :: timer
+      type(ftimer_mpi_summary_t) :: summary
+      integer :: allgather_count
+      integer :: ierr
+      integer :: mismatch_flag_allgather_count
+      integer :: rank
+
+      rank = this%getProcessRank()
+      call ftimer_test_reset_mpi_preflight_collectives()
+
+      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(timer)
+
+      call build_inconsistent_contexts(timer, rank, ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call timer%mpi_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_ERR_MPI_INCON, ierr)
+
+      call ftimer_test_get_mpi_preflight_collectives(allgather_count, mismatch_flag_allgather_count)
+
+      @assertEqual(1, allgather_count)
+      @assertEqual(1, mismatch_flag_allgather_count)
+
+      call timer%finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_mismatch_preflight_allgathers_flags_only
 
    subroutine build_inconsistent_contexts(timer, rank, ierr)
       class(ftimer_t), intent(inout) :: timer

--- a/tests/mpi/test_mpi_consistency.pf
+++ b/tests/mpi/test_mpi_consistency.pf
@@ -3,6 +3,7 @@ module test_mpi_consistency
    use mpi
    use ftimer_core, only: ftimer_t
    use ftimer_mpi, only: ftimer_test_get_mpi_preflight_collectives, &
+                         ftimer_test_get_mpi_preflight_mismatch_flags, &
                          ftimer_test_reset_mpi_preflight_collectives
    use ftimer_types, only: FTIMER_ERR_MPI_INCON, FTIMER_ERR_UNKNOWN, FTIMER_NAME_LEN, FTIMER_SUCCESS, &
                            ftimer_mpi_summary_t, wp
@@ -202,8 +203,11 @@ contains
       type(ftimer_t) :: timer
       type(ftimer_mpi_summary_t) :: summary
       integer :: allgather_count
+      integer :: entry_count
       integer :: ierr
       integer :: mismatch_flag_allgather_count
+      integer :: parent_id
+      integer :: summary_reduction_count
 
       call ftimer_test_reset_mpi_preflight_collectives()
 
@@ -211,16 +215,24 @@ contains
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
-      call build_tied_timer_set(timer, ierr)
+      call build_tied_nested_timer_set(timer, ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
 
       call timer%mpi_summary(summary, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
 
-      call ftimer_test_get_mpi_preflight_collectives(allgather_count, mismatch_flag_allgather_count)
+      call ftimer_test_get_mpi_preflight_collectives(allgather_count, mismatch_flag_allgather_count, &
+                                                     summary_reduction_count)
 
+      entry_count = summary%num_entries
+      parent_id = -1
+      if (entry_count >= 2) parent_id = summary%entries(2)%parent_id
+
+      @assertEqual(2, entry_count)
+      @assertEqual(1, parent_id)
       @assertEqual(0, allgather_count)
       @assertEqual(0, mismatch_flag_allgather_count)
+      @assertEqual(1, summary_reduction_count)
 
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
@@ -233,8 +245,11 @@ contains
       type(ftimer_mpi_summary_t) :: summary
       integer :: allgather_count
       integer :: ierr
+      integer :: mismatch_flag_count
       integer :: mismatch_flag_allgather_count
+      integer, allocatable :: mismatch_flags(:)
       integer :: rank
+      integer :: summary_reduction_count
 
       rank = this%getProcessRank()
       call ftimer_test_reset_mpi_preflight_collectives()
@@ -249,10 +264,19 @@ contains
       call timer%mpi_summary(summary, ierr=ierr)
       @assertEqual(FTIMER_ERR_MPI_INCON, ierr)
 
-      call ftimer_test_get_mpi_preflight_collectives(allgather_count, mismatch_flag_allgather_count)
+      call ftimer_test_get_mpi_preflight_collectives(allgather_count, mismatch_flag_allgather_count, &
+                                                     summary_reduction_count)
+      call ftimer_test_get_mpi_preflight_mismatch_flags(mismatch_flags)
+      mismatch_flag_count = size(mismatch_flags)
 
       @assertEqual(1, allgather_count)
       @assertEqual(1, mismatch_flag_allgather_count)
+      @assertEqual(0, summary_reduction_count)
+      @assertEqual(2, mismatch_flag_count)
+      if (mismatch_flag_count == 2) then
+         @assertEqual(0, mismatch_flags(1))
+         @assertEqual(1, mismatch_flags(2))
+      end if
 
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
@@ -319,6 +343,26 @@ contains
       fake_time = 6.0_wp
       call timer%stop("tie", ierr=ierr)
    end subroutine build_tied_timer_set
+
+   subroutine build_tied_nested_timer_set(timer, ierr)
+      class(ftimer_t), intent(inout) :: timer
+      integer, intent(out) :: ierr
+
+      fake_time = 0.0_wp
+      call timer%start("tie", ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) return
+
+      fake_time = 2.0_wp
+      call timer%start("inner", ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) return
+
+      fake_time = 5.0_wp
+      call timer%stop("inner", ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) return
+
+      fake_time = 6.0_wp
+      call timer%stop("tie", ierr=ierr)
+   end subroutine build_tied_nested_timer_set
 
    subroutine assert_real_close(actual, expected)
       real(wp), intent(in) :: actual

--- a/tests/mpi/test_mpi_consistency_4pe.pf
+++ b/tests/mpi/test_mpi_consistency_4pe.pf
@@ -2,7 +2,9 @@ module test_mpi_consistency_4pe
    use pfunit
    use mpi
    use ftimer_core, only: ftimer_t
-   use ftimer_mpi, only: build_mpi_summary
+   use ftimer_mpi, only: build_mpi_summary, ftimer_test_get_mpi_preflight_collectives, &
+                         ftimer_test_get_mpi_preflight_mismatch_flags, &
+                         ftimer_test_reset_mpi_preflight_collectives
    use ftimer_types, only: FTIMER_ERR_MPI_INCON, FTIMER_SUCCESS, ftimer_mpi_summary_t, ftimer_summary_t, wp
    use test_support, only: attach_mock_clock, begin_stderr_capture, end_stderr_capture, fake_time
    implicit none
@@ -108,6 +110,52 @@ contains
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
    end subroutine test_mpi_summary_no_global_result_for_hierarchy_mismatch
+
+   @test
+   subroutine test_mpi_summary_records_partial_mismatch_flags(this)
+      class(mpi_consistency_4pe_case), intent(inout) :: this
+      type(ftimer_t) :: timer
+      type(ftimer_mpi_summary_t) :: summary
+      integer :: allgather_count
+      integer :: ierr
+      integer :: mismatch_flag_allgather_count
+      integer :: mismatch_flag_count
+      integer, allocatable :: mismatch_flags(:)
+      integer :: rank
+      integer :: summary_reduction_count
+
+      rank = this%getProcessRank()
+      call ftimer_test_reset_mpi_preflight_collectives()
+
+      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(timer)
+
+      call build_rank_one_hierarchy_mismatch(timer, rank, ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call timer%mpi_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_ERR_MPI_INCON, ierr)
+
+      call ftimer_test_get_mpi_preflight_collectives(allgather_count, mismatch_flag_allgather_count, &
+                                                     summary_reduction_count)
+      call ftimer_test_get_mpi_preflight_mismatch_flags(mismatch_flags)
+      mismatch_flag_count = size(mismatch_flags)
+
+      @assertEqual(1, allgather_count)
+      @assertEqual(1, mismatch_flag_allgather_count)
+      @assertEqual(0, summary_reduction_count)
+      @assertEqual(4, mismatch_flag_count)
+      if (mismatch_flag_count == 4) then
+         @assertEqual(0, mismatch_flags(1))
+         @assertEqual(1, mismatch_flags(2))
+         @assertEqual(0, mismatch_flags(3))
+         @assertEqual(0, mismatch_flags(4))
+      end if
+
+      call timer%finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_mpi_summary_records_partial_mismatch_flags
 
    @test
    subroutine test_mpi_summary_reports_all_disagreeing_ranks_on_mismatch(this)
@@ -376,5 +424,38 @@ contains
          call timer%stop("work", ierr=ierr)
       end if
    end subroutine build_four_rank_hierarchy_mismatch
+
+   subroutine build_rank_one_hierarchy_mismatch(timer, rank, ierr)
+      class(ftimer_t), intent(inout) :: timer
+      integer, intent(in) :: rank
+      integer, intent(out) :: ierr
+
+      fake_time = 0.0_wp
+      call timer%start("outer", ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) return
+
+      if (rank == 1) then
+         fake_time = 2.0_wp + real(rank, wp)
+         call timer%stop("outer", ierr=ierr)
+         if (ierr /= FTIMER_SUCCESS) return
+
+         call timer%start("work", ierr=ierr)
+         if (ierr /= FTIMER_SUCCESS) return
+
+         fake_time = 6.0_wp + real(rank, wp)
+         call timer%stop("work", ierr=ierr)
+      else
+         fake_time = 2.0_wp + real(rank, wp)
+         call timer%start("work", ierr=ierr)
+         if (ierr /= FTIMER_SUCCESS) return
+
+         fake_time = 5.0_wp + real(rank, wp)
+         call timer%stop("work", ierr=ierr)
+         if (ierr /= FTIMER_SUCCESS) return
+
+         fake_time = 7.0_wp + real(rank, wp)
+         call timer%stop("outer", ierr=ierr)
+      end if
+   end subroutine build_rank_one_hierarchy_mismatch
 
 end module test_mpi_consistency_4pe


### PR DESCRIPTION
Closes #174.

Summary:
- Add a test-only MPI preflight Allgather counter seam in ftimer_mpi.
- Add MPI pFUnit coverage proving the successful descriptor preflight performs no Allgather and the mismatch path only Allgathers mismatch flags.

Validation:
- cmake --build build-tests-mpi --target ftimer_mpi_tests
- ctest --test-dir build-tests-mpi --output-on-failure -L mpi
- cmake -B build-smoke
- cmake --build build-smoke
- ctest --test-dir build-smoke --output-on-failure
- cmake --build build-tests --target ftimer_serial_tests
- ctest --test-dir build-tests --output-on-failure -R ftimer_serial_tests
- fprettify --diff src/ftimer_mpi.F90 tests/mpi/test_mpi_consistency.pf
- git diff --check