### PR TITLE
Adopt mpi_f08 as primary MPI contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Supported toolchain matrix:
 
 - Serial smoke/library build: GNU Fortran and LLVM Flang are the validated automation paths.
 - Serial + pFUnit tests: GNU Fortran (`gfortran`) with a pFUnit installation built for the same compiler/toolchain.
-- MPI: an MPI wrapper compiler such as `mpifort`. `FTIMER_USE_MPI=ON` now runs a configure-time `use mpi` probe and fails early if the active compiler cannot consume the discovered MPI module files.
+- MPI: an MPI wrapper compiler such as `mpifort`. `FTIMER_USE_MPI=ON` now runs a configure-time `mpi_f08` probe and fails early if the active compiler cannot consume the discovered MPI module files.
 - OpenMP: GNU Fortran (`gfortran`) only for the documented/supported path.
 
 Other serial compilers may still work, but they are not part of the current release-validated matrix unless the repo adds direct automation for them.
@@ -93,7 +93,7 @@ ftimer.F90  (procedural wrappers + default global instance)
 - **Context-sensitive accounting**: The same timer name under different parent call stacks is tracked independently.
 - **Exclusive/self time**: Computed as inclusive time minus sum of direct children's inclusive times.
 - **Callback hooks**: Configure callbacks through `set_callback()` / `clear_callback()`. The hook fires on normal start/stop events only; internal repair transitions do NOT fire callbacks.
-- **MPI interface contract**: The current validated MPI path is `use mpi` with integer communicator handles captured at `init`. Broader `mpif.h` or `mpi_f08` compatibility is not part of the current documented contract.
+- **MPI interface contract**: The primary validated MPI path is `mpi_f08` with `type(MPI_Comm)` communicator handles captured at `init`. Legacy integer communicator handles are accepted as transitional compatibility. `mpif.h` is not part of the current documented contract.
 - **OpenMP master-thread-only timing**: When built with `FTIMER_USE_OPENMP=ON`, all guarded timer operations run only on the master thread (thread 0). Worker-thread calls are silent no-ops: no summary entry is created, no call count is incremented, and no `ierr` is set. Timer calls made exclusively on worker threads produce no summary entry. The supported pattern is to place `start`/`stop` outside `!$omp parallel` blocks. Placing `start`/`stop` inside a parallel region expecting each thread to contribute is the misleading anti-pattern. See `docs/semantics.md` "Consequences for timing data" for the full contract.
 
 ### Key Data Flow
@@ -241,7 +241,7 @@ The native Codex trigger comments are intentionally posted as single-line `@code
 
 ## Configuration
 
-- **`FTIMER_USE_MPI`** (CMake option, default OFF): Enables MPI support. When ON, `MPI_Wtime()` is used as the clock source and `mpi_summary()` can populate cross-rank fields. The supported path is an MPI wrapper compiler such as `mpifort`; configure now fails early if the active compiler cannot compile a minimal `use mpi` probe against the discovered MPI toolchain. When OFF, `mpi_summary()` returns `FTIMER_ERR_NOT_IMPLEMENTED` and leaves the summary local-only.
+- **`FTIMER_USE_MPI`** (CMake option, default OFF): Enables MPI support. When ON, `MPI_Wtime()` is used as the clock source and `mpi_summary()` can populate cross-rank fields. The supported path is an MPI wrapper compiler such as `mpifort`; configure now fails early if the active compiler cannot compile a minimal `mpi_f08` probe against the discovered MPI toolchain. When OFF, `mpi_summary()` returns `FTIMER_ERR_NOT_IMPLEMENTED` and leaves the summary local-only.
 - **`FTIMER_USE_OPENMP`** (CMake option, default OFF): Enables the Phase 6 `!$omp master` guards around the guarded `ftimer_core` entry points. This is limited master-thread-only protection, not full thread safety. The documented/supported build path is GNU Fortran (`gfortran`).
 - **`FTIMER_BUILD_SMOKE_TESTS`** (CMake option, default ON): Enables the current smoke-test baseline, including install/export consumer verification and the script-driven build-contract regression checks when their toolchain prerequisites are available.
 - **`FTIMER_BUILD_TESTS`** (CMake option, default OFF): Enables the pFUnit-backed behavioral and MPI test suites.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Supported toolchain matrix:
 
 - Serial smoke/library build: GNU Fortran and LLVM Flang are the validated automation paths.
 - Serial + pFUnit tests: GNU Fortran (`gfortran`) with a pFUnit installation built for the same compiler/toolchain.
-- MPI: an MPI wrapper compiler such as `mpifort`. `FTIMER_USE_MPI=ON` now runs a configure-time `use mpi` probe and fails early if the active compiler cannot consume the discovered MPI module files.
+- MPI: an MPI wrapper compiler such as `mpifort`. `FTIMER_USE_MPI=ON` now runs a configure-time `mpi_f08` probe and fails early if the active compiler cannot consume the discovered MPI module files.
 - OpenMP: GNU Fortran (`gfortran`) only for the documented/supported path.
 
 Other serial compilers may still work, but they are not part of the current release-validated matrix unless the repo adds direct automation for them.
@@ -93,7 +93,7 @@ ftimer.F90  (procedural wrappers + default global instance)
 - **Context-sensitive accounting**: The same timer name under different parent call stacks is tracked independently.
 - **Exclusive/self time**: Computed as inclusive time minus sum of direct children's inclusive times.
 - **Callback hooks**: Configure callbacks through `set_callback()` / `clear_callback()`. The hook fires on normal start/stop events only; internal repair transitions do NOT fire callbacks.
-- **MPI interface contract**: The current validated MPI path is `use mpi` with integer communicator handles captured at `init`. Broader `mpif.h` or `mpi_f08` compatibility is not part of the current documented contract.
+- **MPI interface contract**: The primary validated MPI path is `mpi_f08` with `type(MPI_Comm)` communicator handles captured at `init`. Legacy integer communicator handles are accepted as transitional compatibility. `mpif.h` is not part of the current documented contract.
 - **OpenMP master-thread-only timing**: When built with `FTIMER_USE_OPENMP=ON`, all guarded timer operations run only on the master thread (thread 0). Worker-thread calls are silent no-ops: no summary entry is created, no call count is incremented, and no `ierr` is set. Timer calls made exclusively on worker threads produce no summary entry. The supported pattern is to place `start`/`stop` outside `!$omp parallel` blocks. Placing `start`/`stop` inside a parallel region expecting each thread to contribute is the misleading anti-pattern. See `docs/semantics.md` "Consequences for timing data" for the full contract.
 
 ### Key Data Flow
@@ -240,7 +240,7 @@ The native Codex trigger comments are intentionally posted as single-line `@code
 
 ## Configuration
 
-- **`FTIMER_USE_MPI`** (CMake option, default OFF): Enables MPI support. When ON, `MPI_Wtime()` is used as the clock source and `mpi_summary()` can populate cross-rank fields. The supported path is an MPI wrapper compiler such as `mpifort`; configure now fails early if the active compiler cannot compile a minimal `use mpi` probe against the discovered MPI toolchain. When OFF, `mpi_summary()` returns `FTIMER_ERR_NOT_IMPLEMENTED` and leaves the summary local-only.
+- **`FTIMER_USE_MPI`** (CMake option, default OFF): Enables MPI support. When ON, `MPI_Wtime()` is used as the clock source and `mpi_summary()` can populate cross-rank fields. The supported path is an MPI wrapper compiler such as `mpifort`; configure now fails early if the active compiler cannot compile a minimal `mpi_f08` probe against the discovered MPI toolchain. When OFF, `mpi_summary()` returns `FTIMER_ERR_NOT_IMPLEMENTED` and leaves the summary local-only.
 - **`FTIMER_USE_OPENMP`** (CMake option, default OFF): Enables the Phase 6 `!$omp master` guards around the guarded `ftimer_core` entry points. This is limited master-thread-only protection, not full thread safety. The documented/supported build path is GNU Fortran (`gfortran`).
 - **`FTIMER_BUILD_SMOKE_TESTS`** (CMake option, default ON): Enables the current smoke-test baseline, including install/export consumer verification and the script-driven build-contract regression checks when their toolchain prerequisites are available.
 - **`FTIMER_BUILD_TESTS`** (CMake option, default OFF): Enables the pFUnit-backed behavioral and MPI test suites.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,15 @@ function(ftimer_try_compile_mpi out_var)
   set(_ftimer_mpi_probe_src "${CMAKE_BINARY_DIR}/CMakeFiles/ftimer_mpi_probe.F90")
   file(WRITE "${_ftimer_mpi_probe_src}" [=[
 program ftimer_mpi_probe
-  use mpi
+  use mpi_f08
   implicit none
   integer :: ierr
+  integer :: rank
+  type(MPI_Comm) :: comm
 
   call MPI_Init(ierr)
+  comm = MPI_COMM_WORLD
+  call MPI_Comm_rank(comm, rank, ierr)
   call MPI_Finalize(ierr)
 end program ftimer_mpi_probe
 ]=])
@@ -36,12 +40,12 @@ function(ftimer_try_compile_mpi_datatype_probe out_var)
   file(WRITE "${_ftimer_mpi_datatype_probe_src}" [=[
 program ftimer_mpi_datatype_probe
   use, intrinsic :: iso_fortran_env, only: int64
-  use mpi
+  use mpi_f08
   implicit none
 
   integer, parameter :: wp = selected_real_kind(15, 307)
-  integer :: dtype
-  integer :: errhandler
+  type(MPI_Datatype) :: dtype
+  type(MPI_Errhandler) :: errhandler
   integer :: ierr
   integer :: nbytes
 
@@ -89,7 +93,7 @@ if(FTIMER_USE_MPI)
   ftimer_try_compile_mpi(FTIMER_MPI_TOOLCHAIN_OK)
   if(NOT FTIMER_MPI_TOOLCHAIN_OK)
     message(FATAL_ERROR
-      "FTIMER_USE_MPI=ON requires a compiler/toolchain pair that can compile 'use mpi' against the discovered MPI installation.\n"
+      "FTIMER_USE_MPI=ON requires a compiler/toolchain pair that can compile 'use mpi_f08' against the discovered MPI installation.\n"
       "CMake found MPI, but the active Fortran compiler '${CMAKE_Fortran_COMPILER}' failed a configure-time MPI probe.\n"
       "Supported path: select an MPI wrapper compiler from the same toolchain, for example 'FC=mpifort cmake -B build-mpi -DFTIMER_USE_MPI=ON ...' or '-DCMAKE_Fortran_COMPILER=mpifort'.\n"
       "Plain compiler + find_package(MPI) is not treated as a documented supported path unless that probe succeeds."
@@ -99,8 +103,8 @@ if(FTIMER_USE_MPI)
   ftimer_try_compile_mpi_datatype_probe(FTIMER_MPI_DATATYPES_PROBE_OK)
   if(NOT FTIMER_MPI_DATATYPES_PROBE_OK)
     message(FATAL_ERROR
-      "FTIMER_USE_MPI=ON requires an MPI 'use mpi' implementation that exposes MPI_Type_match_size for validating fTimer's real(wp) and integer(int64) reduction datatypes.\n"
-      "This configure-time probe is intentionally separate from the broader mpi_f08 migration tracked in #136."
+      "FTIMER_USE_MPI=ON requires an MPI 'mpi_f08' implementation that exposes MPI_Type_match_size for validating fTimer's real(wp) and integer(int64) reduction datatypes.\n"
+      "This configure-time probe intentionally validates the primary mpi_f08 contract."
     )
   endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you need a tiny serial timing helper, you can use fTimer that way. If you nee
 fTimer currently supports these usage paths:
 
 - Serial timing with local summaries plus formatted text and CSV reports
-- Pure-MPI builds on the validated `use mpi` path that use `MPI_Wtime()`, produce global MPI summaries on every participating rank, and can emit communicator-level text and CSV reports
+- Pure-MPI builds on the validated `mpi_f08` path that use `MPI_Wtime()`, produce global MPI summaries on every participating rank, and can emit communicator-level text and CSV reports
 - A narrow OpenMP carve-out: master-thread-only timer guards for timing a parallel region as a whole
 - Downstream consumption through `find_package(fTimer CONFIG REQUIRED)`
 - Application-owned instrumentation facades that can select either the real fTimer implementation or a dependency-free no-op implementation at build time
@@ -203,7 +203,7 @@ New users should start with the procedural API unless they already know they nee
 
 Operational notes:
 
-- `ierr` is now the last optional argument in both `init` signatures (`comm`, `mismatch_mode`, `ierr`), so a single positional integer binds to `comm`, not `ierr`. Keywords are recommended for readability.
+- `ierr` is now the last optional argument in the `init` signatures. In MPI builds, the primary communicator form is `type(MPI_Comm)` from `mpi_f08`; integer communicator handles are accepted as transitional compatibility. A single positional integer still binds to that compatibility `comm` path, not `ierr`. Keywords are recommended for readability.
 - `init`, `reset`, and `finalize` are correctness-first on active timers: with `ierr` they return `FTIMER_ERR_ACTIVE`; without `ierr` they warn and leave state unchanged. In `FTIMER_USE_OPENMP=ON` builds, that diagnostic contract applies on the master thread; worker-thread lifecycle calls remain silent no-ops. These paths do not force-stop active timers or synthesize summary data.
 - Stop-mismatch repair remains an explicit `mismatch_mode` choice (`FTIMER_MISMATCH_WARN` or `FTIMER_MISMATCH_REPAIR`); omitted-`ierr` alone does not opt a caller into recovery.
 - Timer names are right-trimmed and must be non-empty, must not begin with a blank, and must not contain ASCII control characters. fTimer does not silently truncate timer names and no longer rejects names solely for exceeding the legacy `FTIMER_NAME_LEN = 64` threshold.
@@ -317,9 +317,9 @@ Use a separate build directory for each compiler or mode. Reconfiguring the same
 - CMake is the supported build and package path. FPM support is intentionally deferred.
 - fTimer is wall-clock only. It does not synchronize asynchronous accelerator/device work, so callers must perform any required device synchronization before `stop` when they intend to measure completed device work rather than host launch/enqueue latency.
 - fTimer does not insert MPI barriers around timed regions. MPI summaries reduce rank-local intervals; callers must add any desired MPI synchronization themselves when they intend to measure a synchronized global phase.
-- `FTIMER_USE_MPI=ON` is intended for wrapper-compiler setups such as `FC=mpifort`. Configure now fails early if the active compiler cannot compile a minimal `use mpi` probe against the discovered MPI installation, or if that `use mpi` path cannot compile the `MPI_Type_match_size`/`MPI_ERRORS_RETURN` calls fTimer uses to validate reduction datatypes.
-- The current validated MPI interface contract is the `use mpi` path with integer communicator handles captured at `init`. Broader `mpif.h` or `mpi_f08` compatibility is not yet part of the documented release contract.
-- MPI summary reductions select MPI datatypes with `MPI_Type_match_size` for fTimer's actual `real(wp)` and `integer(int64)` storage sizes instead of assuming fixed `MPI_DOUBLE_PRECISION`, `MPI_2DOUBLE_PRECISION`, or `MPI_INTEGER8` mappings. The compile-time MPI probe validates that this API is available through the current `use mpi` path; if the API exists but no matching runtime datatype can be returned, `mpi_summary()` temporarily requests MPI error returns for the datatype lookup, fails with `FTIMER_ERR_UNKNOWN`, and leaves the MPI result empty. This is a targeted guard for the current `use mpi` implementation; the broader `mpi_f08` migration remains tracked separately in GitHub issue #136.
+- `FTIMER_USE_MPI=ON` is intended for wrapper-compiler setups such as `FC=mpifort`. Configure now fails early if the active compiler cannot compile a minimal `mpi_f08` probe against the discovered MPI installation, or if that `mpi_f08` path cannot compile the `MPI_Type_match_size`/`MPI_ERRORS_RETURN` calls fTimer uses to validate reduction datatypes.
+- The current primary MPI interface contract is `mpi_f08` with `type(MPI_Comm)` communicator handles captured at `init`. Legacy integer communicator handles are accepted as transitional compatibility pending #187; `mpif.h` is not a supported interface path.
+- MPI summary reductions select MPI datatypes with `MPI_Type_match_size` for fTimer's actual `real(wp)` and `integer(int64)` storage sizes instead of assuming fixed `MPI_DOUBLE_PRECISION`, `MPI_2DOUBLE_PRECISION`, or `MPI_INTEGER8` mappings. The compile-time MPI probe validates that this API is available through the `mpi_f08` path; if the API exists but no matching runtime datatype can be returned, `mpi_summary()` temporarily requests MPI error returns for the datatype lookup, fails with `FTIMER_ERR_UNKNOWN`, and leaves the MPI result empty.
 - `mpi_summary()` now returns a distinct `ftimer_mpi_summary_t`; it does not fall back to a local `ftimer_summary_t` on MPI-disabled or MPI-error paths. Call `get_summary()` separately if you need local data in those cases.
 - Descriptor-preflight failures inside one communicator now report the disagreeing communicator-local ranks in the omitted-`ierr` diagnostic path when possible.
 - Rank-conditional timer reductions are not supported by the current strict `mpi_summary()` API. Sparse/union MPI summaries are planned as a separate opt-in path; see [`docs/mpi-sparse-summary-decision.md`](docs/mpi-sparse-summary-decision.md).

--- a/docs/design.md
+++ b/docs/design.md
@@ -173,6 +173,7 @@ The currently exported procedural entry points are:
 Important current-state API notes:
 
 - `ierr` is now the last optional argument in the `init` signatures. Keywords are recommended for readability.
+- In MPI builds, the primary communicator argument is `type(MPI_Comm)` from `mpi_f08`; integer communicator handles are accepted only as transitional compatibility pending #187.
 - `init`, `reset`, and `finalize` treat active timers as an error in both API styles. With `ierr` they return `FTIMER_ERR_ACTIVE`; without `ierr` they warn and leave state untouched rather than force-stopping or cleaning up implicitly. In `FTIMER_USE_OPENMP=ON` builds, that lifecycle-diagnostic contract applies on the master thread; non-master lifecycle calls remain suppressed no-ops.
 - Repairing stop mismatches remains an explicit `mismatch_mode` decision; omitted `ierr` alone is not a recovery mode.
 - Name-based `start`/`stop` remains the default user path. `lookup()` plus `start_id()`/`stop_id()` is documented as an optional cached-id hot path rather than a separate primary workflow.
@@ -214,8 +215,8 @@ The top-level CMake options that shape those paths are:
 
 The MPI and OpenMP enablement paths are guarded at configure time:
 
-- `FTIMER_USE_MPI=ON` requires a compiler/toolchain pair that can compile a minimal `use mpi` probe against the discovered MPI installation.
-- MPI builds also require the same `use mpi` path to compile the `MPI_Type_match_size`/`MPI_ERRORS_RETURN` validation calls used to select reduction datatypes for `real(wp)` and `integer(int64)` without completing the broader `mpi_f08` migration tracked in #136.
+- `FTIMER_USE_MPI=ON` requires a compiler/toolchain pair that can compile a minimal `mpi_f08` probe against the discovered MPI installation.
+- MPI builds also require the same `mpi_f08` path to compile the `MPI_Type_match_size`/`MPI_ERRORS_RETURN` validation calls used to select reduction datatypes for `real(wp)` and `integer(int64)`.
 - `FTIMER_USE_OPENMP=ON` is currently supported only with GNU Fortran and requires `OpenMP::OpenMP_Fortran` to resolve successfully.
 
 ### Test Categories

--- a/docs/mpi-sparse-summary-decision.md
+++ b/docs/mpi-sparse-summary-decision.md
@@ -28,7 +28,7 @@ The current implementation is strict by construction:
 Prior MPI cleanup work supports keeping the default strict path:
 
 - #119 replaced the earlier hybrid local-plus-reduced result with a distinct `ftimer_mpi_summary_t` and first-class MPI report paths.
-- #124 narrowed the MPI contract to the validated `use mpi` path, added extrema-rank attribution, and improved descriptor mismatch diagnostics.
+- #124 narrowed the MPI summary contract, added extrema-rank attribution, and improved descriptor mismatch diagnostics.
 - #129 positioned fTimer around disciplined serial and pure-MPI timing with correctness-first contracts.
 
 ## Rationale

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -185,8 +185,9 @@ This disabled-facade behavior is an application integration contract, not an alt
 - Omitting `comm` at `init` means `mpi_summary()` uses `MPI_COMM_WORLD`
 - All ranks in that communicator must enter `mpi_summary()` with fully stopped timers
 - Unlike local summaries, MPI summaries are final stopped-run summaries only; active timers return `FTIMER_ERR_ACTIVE`
-- The current validated MPI interface path is `use mpi` with integer communicator handles captured at `init`
-- `FTIMER_USE_MPI=ON` configure requires that the active `use mpi` path compile the `MPI_Type_match_size` and `MPI_ERRORS_RETURN` calls used for datatype validation
+- The primary MPI interface path is `mpi_f08` with `type(MPI_Comm)` communicator handles captured at `init`
+- Integer communicator handles are accepted by `init` as transitional compatibility for pre-`mpi_f08` callers pending #187; `mpif.h` is not a supported interface path
+- `FTIMER_USE_MPI=ON` configure requires that the active `mpi_f08` path compile the `MPI_Type_match_size` and `MPI_ERRORS_RETURN` calls used for datatype validation
 - MPI summary reductions select MPI datatypes with `MPI_Type_match_size` for the actual `real(wp)` and `integer(int64)` storage sizes before reducing those buffers. If that validation API is present but the active MPI implementation cannot provide matching datatypes at runtime, `mpi_summary()` temporarily requests MPI error returns for the datatype lookup, fails with `FTIMER_ERR_UNKNOWN`, and leaves the MPI result empty instead of reducing through a mismatched fixed datatype.
 - Hash-based timer-descriptor preflight before the reduction phase
 - The strict MPI preflight compares rank-local descriptor hashes against a rank-0 reference hash, then reduces a mismatch flag across the communicator. Successful summaries do not allgather every rank's hashes or exchange exact descriptor strings.
@@ -215,7 +216,7 @@ The supported pattern is simple: capture one communicator consistently at `init`
 - `ftimer_mpi_summary_t` entries retain `name`, `depth`, `node_id`, and `parent_id`, so MPI summaries keep the explicit-tree data model instead of collapsing to flat rows.
 - The MPI summary tree order is canonical across ranks. It does not depend on the local timer creation order on one chosen rank.
 - `mpi_summary()` does not return local fallback data on errors. If the caller needs local data after an MPI-disabled or MPI-error path, it must call `get_summary()` separately.
-- This datatype selection is a targeted portability guard for the current `use mpi` implementation. The broader `mpi_f08` interface migration remains separate follow-up work tracked in GitHub issue #136.
+- This datatype selection remains the portability guard for the current `mpi_f08` implementation and preserves the reduction-datatype work completed before the interface migration.
 
 ## MPI Reporting Contract
 

--- a/examples/mpi_example.F90
+++ b/examples/mpi_example.F90
@@ -2,7 +2,7 @@ program mpi_example
    use ftimer, only: ftimer_finalize, ftimer_init, ftimer_mpi_summary, ftimer_print_mpi_summary, &
                      ftimer_start, ftimer_stop
    use ftimer_types, only: ftimer_mpi_summary_t
-   use mpi
+   use mpi_f08
    implicit none
    integer :: ierr
    integer :: i

--- a/src/ftimer.F90
+++ b/src/ftimer.F90
@@ -3,6 +3,9 @@ module ftimer
    use ftimer_core, only: ftimer_internal_start_scope_activation, ftimer_internal_stop_scope_activation, ftimer_t
    use ftimer_types, only: FTIMER_ERR_ACTIVE, FTIMER_SUCCESS, ftimer_metadata_t, ftimer_mpi_summary_t, &
                            ftimer_summary_t
+#ifdef FTIMER_USE_MPI
+   use mpi_f08, only: MPI_Comm
+#endif
    implicit none
    private
 
@@ -25,6 +28,17 @@ module ftimer
    public :: ftimer_write_mpi_summary
    public :: ftimer_write_mpi_summary_csv
    public :: ftimer_default_instance
+
+#ifdef FTIMER_USE_MPI
+   interface ftimer_init
+      module procedure ftimer_init_with_integer_comm
+      module procedure ftimer_init_with_mpi_comm
+   end interface
+#else
+   interface ftimer_init
+      module procedure ftimer_init_with_integer_comm
+   end interface
+#endif
 
    type(ftimer_t), save, target :: ftimer_default_instance
 
@@ -124,16 +138,23 @@ contains
       end if
    end subroutine report_guard_status
 
-   subroutine ftimer_init(comm, mismatch_mode, ierr)
+   subroutine ftimer_init_with_integer_comm(comm, mismatch_mode, ierr)
       integer, intent(in), optional :: comm
       integer, intent(in), optional :: mismatch_mode
       integer, intent(out), optional :: ierr
 
-      ! Contract: ierr is last to eliminate the positional intent(out) trap.
-      ! A single positional integer now binds to comm (intent(in)), not ierr.
-      ! Keywords are recommended for readability.
-      call ftimer_default_instance%init(ierr=ierr, comm=comm, mismatch_mode=mismatch_mode)
-   end subroutine ftimer_init
+      call ftimer_default_instance%init(comm=comm, mismatch_mode=mismatch_mode, ierr=ierr)
+   end subroutine ftimer_init_with_integer_comm
+
+#ifdef FTIMER_USE_MPI
+   subroutine ftimer_init_with_mpi_comm(comm, mismatch_mode, ierr)
+      type(MPI_Comm), intent(in) :: comm
+      integer, intent(in), optional :: mismatch_mode
+      integer, intent(out), optional :: ierr
+
+      call ftimer_default_instance%init(comm=comm, mismatch_mode=mismatch_mode, ierr=ierr)
+   end subroutine ftimer_init_with_mpi_comm
+#endif
 
    subroutine ftimer_finalize(ierr)
       integer, intent(out), optional :: ierr

--- a/src/ftimer_clock.F90
+++ b/src/ftimer_clock.F90
@@ -1,6 +1,9 @@
 module ftimer_clock
    use, intrinsic :: iso_fortran_env, only: int64
    use ftimer_types, only: wp
+#ifdef FTIMER_USE_MPI
+   use mpi_f08, only: MPI_Wtime
+#endif
    implicit none
    private
 
@@ -30,10 +33,6 @@ contains
 
    function ftimer_mpi_clock() result(t)
       real(wp) :: t
-#ifdef FTIMER_USE_MPI
-      double precision :: MPI_Wtime
-      external :: MPI_Wtime
-#endif
 
 #ifdef FTIMER_USE_MPI
       t = real(MPI_Wtime(), wp)

--- a/src/ftimer_core.F90
+++ b/src/ftimer_core.F90
@@ -834,7 +834,7 @@ contains
       state%initialized = self%initialized
       state%mismatch_mode = self%mismatch_mode
 #ifdef FTIMER_USE_MPI
-      state%mpi_comm = self%mpi_comm%MPI_VAL
+      if (self%initialized) state%mpi_comm = self%mpi_comm%MPI_VAL
       state%mpi_comm_was_present = self%mpi_comm_was_present
       state%mpi_rank = self%mpi_rank
       state%mpi_nprocs = self%mpi_nprocs

--- a/src/ftimer_core.F90
+++ b/src/ftimer_core.F90
@@ -7,6 +7,9 @@ module ftimer_core
                            FTIMER_MISMATCH_REPAIR, FTIMER_MISMATCH_STRICT, FTIMER_MISMATCH_WARN, FTIMER_SUCCESS, &
                            ftimer_call_stack_t, ftimer_clock_func, ftimer_hook_proc, ftimer_metadata_t, &
                            ftimer_mpi_summary_t, ftimer_segment_t, ftimer_summary_t, wp
+#ifdef FTIMER_USE_MPI
+   use mpi_f08, only: MPI_Comm, MPI_COMM_WORLD
+#endif
    implicit none
    private
 
@@ -39,6 +42,7 @@ module ftimer_core
       integer :: mismatch_mode = FTIMER_MISMATCH_STRICT
 #ifdef FTIMER_USE_MPI
       integer :: mpi_comm = -1
+      logical :: mpi_comm_was_present = .false.
       integer :: mpi_rank = -1
       integer :: mpi_nprocs = 1
 #endif
@@ -62,7 +66,8 @@ module ftimer_core
       logical :: initialized = .false.
       integer :: mismatch_mode = FTIMER_MISMATCH_STRICT
 #ifdef FTIMER_USE_MPI
-      integer :: mpi_comm = -1
+      type(MPI_Comm) :: mpi_comm
+      logical :: mpi_comm_was_present = .false.
       integer :: mpi_rank = -1
       integer :: mpi_nprocs = 1
 #endif
@@ -70,7 +75,13 @@ module ftimer_core
       procedure(ftimer_hook_proc), pointer, nopass :: on_event => null()
       type(c_ptr) :: user_data = c_null_ptr
    contains
-      procedure :: init
+      procedure, private :: init_with_integer_comm
+#ifdef FTIMER_USE_MPI
+      procedure, private :: init_with_mpi_comm
+      generic, public :: init => init_with_integer_comm, init_with_mpi_comm
+#else
+      procedure, public :: init => init_with_integer_comm
+#endif
       procedure :: finalize
       procedure :: set_clock
       procedure :: clear_clock
@@ -183,25 +194,45 @@ contains
 !$omp end master
    end function ftimer_internal_stop_scope_activation
 
-   subroutine init(self, comm, mismatch_mode, ierr)
+   subroutine init_with_integer_comm(self, comm, mismatch_mode, ierr)
       class(ftimer_t), intent(inout) :: self
       integer, intent(in), optional :: comm
       integer, intent(in), optional :: mismatch_mode
       integer, intent(out), optional :: ierr
 
       ! Contract: ierr is last to eliminate the positional intent(out) trap.
-      ! A single positional integer now binds to comm (intent(in)), not ierr.
-      ! Keywords are recommended for readability.
+      ! A single positional integer still binds to the transitional legacy
+      ! communicator path, not ierr. Keywords are recommended for readability.
       !$omp master
-      call init_impl(self, ierr=ierr, comm=comm, mismatch_mode=mismatch_mode)
+      call init_impl(self, ierr=ierr, legacy_comm=comm, mismatch_mode=mismatch_mode)
 !$omp end master
-   end subroutine init
+   end subroutine init_with_integer_comm
 
-   subroutine init_impl(self, comm, mismatch_mode, ierr)
+#ifdef FTIMER_USE_MPI
+   subroutine init_with_mpi_comm(self, comm, mismatch_mode, ierr)
       class(ftimer_t), intent(inout) :: self
-      integer, intent(in), optional :: comm
+      type(MPI_Comm), intent(in) :: comm
       integer, intent(in), optional :: mismatch_mode
       integer, intent(out), optional :: ierr
+
+!$omp master
+      call init_impl(self, ierr=ierr, comm=comm, mismatch_mode=mismatch_mode)
+!$omp end master
+   end subroutine init_with_mpi_comm
+#endif
+
+   subroutine init_impl(self, mismatch_mode, ierr, comm, legacy_comm)
+      class(ftimer_t), intent(inout) :: self
+      integer, intent(in), optional :: mismatch_mode
+      integer, intent(out), optional :: ierr
+#ifdef FTIMER_USE_MPI
+      type(MPI_Comm), intent(in), optional :: comm
+      type(MPI_Comm) :: requested_mpi_comm
+      logical :: requested_mpi_comm_was_present
+#else
+      integer, intent(in), optional :: comm
+#endif
+      integer, intent(in), optional :: legacy_comm
 
       if (present(mismatch_mode)) then
          select case (mismatch_mode)
@@ -217,6 +248,19 @@ contains
          return
       end if
 
+#ifdef FTIMER_USE_MPI
+      requested_mpi_comm = MPI_COMM_WORLD
+      requested_mpi_comm_was_present = .false.
+      if (present(comm)) then
+         requested_mpi_comm = comm
+         requested_mpi_comm_was_present = .true.
+      end if
+      if (present(legacy_comm)) then
+         requested_mpi_comm%MPI_VAL = legacy_comm
+         requested_mpi_comm_was_present = .true.
+      end if
+#endif
+
       call clear_runtime_state(self, keep_hooks=.true.)
       self%initialized = .true.
 
@@ -227,11 +271,8 @@ contains
       end if
 
 #ifdef FTIMER_USE_MPI
-      if (present(comm)) then
-         self%mpi_comm = comm
-      else
-         self%mpi_comm = -1
-      end if
+      self%mpi_comm = requested_mpi_comm
+      self%mpi_comm_was_present = requested_mpi_comm_was_present
       self%mpi_rank = -1
       self%mpi_nprocs = 1
 #endif
@@ -793,7 +834,8 @@ contains
       state%initialized = self%initialized
       state%mismatch_mode = self%mismatch_mode
 #ifdef FTIMER_USE_MPI
-      state%mpi_comm = self%mpi_comm
+      state%mpi_comm = self%mpi_comm%MPI_VAL
+      state%mpi_comm_was_present = self%mpi_comm_was_present
       state%mpi_rank = self%mpi_rank
       state%mpi_nprocs = self%mpi_nprocs
 #endif
@@ -823,7 +865,8 @@ contains
       self%initialized = .false.
       self%mismatch_mode = FTIMER_MISMATCH_STRICT
 #ifdef FTIMER_USE_MPI
-      self%mpi_comm = -1
+      self%mpi_comm = MPI_COMM_WORLD
+      self%mpi_comm_was_present = .false.
       self%mpi_rank = -1
       self%mpi_nprocs = 1
 #endif

--- a/src/ftimer_core_summary_bindings.F90
+++ b/src/ftimer_core_summary_bindings.F90
@@ -7,7 +7,7 @@ submodule(ftimer_core) ftimer_core_summary_bindings
                            ftimer_metadata_t, ftimer_mpi_summary_entry_t, ftimer_mpi_summary_t, &
                            ftimer_summary_entry_t, ftimer_summary_t, wp
 #ifdef FTIMER_USE_MPI
-   use mpi, only: MPI_Bcast, MPI_CHARACTER, MPI_INTEGER, MPI_SUCCESS
+   use mpi_f08, only: MPI_Bcast, MPI_CHARACTER, MPI_INTEGER, MPI_SUCCESS
 #endif
    implicit none
 
@@ -174,12 +174,16 @@ contains
    character(len=:), allocatable :: text
    character(len=256) :: diagnostic
    character(len=256) :: iomsg
-   integer :: active_comm
    integer :: io
    integer :: nprocs
    integer :: out_unit
    integer :: rank
    integer :: status
+#ifdef FTIMER_USE_MPI
+   type(MPI_Comm) :: active_comm
+#else
+   integer :: active_comm
+#endif
 
    if (.not. self%initialized) then
       call report_summary_status(ierr, FTIMER_ERR_NOT_INIT, "ftimer print_mpi_summary before init")
@@ -195,7 +199,11 @@ contains
    call format_mpi_summary(summary, text, metadata)
 
 #ifdef FTIMER_USE_MPI
-   call get_mpi_summary_comm_info(self%mpi_comm, active_comm, rank, nprocs, status)
+   if (self%mpi_comm_was_present) then
+      call get_mpi_summary_comm_info(self%mpi_comm, active_comm, rank, nprocs, status)
+   else
+      call get_mpi_summary_comm_info(active_comm=active_comm, rank=rank, nprocs=nprocs, status=status)
+   end if
 #else
    active_comm = -1
    rank = 0
@@ -230,7 +238,6 @@ contains
    character(len=256) :: diagnostic
    character(len=256) :: collective_message
    character(len=256) :: iomsg
-   integer :: active_comm
    integer :: collective_status
    integer :: file_unit
    integer :: io
@@ -239,6 +246,11 @@ contains
    integer :: rank
    integer :: status
    logical :: append_mode
+#ifdef FTIMER_USE_MPI
+   type(MPI_Comm) :: active_comm
+#else
+   integer :: active_comm
+#endif
 
    if (.not. self%initialized) then
       call report_summary_status(ierr, FTIMER_ERR_NOT_INIT, "ftimer write_mpi_summary before init")
@@ -254,7 +266,11 @@ contains
    call format_mpi_summary(summary, text, metadata)
 
 #ifdef FTIMER_USE_MPI
-   call get_mpi_summary_comm_info(self%mpi_comm, active_comm, rank, nprocs, status)
+   if (self%mpi_comm_was_present) then
+      call get_mpi_summary_comm_info(self%mpi_comm, active_comm, rank, nprocs, status)
+   else
+      call get_mpi_summary_comm_info(active_comm=active_comm, rank=rank, nprocs=nprocs, status=status)
+   end if
 #else
    active_comm = -1
    rank = 0
@@ -325,7 +341,6 @@ contains
    character(len=256) :: diagnostic
    character(len=256) :: collective_message
    character(len=256) :: iomsg
-   integer :: active_comm
    integer :: collective_status
    integer :: file_unit
    integer :: header_status
@@ -336,6 +351,11 @@ contains
    integer :: status
    logical :: append_mode
    logical :: include_header
+#ifdef FTIMER_USE_MPI
+   type(MPI_Comm) :: active_comm
+#else
+   integer :: active_comm
+#endif
 
    if (.not. self%initialized) then
       call report_summary_status(ierr, FTIMER_ERR_NOT_INIT, "ftimer write_mpi_summary_csv before init")
@@ -349,7 +369,11 @@ contains
    end if
 
 #ifdef FTIMER_USE_MPI
-   call get_mpi_summary_comm_info(self%mpi_comm, active_comm, rank, nprocs, status)
+   if (self%mpi_comm_was_present) then
+      call get_mpi_summary_comm_info(self%mpi_comm, active_comm, rank, nprocs, status)
+   else
+      call get_mpi_summary_comm_info(active_comm=active_comm, rank=rank, nprocs=nprocs, status=status)
+   end if
 #else
    active_comm = -1
    rank = 0
@@ -447,24 +471,34 @@ contains
       integer, intent(out) :: status
       character(len=*), intent(out) :: diagnostic
       type(ftimer_summary_t) :: local_summary
-      integer :: comm
       logical :: local_has_active_timers
 
       diagnostic = ''
-      comm = -1
       local_has_active_timers = self%call_stack%depth > 0
       call build_current_summary(self, local_summary)
 #ifdef FTIMER_USE_MPI
-      comm = self%mpi_comm
+      if (self%mpi_comm_was_present) then
+         call check_mpi_summary_prereqs(local_has_active_timers, self%mpi_comm, status)
+      else
+         call check_mpi_summary_prereqs(local_has_active_timers, status=status)
+      end if
+#else
+      call check_mpi_summary_prereqs(local_has_active_timers, status=status)
 #endif
-
-      call check_mpi_summary_prereqs(local_has_active_timers, comm, status)
       if (status /= FTIMER_SUCCESS) then
          call reset_mpi_summary(summary)
          return
       end if
 
-      call build_mpi_summary(local_summary, comm, summary, status, diagnostic)
+#ifdef FTIMER_USE_MPI
+      if (self%mpi_comm_was_present) then
+         call build_mpi_summary(local_summary, self%mpi_comm, summary, status, diagnostic)
+      else
+         call build_mpi_summary(local_summary, summary=summary, status=status, diagnostic=diagnostic)
+      end if
+#else
+      call build_mpi_summary(local_summary, summary=summary, status=status, diagnostic=diagnostic)
+#endif
       if (status /= FTIMER_SUCCESS) call reset_mpi_summary(summary)
    end subroutine build_current_mpi_summary
 

--- a/src/ftimer_mpi.F90
+++ b/src/ftimer_mpi.F90
@@ -4,7 +4,12 @@ module ftimer_mpi
                            FTIMER_ERR_UNKNOWN, FTIMER_SUCCESS, ftimer_mpi_summary_t, ftimer_summary_entry_t, &
                            ftimer_summary_t, wp
 #ifdef FTIMER_USE_MPI
-   use mpi
+   use mpi_f08, only: MPI_Allgather, MPI_Allreduce, MPI_Bcast, MPI_CHARACTER, MPI_Comm, MPI_COMM_NULL, &
+                      MPI_COMM_SELF, MPI_COMM_WORLD, MPI_Datatype, MPI_DATATYPE_NULL, MPI_Errhandler, &
+                      MPI_ERRORS_RETURN, MPI_INTEGER, MPI_MAX, MPI_MIN, MPI_Op, MPI_SUCCESS, MPI_SUM, &
+                      MPI_TYPECLASS_INTEGER, MPI_TYPECLASS_REAL, MPI_Comm_get_errhandler, MPI_Comm_rank, &
+                      MPI_Comm_set_errhandler, MPI_Comm_size, MPI_Errhandler_free, MPI_Type_match_size, &
+                      MPI_Type_size
 #endif
    implicit none
    private
@@ -44,17 +49,22 @@ module ftimer_mpi
 contains
 
    subroutine resolve_mpi_summary_comm(comm, active_comm, status)
-      integer, intent(in) :: comm
+#ifdef FTIMER_USE_MPI
+      type(MPI_Comm), intent(in), optional :: comm
+      type(MPI_Comm), intent(out) :: active_comm
+#else
+      integer, intent(in), optional :: comm
       integer, intent(out) :: active_comm
+#endif
       integer, intent(out) :: status
 #ifdef FTIMER_USE_MPI
       ! Contract: mpi_summary() is collective over the communicator captured at init.
-      ! If init omitted `comm`, ftimer_core passes a sentinel and mpi_summary()
-      ! resolves that contract to MPI_COMM_WORLD here.
-      active_comm = comm
-      if (active_comm < 0) active_comm = MPI_COMM_WORLD
+      ! If init omitted `comm`, ftimer_core omits it here and mpi_summary()
+      ! resolves that contract to MPI_COMM_WORLD.
+      active_comm = MPI_COMM_WORLD
+      if (present(comm)) active_comm = comm
 
-      if (active_comm == MPI_COMM_NULL) then
+      if (active_comm%MPI_VAL == MPI_COMM_NULL%MPI_VAL) then
          status = FTIMER_ERR_UNKNOWN
          return
       end if
@@ -75,8 +85,13 @@ contains
    end function ftimer_mpi_enabled
 
    subroutine get_mpi_summary_comm_info(comm, active_comm, rank, nprocs, status)
-      integer, intent(in) :: comm
+#ifdef FTIMER_USE_MPI
+      type(MPI_Comm), intent(in), optional :: comm
+      type(MPI_Comm), intent(out) :: active_comm
+#else
+      integer, intent(in), optional :: comm
       integer, intent(out) :: active_comm
+#endif
       integer, intent(out) :: rank
       integer, intent(out) :: nprocs
       integer, intent(out) :: status
@@ -115,10 +130,14 @@ contains
 
    subroutine check_mpi_summary_prereqs(local_has_active_timers, comm, status)
       logical, intent(in) :: local_has_active_timers
-      integer, intent(in) :: comm
+#ifdef FTIMER_USE_MPI
+      type(MPI_Comm), intent(in), optional :: comm
+#else
+      integer, intent(in), optional :: comm
+#endif
       integer, intent(out) :: status
 #ifdef FTIMER_USE_MPI
-      integer :: active_comm
+      type(MPI_Comm) :: active_comm
       integer :: any_active
       integer :: local_active
       integer :: mpierr
@@ -145,12 +164,16 @@ contains
 
    subroutine build_mpi_summary(local_summary, comm, summary, status, diagnostic)
       type(ftimer_summary_t), intent(in) :: local_summary
-      integer, intent(in) :: comm
+#ifdef FTIMER_USE_MPI
+      type(MPI_Comm), intent(in), optional :: comm
+#else
+      integer, intent(in), optional :: comm
+#endif
       type(ftimer_mpi_summary_t), intent(out) :: summary
       integer, intent(out) :: status
       character(len=*), intent(out), optional :: diagnostic
 #ifdef FTIMER_USE_MPI
-      integer :: active_comm
+      type(MPI_Comm) :: active_comm
       integer :: all_datatypes_ready
       integer :: datatypes_ready
       integer :: entry_count
@@ -161,13 +184,13 @@ contains
       integer :: max_node_id
       integer :: max_total_time_rank
       integer :: min_total_time_rank
-      integer :: mpi_int64_type
       integer :: mpierr
-      integer :: mpi_wp_type
       integer :: nprocs
       integer :: parent_entry
       integer :: parent_id
       integer :: rank
+      type(MPI_Datatype) :: mpi_int64_type
+      type(MPI_Datatype) :: mpi_wp_type
       integer, allocatable :: local_calls(:)
       integer, allocatable :: local_entry_to_canonical(:)
       integer, allocatable :: local_max_inclusive_ranks(:)
@@ -536,15 +559,15 @@ contains
 
 #ifdef FTIMER_USE_MPI
    subroutine resolve_mpi_summary_datatypes(mpi_wp_type, mpi_int64_type, status, diagnostic)
-      integer, intent(out) :: mpi_wp_type
-      integer, intent(out) :: mpi_int64_type
+      type(MPI_Datatype), intent(out) :: mpi_wp_type
+      type(MPI_Datatype), intent(out) :: mpi_int64_type
       integer, intent(out) :: status
       character(len=*), intent(out), optional :: diagnostic
       logical :: cleanup_ok
       integer :: int64_size
       integer :: mpierr
       integer :: reported_size
-      integer :: saved_errhandler
+      type(MPI_Errhandler) :: saved_errhandler
       integer :: wp_size
 
       mpi_wp_type = MPI_DATATYPE_NULL
@@ -577,7 +600,7 @@ contains
       end if
 
       call MPI_Type_match_size(MPI_TYPECLASS_REAL, wp_size, mpi_wp_type, mpierr)
-      if ((mpierr /= MPI_SUCCESS) .or. (mpi_wp_type == MPI_DATATYPE_NULL)) then
+      if ((mpierr /= MPI_SUCCESS) .or. (mpi_wp_type%MPI_VAL == MPI_DATATYPE_NULL%MPI_VAL)) then
          if (present(diagnostic)) diagnostic = &
             "ftimer mpi_summary could not find an MPI real datatype matching real(wp)"
          call restore_mpi_comm_self_errhandler(saved_errhandler, cleanup_ok, diagnostic)
@@ -593,7 +616,7 @@ contains
       end if
 
       call MPI_Type_match_size(MPI_TYPECLASS_INTEGER, int64_size, mpi_int64_type, mpierr)
-      if ((mpierr /= MPI_SUCCESS) .or. (mpi_int64_type == MPI_DATATYPE_NULL)) then
+      if ((mpierr /= MPI_SUCCESS) .or. (mpi_int64_type%MPI_VAL == MPI_DATATYPE_NULL%MPI_VAL)) then
          if (present(diagnostic)) diagnostic = &
             "ftimer mpi_summary could not find an MPI integer datatype matching integer(int64)"
          call restore_mpi_comm_self_errhandler(saved_errhandler, cleanup_ok, diagnostic)
@@ -617,7 +640,7 @@ contains
    end subroutine resolve_mpi_summary_datatypes
 
    subroutine restore_mpi_comm_self_errhandler(saved_errhandler, cleanup_ok, diagnostic)
-      integer, intent(inout) :: saved_errhandler
+      type(MPI_Errhandler), intent(inout) :: saved_errhandler
       logical, intent(out) :: cleanup_ok
       character(len=*), intent(inout), optional :: diagnostic
       character(len=256) :: original_diagnostic
@@ -636,7 +659,7 @@ contains
    end subroutine restore_mpi_comm_self_errhandler
 
    subroutine free_mpi_errhandler(errhandler, cleanup_ok, diagnostic)
-      integer, intent(inout) :: errhandler
+      type(MPI_Errhandler), intent(inout) :: errhandler
       logical, intent(inout) :: cleanup_ok
       character(len=*), intent(inout), optional :: diagnostic
       character(len=256) :: original_diagnostic
@@ -922,11 +945,11 @@ contains
    subroutine ftimer_mpi_allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, mpierr)
       integer, intent(in) :: sendbuf
       integer, intent(in) :: sendcount
-      integer, intent(in) :: sendtype
+      type(MPI_Datatype), intent(in) :: sendtype
       integer, intent(out) :: recvbuf(*)
       integer, intent(in) :: recvcount
-      integer, intent(in) :: recvtype
-      integer, intent(in) :: comm
+      type(MPI_Datatype), intent(in) :: recvtype
+      type(MPI_Comm), intent(in) :: comm
       integer, intent(out) :: mpierr
 #ifdef FTIMER_BUILD_TESTS
       integer :: nvalues
@@ -934,7 +957,7 @@ contains
 
       test_preflight_allgather_count = test_preflight_allgather_count + 1
       if ((sendcount == 1) .and. (recvcount == 1) .and. &
-          (sendtype == MPI_INTEGER) .and. (recvtype == MPI_INTEGER)) then
+          (sendtype%MPI_VAL == MPI_INTEGER%MPI_VAL) .and. (recvtype%MPI_VAL == MPI_INTEGER%MPI_VAL)) then
          test_preflight_mismatch_flag_allgather_count = test_preflight_mismatch_flag_allgather_count + 1
       end if
 #endif
@@ -942,7 +965,7 @@ contains
       call MPI_Allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, mpierr)
 #ifdef FTIMER_BUILD_TESTS
       if ((mpierr == MPI_SUCCESS) .and. (sendcount == 1) .and. (recvcount == 1) .and. &
-          (sendtype == MPI_INTEGER) .and. (recvtype == MPI_INTEGER)) then
+          (sendtype%MPI_VAL == MPI_INTEGER%MPI_VAL) .and. (recvtype%MPI_VAL == MPI_INTEGER%MPI_VAL)) then
          if (allocated(test_preflight_mismatch_flags)) deallocate (test_preflight_mismatch_flags)
          call MPI_Comm_size(comm, nvalues, test_mpierr)
          if (test_mpierr == MPI_SUCCESS) then
@@ -957,9 +980,9 @@ contains
       integer, intent(in) :: sendbuf
       integer, intent(out) :: recvbuf
       integer, intent(in) :: count
-      integer, intent(in) :: datatype
-      integer, intent(in) :: op
-      integer, intent(in) :: comm
+      type(MPI_Datatype), intent(in) :: datatype
+      type(MPI_Op), intent(in) :: op
+      type(MPI_Comm), intent(in) :: comm
       integer, intent(out) :: mpierr
 
       call ftimer_test_note_summary_reduction_phase()
@@ -970,9 +993,9 @@ contains
       integer, intent(in) :: sendbuf(:)
       integer, intent(out) :: recvbuf(:)
       integer, intent(in) :: count
-      integer, intent(in) :: datatype
-      integer, intent(in) :: op
-      integer, intent(in) :: comm
+      type(MPI_Datatype), intent(in) :: datatype
+      type(MPI_Op), intent(in) :: op
+      type(MPI_Comm), intent(in) :: comm
       integer, intent(out) :: mpierr
 
       call ftimer_test_note_summary_reduction_phase()
@@ -983,9 +1006,9 @@ contains
       integer(int64), intent(in) :: sendbuf(:)
       integer(int64), intent(out) :: recvbuf(:)
       integer, intent(in) :: count
-      integer, intent(in) :: datatype
-      integer, intent(in) :: op
-      integer, intent(in) :: comm
+      type(MPI_Datatype), intent(in) :: datatype
+      type(MPI_Op), intent(in) :: op
+      type(MPI_Comm), intent(in) :: comm
       integer, intent(out) :: mpierr
 
       call ftimer_test_note_summary_reduction_phase()
@@ -996,9 +1019,9 @@ contains
       real(wp), intent(in) :: sendbuf
       real(wp), intent(out) :: recvbuf
       integer, intent(in) :: count
-      integer, intent(in) :: datatype
-      integer, intent(in) :: op
-      integer, intent(in) :: comm
+      type(MPI_Datatype), intent(in) :: datatype
+      type(MPI_Op), intent(in) :: op
+      type(MPI_Comm), intent(in) :: comm
       integer, intent(out) :: mpierr
 
       call ftimer_test_note_summary_reduction_phase()
@@ -1009,9 +1032,9 @@ contains
       real(wp), intent(in) :: sendbuf(:)
       real(wp), intent(out) :: recvbuf(:)
       integer, intent(in) :: count
-      integer, intent(in) :: datatype
-      integer, intent(in) :: op
-      integer, intent(in) :: comm
+      type(MPI_Datatype), intent(in) :: datatype
+      type(MPI_Op), intent(in) :: op
+      type(MPI_Comm), intent(in) :: comm
       integer, intent(out) :: mpierr
 
       call ftimer_test_note_summary_reduction_phase()

--- a/tests/check_configure_contracts.cmake
+++ b/tests/check_configure_contracts.cmake
@@ -96,6 +96,11 @@ if(ftimer_mpi_source MATCHES "MPI_(2DOUBLE_PRECISION|DOUBLE_PRECISION|INTEGER8)"
 endif()
 
 file(READ "${REPO_ROOT}/CMakeLists.txt" ftimer_root_cmake)
+if(NOT ftimer_root_cmake MATCHES "use mpi_f08")
+  message(FATAL_ERROR
+    "FTIMER_USE_MPI=ON configure coverage must compile-check mpi_f08 so the documented MPI interface contract stays explicit."
+  )
+endif()
 if(NOT ftimer_root_cmake MATCHES "MPI_Type_match_size")
   message(FATAL_ERROR
     "FTIMER_USE_MPI=ON configure coverage must compile-check MPI_Type_match_size so MPI reduction datatype validation stays explicit."

--- a/tests/check_installed_package_consumer.cmake
+++ b/tests/check_installed_package_consumer.cmake
@@ -205,12 +205,19 @@ endif()
 
 if(TEST_ENABLE_MPI)
   set(mpi_consumer_executable "${consumer_build_dir}/ftimer_installed_mpi_consumer${TEST_EXECUTABLE_SUFFIX}")
+  set(legacy_mpi_consumer_executable "${consumer_build_dir}/ftimer_installed_legacy_mpi_consumer${TEST_EXECUTABLE_SUFFIX}")
   if(DEFINED TEST_CONFIG AND NOT TEST_CONFIG STREQUAL "")
     set(configured_mpi_consumer_executable
       "${consumer_build_dir}/${TEST_CONFIG}/ftimer_installed_mpi_consumer${TEST_EXECUTABLE_SUFFIX}"
     )
     if(EXISTS "${configured_mpi_consumer_executable}")
       set(mpi_consumer_executable "${configured_mpi_consumer_executable}")
+    endif()
+    set(configured_legacy_mpi_consumer_executable
+      "${consumer_build_dir}/${TEST_CONFIG}/ftimer_installed_legacy_mpi_consumer${TEST_EXECUTABLE_SUFFIX}"
+    )
+    if(EXISTS "${configured_legacy_mpi_consumer_executable}")
+      set(legacy_mpi_consumer_executable "${configured_legacy_mpi_consumer_executable}")
     endif()
   endif()
 
@@ -249,5 +256,32 @@ if(TEST_ENABLE_MPI)
 
   if(NOT EXISTS "${consumer_build_dir}/consumer_mpi_summary.txt")
     message(FATAL_ERROR "Installed-package MPI consumer did not write consumer_mpi_summary.txt.")
+  endif()
+
+  set(ftimer_legacy_mpi_launch_command "${ftimer_mpiexec}")
+  if(DEFINED TEST_MPIEXEC_NUMPROC_FLAG AND NOT TEST_MPIEXEC_NUMPROC_FLAG STREQUAL "")
+    list(APPEND ftimer_legacy_mpi_launch_command "${TEST_MPIEXEC_NUMPROC_FLAG}" 2)
+  else()
+    list(APPEND ftimer_legacy_mpi_launch_command -n 2)
+  endif()
+  if(DEFINED TEST_MPIEXEC_PREFLAGS AND NOT TEST_MPIEXEC_PREFLAGS STREQUAL "")
+    list(APPEND ftimer_legacy_mpi_launch_command ${TEST_MPIEXEC_PREFLAGS})
+  endif()
+  list(APPEND ftimer_legacy_mpi_launch_command "${legacy_mpi_consumer_executable}")
+  if(DEFINED TEST_MPIEXEC_POSTFLAGS AND NOT TEST_MPIEXEC_POSTFLAGS STREQUAL "")
+    list(APPEND ftimer_legacy_mpi_launch_command ${TEST_MPIEXEC_POSTFLAGS})
+  endif()
+
+  execute_process(
+    COMMAND ${ftimer_legacy_mpi_launch_command}
+    WORKING_DIRECTORY "${consumer_build_dir}"
+    RESULT_VARIABLE legacy_mpi_consumer_run_result
+  )
+  if(NOT legacy_mpi_consumer_run_result EQUAL 0)
+    message(FATAL_ERROR "Installed-package legacy MPI consumer executable exited with a nonzero status.")
+  endif()
+
+  if(NOT EXISTS "${consumer_build_dir}/consumer_legacy_mpi_summary.txt")
+    message(FATAL_ERROR "Installed-package legacy MPI consumer did not write consumer_legacy_mpi_summary.txt.")
   endif()
 endif()

--- a/tests/install-consumer/CMakeLists.txt
+++ b/tests/install-consumer/CMakeLists.txt
@@ -15,4 +15,7 @@ target_link_libraries(ftimer_installed_oop_consumer PRIVATE fTimer::ftimer)
 if(FTIMER_CONSUMER_ENABLE_MPI)
   add_executable(ftimer_installed_mpi_consumer mpi_main.F90)
   target_link_libraries(ftimer_installed_mpi_consumer PRIVATE fTimer::ftimer)
+
+  add_executable(ftimer_installed_legacy_mpi_consumer legacy_mpi_main.F90)
+  target_link_libraries(ftimer_installed_legacy_mpi_consumer PRIVATE fTimer::ftimer)
 endif()

--- a/tests/install-consumer/legacy_mpi_main.F90
+++ b/tests/install-consumer/legacy_mpi_main.F90
@@ -1,0 +1,109 @@
+program ftimer_installed_legacy_mpi_consumer
+   use ftimer, only: ftimer_finalize, ftimer_init, ftimer_mpi_summary, ftimer_start, ftimer_stop, &
+                     ftimer_write_mpi_summary
+   use ftimer_core, only: ftimer_t
+   use ftimer_types, only: ftimer_mpi_summary_t
+   use mpi
+   implicit none
+   integer :: i
+   integer :: ierr
+   integer :: rank
+   integer :: subcomm
+   integer :: subrank
+   real :: accumulator
+   type(ftimer_t) :: timer
+   type(ftimer_mpi_summary_t) :: summary
+
+   call MPI_Init(ierr)
+   if (ierr /= MPI_SUCCESS) error stop 1
+
+   call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierr)
+   if (ierr /= MPI_SUCCESS) error stop 2
+
+   accumulator = 0.0
+
+   call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+   if (ierr /= 0) error stop 3
+   call run_oop_work(timer, "legacy_oop_world", rank, ierr)
+   if (ierr /= 0) error stop 4
+   call timer%mpi_summary(summary, ierr=ierr)
+   if (ierr /= 0) error stop 5
+   if (summary%num_ranks /= 2) error stop 6
+   if (trim(summary%entries(1)%name) /= "legacy_oop_world") error stop 7
+   call timer%finalize(ierr=ierr)
+   if (ierr /= 0) error stop 8
+
+   call MPI_Comm_split(MPI_COMM_WORLD, rank, rank, subcomm, ierr)
+   if (ierr /= MPI_SUCCESS) error stop 9
+   call MPI_Comm_rank(subcomm, subrank, ierr)
+   if (ierr /= MPI_SUCCESS) error stop 10
+
+   call timer%init(comm=subcomm, ierr=ierr)
+   if (ierr /= 0) error stop 11
+   call run_oop_work(timer, "legacy_oop_split", rank, ierr)
+   if (ierr /= 0) error stop 12
+   call timer%mpi_summary(summary, ierr=ierr)
+   if (ierr /= 0) error stop 13
+   if (summary%num_ranks /= 1) error stop 14
+   if (summary%entries(1)%min_inclusive_time_rank /= subrank) error stop 15
+   call timer%finalize(ierr=ierr)
+   if (ierr /= 0) error stop 16
+
+   call ftimer_init(comm=subcomm, ierr=ierr)
+   if (ierr /= 0) error stop 17
+   call run_procedural_work("legacy_procedural_split", rank, ierr)
+   if (ierr /= 0) error stop 18
+   call ftimer_mpi_summary(summary, ierr=ierr)
+   if (ierr /= 0) error stop 19
+   if (summary%num_ranks /= 1) error stop 20
+   if (trim(summary%entries(1)%name) /= "legacy_procedural_split") error stop 21
+
+   call ftimer_write_mpi_summary("consumer_legacy_mpi_summary.txt", ierr=ierr)
+   if (ierr /= 0) error stop 22
+   call ftimer_finalize(ierr=ierr)
+   if (ierr /= 0) error stop 23
+
+   call MPI_Comm_free(subcomm, ierr)
+   if (ierr /= MPI_SUCCESS) error stop 24
+
+   call MPI_Finalize(ierr)
+   if (ierr /= MPI_SUCCESS) error stop 25
+
+   if (accumulator < 0.0) print *, accumulator
+
+contains
+
+   subroutine run_oop_work(active_timer, name, work_rank, ierr)
+      type(ftimer_t), intent(inout) :: active_timer
+      character(len=*), intent(in) :: name
+      integer, intent(in) :: work_rank
+      integer, intent(out) :: ierr
+
+      call active_timer%start(name, ierr=ierr)
+      if (ierr /= 0) return
+
+      call burn(work_rank)
+      call active_timer%stop(name, ierr=ierr)
+   end subroutine run_oop_work
+
+   subroutine run_procedural_work(name, work_rank, ierr)
+      character(len=*), intent(in) :: name
+      integer, intent(in) :: work_rank
+      integer, intent(out) :: ierr
+
+      call ftimer_start(name, ierr=ierr)
+      if (ierr /= 0) return
+
+      call burn(work_rank)
+      call ftimer_stop(name, ierr=ierr)
+   end subroutine run_procedural_work
+
+   subroutine burn(work_rank)
+      integer, intent(in) :: work_rank
+
+      do i = 1, (work_rank + 1)*10000
+         accumulator = accumulator + real(i)
+      end do
+   end subroutine burn
+
+end program ftimer_installed_legacy_mpi_consumer

--- a/tests/install-consumer/mpi_main.F90
+++ b/tests/install-consumer/mpi_main.F90
@@ -2,7 +2,7 @@ program ftimer_installed_mpi_consumer
    use ftimer, only: ftimer_finalize, ftimer_init, ftimer_mpi_summary, ftimer_write_mpi_summary, &
                      ftimer_start, ftimer_stop
    use ftimer_types, only: ftimer_mpi_summary_t, wp
-   use mpi
+   use mpi_f08
    implicit none
    integer :: ierr
    integer :: i

--- a/tests/mpi/test_mpi_consistency.pf
+++ b/tests/mpi/test_mpi_consistency.pf
@@ -1,6 +1,12 @@
 module test_mpi_consistency
    use pfunit
-   use mpi
+   use mpi_f08, only: MPI_F08_Allreduce => MPI_Allreduce, MPI_F08_Barrier => MPI_Barrier, &
+                      MPI_F08_Bcast => MPI_Bcast, MPI_F08_Comm => MPI_Comm, &
+                      MPI_F08_COMM_NULL => MPI_COMM_NULL, MPI_F08_COMM_WORLD => MPI_COMM_WORLD, &
+                      MPI_F08_Comm_free => MPI_Comm_free, MPI_F08_Comm_rank => MPI_Comm_rank, &
+                      MPI_F08_Comm_split => MPI_Comm_split, MPI_F08_INTEGER => MPI_INTEGER, &
+                      MPI_F08_MAX => MPI_MAX, MPI_F08_MIN => MPI_MIN, MPI_F08_SUCCESS => MPI_SUCCESS, &
+                      MPI_F08_SUM => MPI_SUM
    use ftimer_core, only: ftimer_t
    use ftimer_mpi, only: ftimer_test_get_mpi_preflight_collectives, &
                          ftimer_test_get_mpi_preflight_mismatch_flags, &
@@ -31,7 +37,7 @@ contains
       rank = this%getProcessRank()
       saved_fd = -1
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       call attach_mock_clock(timer)
 
       call build_inconsistent_contexts(timer, rank, ierr)
@@ -69,7 +75,7 @@ contains
       saved_fd = -1
       flags = 0
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       call attach_mock_clock(timer)
 
       call build_inconsistent_contexts(timer, rank, ierr)
@@ -91,8 +97,8 @@ contains
          @assertEqual(FTIMER_ERR_MPI_INCON, ierr)
       end if
 
-      call MPI_Bcast(flags, size(flags), MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Bcast(flags, size(flags), MPI_F08_INTEGER, 0, MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       @assertEqual(1, flags(1))
       @assertEqual(1, flags(2))
@@ -110,7 +116,7 @@ contains
       type(ftimer_mpi_summary_t) :: summary
       integer :: ierr
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -152,7 +158,7 @@ contains
          timer_name = legacy_prefix//'rank0001'
       end if
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -180,7 +186,7 @@ contains
       type(ftimer_mpi_summary_t) :: summary
       integer :: ierr
 
-      call timer%init(comm=MPI_COMM_NULL, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_NULL, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -211,7 +217,7 @@ contains
 
       call ftimer_test_reset_mpi_preflight_collectives()
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -254,7 +260,7 @@ contains
       rank = this%getProcessRank()
       call ftimer_test_reset_mpi_preflight_collectives()
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 

--- a/tests/mpi/test_mpi_consistency_4pe.pf
+++ b/tests/mpi/test_mpi_consistency_4pe.pf
@@ -1,6 +1,12 @@
 module test_mpi_consistency_4pe
    use pfunit
-   use mpi
+   use mpi_f08, only: MPI_F08_Allreduce => MPI_Allreduce, MPI_F08_Barrier => MPI_Barrier, &
+                      MPI_F08_Bcast => MPI_Bcast, MPI_F08_Comm => MPI_Comm, &
+                      MPI_F08_COMM_NULL => MPI_COMM_NULL, MPI_F08_COMM_WORLD => MPI_COMM_WORLD, &
+                      MPI_F08_Comm_free => MPI_Comm_free, MPI_F08_Comm_rank => MPI_Comm_rank, &
+                      MPI_F08_Comm_split => MPI_Comm_split, MPI_F08_INTEGER => MPI_INTEGER, &
+                      MPI_F08_MAX => MPI_MAX, MPI_F08_MIN => MPI_MIN, MPI_F08_SUCCESS => MPI_SUCCESS, &
+                      MPI_F08_SUM => MPI_SUM
    use ftimer_core, only: ftimer_t
    use ftimer_mpi, only: build_mpi_summary, ftimer_test_get_mpi_preflight_collectives, &
                          ftimer_test_get_mpi_preflight_mismatch_flags, &
@@ -22,7 +28,7 @@ contains
       type(ftimer_mpi_summary_t) :: summary
       integer :: ierr
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -46,7 +52,7 @@ contains
       type(ftimer_mpi_summary_t) :: summary
       integer :: ierr
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -70,7 +76,7 @@ contains
       type(ftimer_mpi_summary_t) :: summary
       integer :: ierr
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -94,7 +100,7 @@ contains
       type(ftimer_mpi_summary_t) :: summary
       integer :: ierr
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -127,7 +133,7 @@ contains
       rank = this%getProcessRank()
       call ftimer_test_reset_mpi_preflight_collectives()
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -173,7 +179,7 @@ contains
       saved_fd = -1
       flags = 0
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -196,8 +202,8 @@ contains
          @assertEqual(FTIMER_ERR_MPI_INCON, ierr)
       end if
 
-      call MPI_Bcast(flags, size(flags), MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Bcast(flags, size(flags), MPI_F08_INTEGER, 0, MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       @assertEqual(1, flags(1))
       @assertEqual(1, flags(2))
@@ -223,17 +229,17 @@ contains
       integer :: rank
       integer :: root_flags(5)
       integer :: saved_fd
-      integer :: split_comm
+      type(MPI_F08_Comm) :: split_comm
 
       rank = this%getProcessRank()
       color = rank/2
       saved_fd = -1
       root_flags = 0
 
-      call MPI_Comm_split(MPI_COMM_WORLD, color, rank, split_comm, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
-      call MPI_Comm_rank(split_comm, comm_rank, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Comm_split(MPI_F08_COMM_WORLD, color, rank, split_comm, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
+      call MPI_F08_Comm_rank(split_comm, comm_rank, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       call timer%init(comm=split_comm, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
@@ -260,8 +266,8 @@ contains
          @assertEqual(FTIMER_ERR_MPI_INCON, ierr)
       end if
 
-      call MPI_Allreduce(root_flags, global_flags, size(root_flags), MPI_INTEGER, MPI_SUM, MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Allreduce(root_flags, global_flags, size(root_flags), MPI_F08_INTEGER, MPI_F08_SUM, MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       @assertEqual(2, global_flags(1))
       @assertEqual(2, global_flags(2))
@@ -271,8 +277,8 @@ contains
 
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
-      call MPI_Comm_free(split_comm, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Comm_free(split_comm, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
    end subroutine test_mpi_summary_reports_split_comm_disagreeing_ranks
 
    @test
@@ -294,7 +300,7 @@ contains
       diagnostic = ''
       partial_diagnostic = ''
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -304,8 +310,8 @@ contains
       call timer%get_summary(local_summary, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
 
-      call build_mpi_summary(local_summary, MPI_COMM_WORLD, mpi_summary, status, diagnostic)
-      call build_mpi_summary(local_summary, MPI_COMM_WORLD, mpi_summary, partial_status, partial_diagnostic)
+      call build_mpi_summary(local_summary, MPI_F08_COMM_WORLD, mpi_summary, status, diagnostic)
+      call build_mpi_summary(local_summary, MPI_F08_COMM_WORLD, mpi_summary, partial_status, partial_diagnostic)
 
       if ((status == FTIMER_ERR_MPI_INCON) .and. (partial_status == FTIMER_ERR_MPI_INCON)) flags(1) = 1
       if (index(diagnostic, 'truncated') > 0) flags(2) = 1

--- a/tests/mpi/test_mpi_summary.pf
+++ b/tests/mpi/test_mpi_summary.pf
@@ -1,6 +1,12 @@
 module test_mpi_summary
    use pfunit
-   use mpi
+   use mpi_f08, only: MPI_F08_Allreduce => MPI_Allreduce, MPI_F08_Barrier => MPI_Barrier, &
+                      MPI_F08_Bcast => MPI_Bcast, MPI_F08_Comm => MPI_Comm, &
+                      MPI_F08_COMM_NULL => MPI_COMM_NULL, MPI_F08_COMM_WORLD => MPI_COMM_WORLD, &
+                      MPI_F08_Comm_free => MPI_Comm_free, MPI_F08_Comm_rank => MPI_Comm_rank, &
+                      MPI_F08_Comm_split => MPI_Comm_split, MPI_F08_INTEGER => MPI_INTEGER, &
+                      MPI_F08_MAX => MPI_MAX, MPI_F08_MIN => MPI_MIN, MPI_F08_SUCCESS => MPI_SUCCESS, &
+                      MPI_F08_SUM => MPI_SUM
    use ftimer, only: ftimer_default_instance, ftimer_finalize, ftimer_init, ftimer_mpi_summary, &
                      ftimer_print_mpi_summary, ftimer_start, ftimer_stop
    use ftimer_core, only: ftimer_t
@@ -27,7 +33,7 @@ contains
       nprocs = this%getNumProcesses()
       @assertEqual(2, nprocs)
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -88,7 +94,7 @@ contains
       type(ftimer_mpi_summary_t) :: summary
       integer :: ierr
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -123,7 +129,7 @@ contains
       type(ftimer_mpi_summary_t) :: summary
       integer :: ierr
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -154,7 +160,7 @@ contains
       type(ftimer_mpi_summary_t) :: summary
       integer :: ierr
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -189,7 +195,7 @@ contains
       type(ftimer_mpi_summary_t) :: summary
       integer :: ierr
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -242,7 +248,7 @@ contains
       expected_root_len = len(root_name)
       expected_child_len = len(child_name)
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -276,16 +282,16 @@ contains
          call timer%print_mpi_summary(ierr=ierr)
       end if
       @assertEqual(FTIMER_SUCCESS, ierr)
-      call MPI_Barrier(MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       if (rank == 0) then
          printed = read_file_text(print_path)
          if (index(printed, root_name) > 0) flags(1) = 1
          if (index(printed, child_name) > 0) flags(2) = 1
       end if
-      call MPI_Bcast(flags, size(flags), MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Bcast(flags, size(flags), MPI_F08_INTEGER, 0, MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       @assertEqual(1, flags(1))
       @assertEqual(1, flags(2))
@@ -301,7 +307,7 @@ contains
       type(ftimer_mpi_summary_t) :: summary
       integer :: ierr
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -338,7 +344,7 @@ contains
       type(ftimer_mpi_summary_t) :: summary
       integer :: ierr
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -368,11 +374,11 @@ contains
       type(ftimer_mpi_summary_t) :: procedural_summary
       integer :: ierr
 
-      call oop_timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call oop_timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(oop_timer)
 
-      call ftimer_init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call ftimer_init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(ftimer_default_instance)
 
@@ -393,6 +399,43 @@ contains
       call ftimer_finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
    end subroutine test_procedural_mpi_summary_matches_oop_api
+
+   @test
+   subroutine test_transitional_integer_comm_compatibility(this)
+      class(mpi_summary_case), intent(inout) :: this
+      type(ftimer_t) :: oop_timer
+      type(ftimer_mpi_summary_t) :: oop_summary
+      type(ftimer_mpi_summary_t) :: procedural_summary
+      integer :: ierr
+      integer :: legacy_comm
+
+      legacy_comm = MPI_F08_COMM_WORLD%MPI_VAL
+
+      call oop_timer%init(comm=legacy_comm, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(oop_timer)
+
+      call ftimer_init(comm=legacy_comm, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+      call build_nested_timers(oop_timer, this%getProcessRank(), ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call build_nested_timers_procedural(this%getProcessRank(), ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call oop_timer%mpi_summary(oop_summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call ftimer_mpi_summary(procedural_summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call assert_summary_equal(procedural_summary, oop_summary)
+
+      call oop_timer%finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_transitional_integer_comm_compatibility
 
    @test
    subroutine test_mpi_print_summary_emits_global_report(this)
@@ -417,7 +460,7 @@ contains
 
       rank = this%getProcessRank()
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -439,8 +482,8 @@ contains
          call timer%print_mpi_summary(metadata=metadata, ierr=ierr)
       end if
       @assertEqual(FTIMER_SUCCESS, ierr)
-      call MPI_Barrier(MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       flags = 0
       if (rank == 0) then
@@ -461,8 +504,8 @@ contains
          if (index(printed, 'BlankValue') > 0) flags(14) = 1
          if (index(printed, 'orphan-mpi') == 0) flags(15) = 1
       end if
-      call MPI_Bcast(flags, size(flags), MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Bcast(flags, size(flags), MPI_F08_INTEGER, 0, MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       @assertEqual(1, flags(1))
       @assertEqual(1, flags(2))
@@ -536,7 +579,7 @@ contains
       rank = this%getProcessRank()
       flags = 0
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -547,13 +590,13 @@ contains
       metadata(1)%value = 'mpi, "csv"'
 
       if (rank == 0) call delete_if_exists(csv_path)
-      call MPI_Barrier(MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       call timer%write_mpi_summary_csv(csv_path, metadata=metadata, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
-      call MPI_Barrier(MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       if (rank == 0) then
          csv_text = read_file_text(csv_path)
@@ -656,8 +699,8 @@ contains
          if (io == 0) close (unit, status='delete')
       end if
 
-      call MPI_Bcast(flags, size(flags), MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Bcast(flags, size(flags), MPI_F08_INTEGER, 0, MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       @assertEqual(1, flags(1))
       @assertEqual(1, flags(2))
@@ -739,7 +782,7 @@ contains
       rank = this%getProcessRank()
       flags = 0
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -747,13 +790,13 @@ contains
       @assertEqual(FTIMER_SUCCESS, ierr)
 
       if (rank == 0) call delete_if_exists(csv_path)
-      call MPI_Barrier(MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       call timer%write_mpi_summary_csv(csv_path, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
-      call MPI_Barrier(MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       if (rank == 0) then
          csv_text = read_file_text(csv_path)
@@ -784,8 +827,8 @@ contains
          call delete_if_exists(csv_path)
       end if
 
-      call MPI_Bcast(flags, size(flags), MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Bcast(flags, size(flags), MPI_F08_INTEGER, 0, MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       @assertEqual(1, flags(1))
       @assertEqual(1, flags(2))
@@ -816,7 +859,7 @@ contains
       rank = this%getProcessRank()
       flags = 0
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -824,15 +867,15 @@ contains
       @assertEqual(FTIMER_SUCCESS, ierr)
 
       if (rank == 0) call delete_if_exists(csv_path)
-      call MPI_Barrier(MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       call timer%write_mpi_summary_csv(csv_path, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call timer%write_mpi_summary_csv(csv_path, append=.true., ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
-      call MPI_Barrier(MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       if (rank == 0) then
          csv_text = read_file_text(csv_path)
@@ -842,8 +885,8 @@ contains
          call delete_if_exists(csv_path)
       end if
 
-      call MPI_Bcast(flags, size(flags), MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Bcast(flags, size(flags), MPI_F08_INTEGER, 0, MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       @assertEqual(1, flags(1))
       @assertEqual(1, flags(2))
@@ -867,7 +910,7 @@ contains
 
       rank = this%getProcessRank()
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -875,29 +918,29 @@ contains
       @assertEqual(FTIMER_SUCCESS, ierr)
 
       if (rank == 0) call delete_if_exists(csv_path)
-      call MPI_Barrier(MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       call timer%write_mpi_summary_csv(csv_path, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
-      call MPI_Barrier(MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       if (rank == 0) then
          csv_text = read_file_text(csv_path)
          header = csv_line_at(csv_text, 1)
          call write_raw_text_without_newline(csv_path, header)
       end if
-      call MPI_Barrier(MPI_COMM_WORLD, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       call timer%write_mpi_summary_csv(csv_path, append=.true., ierr=ierr)
       @assertEqual(FTIMER_ERR_IO, ierr)
 
-      call MPI_Allreduce(ierr, min_err, 1, MPI_INTEGER, MPI_MIN, MPI_COMM_WORLD, mpierr)
-      @assertEqual(MPI_SUCCESS, mpierr)
-      call MPI_Allreduce(ierr, max_err, 1, MPI_INTEGER, MPI_MAX, MPI_COMM_WORLD, mpierr)
-      @assertEqual(MPI_SUCCESS, mpierr)
+      call MPI_F08_Allreduce(ierr, min_err, 1, MPI_F08_INTEGER, MPI_F08_MIN, MPI_F08_COMM_WORLD, mpierr)
+      @assertEqual(MPI_F08_SUCCESS, mpierr)
+      call MPI_F08_Allreduce(ierr, max_err, 1, MPI_F08_INTEGER, MPI_F08_MAX, MPI_F08_COMM_WORLD, mpierr)
+      @assertEqual(MPI_F08_SUCCESS, mpierr)
 
       @assertEqual(FTIMER_ERR_IO, min_err)
       @assertEqual(FTIMER_ERR_IO, max_err)
@@ -917,7 +960,7 @@ contains
       integer :: min_err
       integer :: mpierr
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -927,10 +970,10 @@ contains
       call timer%write_mpi_summary('/no_such_dir/test_mpi_summary.txt', ierr=ierr)
       @assertEqual(FTIMER_ERR_IO, ierr)
 
-      call MPI_Allreduce(ierr, min_err, 1, MPI_INTEGER, MPI_MIN, MPI_COMM_WORLD, mpierr)
-      @assertEqual(MPI_SUCCESS, mpierr)
-      call MPI_Allreduce(ierr, max_err, 1, MPI_INTEGER, MPI_MAX, MPI_COMM_WORLD, mpierr)
-      @assertEqual(MPI_SUCCESS, mpierr)
+      call MPI_F08_Allreduce(ierr, min_err, 1, MPI_F08_INTEGER, MPI_F08_MIN, MPI_F08_COMM_WORLD, mpierr)
+      @assertEqual(MPI_F08_SUCCESS, mpierr)
+      call MPI_F08_Allreduce(ierr, max_err, 1, MPI_F08_INTEGER, MPI_F08_MAX, MPI_F08_COMM_WORLD, mpierr)
+      @assertEqual(MPI_F08_SUCCESS, mpierr)
 
       @assertEqual(FTIMER_ERR_IO, min_err)
       @assertEqual(FTIMER_ERR_IO, max_err)
@@ -948,7 +991,7 @@ contains
       integer :: min_err
       integer :: mpierr
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -958,10 +1001,10 @@ contains
       call timer%write_mpi_summary_csv('/no_such_dir/test_mpi_summary.csv', ierr=ierr)
       @assertEqual(FTIMER_ERR_IO, ierr)
 
-      call MPI_Allreduce(ierr, min_err, 1, MPI_INTEGER, MPI_MIN, MPI_COMM_WORLD, mpierr)
-      @assertEqual(MPI_SUCCESS, mpierr)
-      call MPI_Allreduce(ierr, max_err, 1, MPI_INTEGER, MPI_MAX, MPI_COMM_WORLD, mpierr)
-      @assertEqual(MPI_SUCCESS, mpierr)
+      call MPI_F08_Allreduce(ierr, min_err, 1, MPI_F08_INTEGER, MPI_F08_MIN, MPI_F08_COMM_WORLD, mpierr)
+      @assertEqual(MPI_F08_SUCCESS, mpierr)
+      call MPI_F08_Allreduce(ierr, max_err, 1, MPI_F08_INTEGER, MPI_F08_MAX, MPI_F08_COMM_WORLD, mpierr)
+      @assertEqual(MPI_F08_SUCCESS, mpierr)
 
       @assertEqual(FTIMER_ERR_IO, min_err)
       @assertEqual(FTIMER_ERR_IO, max_err)

--- a/tests/mpi/test_mpi_summary_4pe.pf
+++ b/tests/mpi/test_mpi_summary_4pe.pf
@@ -1,6 +1,12 @@
 module test_mpi_summary_4pe
    use pfunit
-   use mpi
+   use mpi_f08, only: MPI_F08_Allreduce => MPI_Allreduce, MPI_F08_Barrier => MPI_Barrier, &
+                      MPI_F08_Bcast => MPI_Bcast, MPI_F08_Comm => MPI_Comm, &
+                      MPI_F08_COMM_NULL => MPI_COMM_NULL, MPI_F08_COMM_WORLD => MPI_COMM_WORLD, &
+                      MPI_F08_Comm_free => MPI_Comm_free, MPI_F08_Comm_rank => MPI_Comm_rank, &
+                      MPI_F08_Comm_split => MPI_Comm_split, MPI_F08_INTEGER => MPI_INTEGER, &
+                      MPI_F08_MAX => MPI_MAX, MPI_F08_MIN => MPI_MIN, MPI_F08_SUCCESS => MPI_SUCCESS, &
+                      MPI_F08_SUM => MPI_SUM
    use ftimer, only: ftimer_default_instance, ftimer_finalize, ftimer_init, ftimer_mpi_summary, ftimer_start, ftimer_stop
    use ftimer_core, only: ftimer_t
    use ftimer_types, only: FTIMER_SUCCESS, ftimer_mpi_summary_t, wp
@@ -21,15 +27,15 @@ contains
       integer :: color
       integer :: ierr
       integer :: rank
-      integer :: subcomm
+      type(MPI_F08_Comm) :: subcomm
       integer :: subrank
 
       rank = this%getProcessRank()
       color = rank/2
-      call MPI_Comm_split(MPI_COMM_WORLD, color, rank, subcomm, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
-      call MPI_Comm_rank(subcomm, subrank, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Comm_split(MPI_F08_COMM_WORLD, color, rank, subcomm, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
+      call MPI_F08_Comm_rank(subcomm, subrank, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       call timer%init(comm=subcomm, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
@@ -54,8 +60,8 @@ contains
 
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
-      call MPI_Comm_free(subcomm, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Comm_free(subcomm, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
    end subroutine test_mpi_summary_supports_consistent_split_communicators
 
    @test
@@ -100,7 +106,7 @@ contains
       type(ftimer_mpi_summary_t) :: summary
       integer :: ierr
 
-      call timer%init(comm=MPI_COMM_WORLD, ierr=ierr)
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
       call attach_mock_clock(timer)
 
@@ -138,15 +144,15 @@ contains
       integer :: color
       integer :: ierr
       integer :: rank
-      integer :: subcomm
+      type(MPI_F08_Comm) :: subcomm
       integer :: subrank
 
       rank = this%getProcessRank()
       color = rank/2
-      call MPI_Comm_split(MPI_COMM_WORLD, color, rank, subcomm, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
-      call MPI_Comm_rank(subcomm, subrank, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Comm_split(MPI_F08_COMM_WORLD, color, rank, subcomm, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
+      call MPI_F08_Comm_rank(subcomm, subrank, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
 
       call ftimer_init(comm=subcomm, ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
@@ -166,8 +172,8 @@ contains
 
       call ftimer_finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
-      call MPI_Comm_free(subcomm, ierr)
-      @assertEqual(MPI_SUCCESS, ierr)
+      call MPI_F08_Comm_free(subcomm, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
    end subroutine test_procedural_mpi_summary_supports_split_communicators
 
    subroutine build_split_comm_timer(timer, color, subrank, ierr)

--- a/tests/mpi/test_mpi_summary_4pe.pf
+++ b/tests/mpi/test_mpi_summary_4pe.pf
@@ -176,6 +176,118 @@ contains
       @assertEqual(MPI_F08_SUCCESS, ierr)
    end subroutine test_procedural_mpi_summary_supports_split_communicators
 
+   @test
+   subroutine test_transitional_integer_comm_supports_split_communicators(this)
+      class(mpi_summary_4pe_case), intent(inout) :: this
+      type(ftimer_t) :: oop_timer
+      type(ftimer_mpi_summary_t) :: oop_summary
+      type(ftimer_mpi_summary_t) :: procedural_summary
+      integer :: color
+      integer :: ierr
+      integer :: legacy_comm
+      integer :: rank
+      type(MPI_F08_Comm) :: subcomm
+      integer :: subrank
+
+      rank = this%getProcessRank()
+      color = rank/2
+      call MPI_F08_Comm_split(MPI_F08_COMM_WORLD, color, rank, subcomm, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
+      call MPI_F08_Comm_rank(subcomm, subrank, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
+      legacy_comm = subcomm%MPI_VAL
+
+      call oop_timer%init(comm=legacy_comm, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(oop_timer)
+
+      call ftimer_init(comm=legacy_comm, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+      call build_split_comm_timer(oop_timer, color, subrank, ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call build_split_comm_timer_procedural(color, subrank, ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call oop_timer%mpi_summary(oop_summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call ftimer_mpi_summary(procedural_summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call assert_split_work_summary(oop_summary, color)
+      call assert_split_work_summary(procedural_summary, color)
+
+      call oop_timer%finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call MPI_F08_Comm_free(subcomm, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
+   end subroutine test_transitional_integer_comm_supports_split_communicators
+
+   @test
+   subroutine test_mpi_summary_reinit_omitted_comm_resets_to_world(this)
+      class(mpi_summary_4pe_case), intent(inout) :: this
+      type(ftimer_t) :: timer
+      type(ftimer_mpi_summary_t) :: summary
+      integer :: color
+      integer :: ierr
+      integer :: rank
+      type(MPI_F08_Comm) :: subcomm
+      integer :: subrank
+
+      rank = this%getProcessRank()
+      color = rank/2
+      call MPI_F08_Comm_split(MPI_F08_COMM_WORLD, color, rank, subcomm, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
+      call MPI_F08_Comm_rank(subcomm, subrank, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
+
+      call timer%init(comm=subcomm, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(timer)
+      call build_split_comm_timer(timer, color, subrank, ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call timer%mpi_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call assert_split_work_summary(summary, color)
+
+      call timer%init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(timer)
+      call build_world_timer(timer, rank, ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call timer%mpi_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call assert_world_summary(summary)
+
+      call ftimer_init(comm=subcomm, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+      call build_split_comm_timer_procedural(color, subrank, ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call ftimer_mpi_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call assert_split_work_summary(summary, color)
+
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+      call build_world_timer_procedural(rank, ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call ftimer_mpi_summary(summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call assert_world_summary(summary)
+
+      call timer%finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call MPI_F08_Comm_free(subcomm, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
+   end subroutine test_mpi_summary_reinit_omitted_comm_resets_to_world
+
    subroutine build_split_comm_timer(timer, color, subrank, ierr)
       class(ftimer_t), intent(inout) :: timer
       integer, intent(in) :: color
@@ -202,6 +314,18 @@ contains
       fake_time = 4.0_wp + real(rank, wp)
       call timer%stop("world", ierr=ierr)
    end subroutine build_world_timer
+
+   subroutine build_world_timer_procedural(rank, ierr)
+      integer, intent(in) :: rank
+      integer, intent(out) :: ierr
+
+      fake_time = 0.0_wp
+      call ftimer_start("world", ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) return
+
+      fake_time = 4.0_wp + real(rank, wp)
+      call ftimer_stop("world", ierr=ierr)
+   end subroutine build_world_timer_procedural
 
    subroutine build_partial_tie_timers(timer, rank, ierr)
       class(ftimer_t), intent(inout) :: timer
@@ -254,6 +378,37 @@ contains
       fake_time = 4.0_wp + real(color, wp) + 2.0_wp*real(subrank, wp)
       call ftimer_stop("work", ierr=ierr)
    end subroutine build_split_comm_timer_procedural
+
+   subroutine assert_split_work_summary(summary, color)
+      type(ftimer_mpi_summary_t), intent(in) :: summary
+      integer, intent(in) :: color
+
+      @assertEqual(2, summary%num_ranks)
+      @assertEqual(1, summary%num_entries)
+      @assertEqual('work', trim(summary%entries(1)%name))
+      call assert_real_close(summary%min_total_time, 4.0_wp + real(color, wp))
+      call assert_real_close(summary%avg_total_time, 5.0_wp + real(color, wp))
+      call assert_real_close(summary%max_total_time, 6.0_wp + real(color, wp))
+      @assertEqual(0, summary%min_total_time_rank)
+      @assertEqual(1, summary%max_total_time_rank)
+      @assertEqual(0, summary%entries(1)%min_inclusive_time_rank)
+      @assertEqual(1, summary%entries(1)%max_inclusive_time_rank)
+   end subroutine assert_split_work_summary
+
+   subroutine assert_world_summary(summary)
+      type(ftimer_mpi_summary_t), intent(in) :: summary
+
+      @assertEqual(4, summary%num_ranks)
+      @assertEqual(1, summary%num_entries)
+      @assertEqual('world', trim(summary%entries(1)%name))
+      call assert_real_close(summary%min_total_time, 4.0_wp)
+      call assert_real_close(summary%avg_total_time, 5.5_wp)
+      call assert_real_close(summary%max_total_time, 7.0_wp)
+      @assertEqual(0, summary%min_total_time_rank)
+      @assertEqual(3, summary%max_total_time_rank)
+      @assertEqual(0, summary%entries(1)%min_inclusive_time_rank)
+      @assertEqual(3, summary%entries(1)%max_inclusive_time_rank)
+   end subroutine assert_world_summary
 
    subroutine assert_real_close(actual, expected)
       real(wp), intent(in) :: actual


### PR DESCRIPTION
## Summary

- make `mpi_f08` the primary MPI implementation path and configure-time probe
- store captured communicators internally as `type(MPI_Comm)` while keeping legacy integer communicator init as transitional compatibility
- update MPI pFUnit tests, the MPI example, and the installed MPI consumer to exercise `mpi_f08`
- update README, semantics/design docs, and agent guidance to document the current contract

## Phase Plan

Phase 1 is this PR: adopt `mpi_f08` internally and in repo-owned/downstream coverage without a flag-day break. The public `init(comm=...)` surface now accepts `type(MPI_Comm)` as the primary MPI form and still accepts integer handles for compatibility.

Phase 2 is tracked separately in #187: remove the transitional integer communicator compatibility path after the `mpi_f08` contract has had a compatibility window.

Closes #136.

## Validation

- `ctest --test-dir build-mpi-tests --output-on-failure -R ftimer_mpi_tests`
- `ctest --test-dir build-smoke --output-on-failure`
- `find src -name '*.F90' -exec fprettify --diff {} +`
- `find tests -name '*.pf' -exec fprettify --diff {} +`
- `find tests -name '*.F90' -exec fprettify --diff {} +`
- `find examples -name '*.F90' -exec fprettify --diff {} +`