### PR TITLE
[codex] Define sparse MPI union summary API model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ ftimer.F90  (procedural wrappers + default global instance)
         ├─► ftimer_types.F90   (derived types, kinds, constants, enums, summary types, callback interface)
         ├─► ftimer_clock.F90   (injectable wall-clock: MPI_Wtime vs system_clock)
         ├─► ftimer_summary.F90 (structured summary building + text formatting)
-        ├─► ftimer_mpi.F90    (MPI gather/reduce for cross-rank summaries)
+        ├─► ftimer_mpi.F90    (strict MPI reductions + sparse/union API skeleton)
         └─► ftimer_core_summary_bindings.F90 (summary/report/CSV file-output bindings)
 ```
 
@@ -128,7 +128,7 @@ The call stack state CHANGES between start and stop — this is the most common 
 
 ## Development Workflow
 
-Current `main` is in Phase 6. The shared types/clock foundation, core timer runtime, local summary/report formatting, procedural convenience wrappers, MPI-reduced structured summaries, and limited OpenMP master-thread guards are implemented.
+Current `main` is in Phase 6. The shared types/clock foundation, core timer runtime, local summary/report formatting, procedural convenience wrappers, MPI-reduced structured summaries, sparse/union MPI API/data-model skeletons, and limited OpenMP master-thread guards are implemented.
 
 During Phase 6, keep the library, examples, install package, smoke tests, and pFUnit suite buildable. Keep the diff phase-bounded: preserve procedural-wrapper parity with the OOP core unless a tracked issue explicitly defers parity, keep MPI summary behavior correct and explicit, preserve the limited master-thread-only OpenMP guard model, and keep current-state docs/examples honest. Do not pull fuller post-Phase-6 design work or broader OpenMP support forward.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ ftimer.F90  (procedural wrappers + default global instance)
         ├─► ftimer_types.F90   (derived types, kinds, constants, enums, summary types, callback interface)
         ├─► ftimer_clock.F90   (injectable wall-clock: MPI_Wtime vs system_clock)
         ├─► ftimer_summary.F90 (structured summary building + text formatting)
-        ├─► ftimer_mpi.F90    (MPI gather/reduce for cross-rank summaries)
+        ├─► ftimer_mpi.F90    (strict MPI reductions + sparse/union API skeleton)
         └─► ftimer_core_summary_bindings.F90 (summary/report/CSV file-output bindings)
 ```
 
@@ -128,7 +128,7 @@ The call stack state CHANGES between start and stop — this is the most common 
 
 ## Development Workflow
 
-Current `main` is in Phase 6. The shared types/clock foundation, core timer runtime, local summary/report formatting, procedural convenience wrappers, MPI-reduced structured summaries, and limited OpenMP master-thread guards are implemented.
+Current `main` is in Phase 6. The shared types/clock foundation, core timer runtime, local summary/report formatting, procedural convenience wrappers, MPI-reduced structured summaries, sparse/union MPI API/data-model skeletons, and limited OpenMP master-thread guards are implemented.
 
 During Phase 6, keep the library, examples, install package, smoke tests, and pFUnit suite buildable. Keep the diff phase-bounded: preserve procedural-wrapper parity with the OOP core unless a tracked issue explicitly defers parity, keep MPI summary behavior correct and explicit, preserve the limited master-thread-only OpenMP guard model, and keep current-state docs/examples honest. Do not pull fuller post-Phase-6 design work or broader OpenMP support forward.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ fTimer fits best when you want timing behavior you can trust:
 - local summaries are live snapshots: active timers are included explicitly and marked in the data model/report output
 - local summary entries retain formatter-friendly preorder `name`/`depth` data and also expose explicit `node_id`/`parent_id` tree links
 - pure-MPI reductions return a distinct `ftimer_mpi_summary_t` with globally meaningful fields on every participating rank
-- sparse/union MPI summaries have a separate opt-in API and result model reserved for rank-conditional timers
+- a sparse/union MPI API and result model are defined for future rank-conditional summaries; the builder is deferred and currently returns `FTIMER_ERR_NOT_IMPLEMENTED`
 - an injectable clock supports deterministic tests and controlled benchmarking
 - optional callback hooks let in-process code observe normal timer start/stop events during a run
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ fTimer fits best when you want timing behavior you can trust:
 - local summaries are live snapshots: active timers are included explicitly and marked in the data model/report output
 - local summary entries retain formatter-friendly preorder `name`/`depth` data and also expose explicit `node_id`/`parent_id` tree links
 - pure-MPI reductions return a distinct `ftimer_mpi_summary_t` with globally meaningful fields on every participating rank
+- sparse/union MPI summaries have a separate opt-in API and result model reserved for rank-conditional timers
 - an injectable clock supports deterministic tests and controlled benchmarking
 - optional callback hooks let in-process code observe normal timer start/stop events during a run
 
@@ -80,7 +81,7 @@ end block
 
 The guard starts the named timer through the default procedural instance and stops that same activation when the guard leaves scope. Call `guard%stop(ierr=ierr)` when you need to observe the stop result before scope exit. For non-lexical lifetimes, cached-id hot paths, or complex ownership, prefer explicit `ftimer_start`/`ftimer_stop`.
 
-Use `ftimer` for the procedural API and `ftimer_types` for shared types and constants such as `ftimer_summary_t`, `ftimer_mpi_summary_t`, `ftimer_metadata_t`, and `FTIMER_MISMATCH_*`.
+Use `ftimer` for the procedural API and `ftimer_types` for shared types and constants such as `ftimer_summary_t`, `ftimer_mpi_summary_t`, `ftimer_mpi_union_summary_t`, `ftimer_metadata_t`, and `FTIMER_MISMATCH_*`.
 
 For metadata headers, construct `ftimer_metadata_t` values by assigning `%key` and `%value` directly. These fields use allocatable-length storage, so assigned strings are not silently capped at the legacy 64-character threshold. fTimer does not currently provide a helper constructor such as `ftimer_metadata(...)`; for formatted numeric metadata, write to a temporary character variable and then assign that string to `%value`.
 
@@ -196,7 +197,7 @@ The repository includes a worked example under `examples/instrumentation_facade_
 
 The public API supports two styles:
 
-- Procedural API from `use ftimer`, including `ftimer_init`, `ftimer_finalize`, `ftimer_start`, `ftimer_stop`, `ftimer_scope`, `ftimer_guard_t`, `ftimer_start_id`, `ftimer_stop_id`, `ftimer_lookup`, `ftimer_reset`, `ftimer_get_summary`, `ftimer_mpi_summary`, `ftimer_print_summary`, `ftimer_write_summary`, `ftimer_write_summary_csv`, `ftimer_print_mpi_summary`, `ftimer_write_mpi_summary`, `ftimer_write_mpi_summary_csv`, and `ftimer_default_instance`
+- Procedural API from `use ftimer`, including `ftimer_init`, `ftimer_finalize`, `ftimer_start`, `ftimer_stop`, `ftimer_scope`, `ftimer_guard_t`, `ftimer_start_id`, `ftimer_stop_id`, `ftimer_lookup`, `ftimer_reset`, `ftimer_get_summary`, `ftimer_mpi_summary`, `ftimer_mpi_union_summary`, `ftimer_print_summary`, `ftimer_write_summary`, `ftimer_write_summary_csv`, `ftimer_print_mpi_summary`, `ftimer_write_mpi_summary`, `ftimer_write_mpi_summary_csv`, and `ftimer_default_instance`
 - OOP API through `type(ftimer_t)` in `ftimer_core`, including the explicit configuration methods `set_clock`, `clear_clock`, `set_callback`, and `clear_callback`
 
 New users should start with the procedural API unless they already know they need instance-level control. Reach for `type(ftimer_t)` when you want multiple independent timer objects, want to avoid the default global instance, or need to manage clock or callback configuration on a specific timer object. Procedural callers that need those advanced controls can use `ftimer_default_instance%...` explicitly.
@@ -223,6 +224,10 @@ Operational notes:
 - `mpi_summary()` and `ftimer_mpi_summary()` require `FTIMER_USE_MPI=ON`, a fully stopped timer set, and collective agreement on the communicator captured by `init`.
 - A successful MPI reduction returns a distinct `ftimer_mpi_summary_t` whose fields are globally meaningful on every participating rank.
 - The MPI result includes communicator-local rank attribution for total-time extrema and per-entry inclusive-time extrema. Ties resolve to the lowest rank that attains the extremum.
+- Sparse/union MPI summaries are reserved for the separate `mpi_union_summary()` / `ftimer_mpi_union_summary()` API and `ftimer_mpi_union_summary_t` result type. The API shape and result fields are public, but the descriptor-union builder is deferred to #170 and currently returns `FTIMER_ERR_NOT_IMPLEMENTED`.
+- `ftimer_mpi_union_summary_t` keeps communicator total-time fields as all-rank statistics. Each entry records `participating_rank_count`; missing rank count is derived as `num_ranks - participating_rank_count`, and entry min/avg/max statistics are defined over participating ranks only.
+- Sparse entries are materialized from descriptors emitted by each rank's local summary. Lookup-only timer definitions are not a first-class sparse-registration contract, absent ranks are not zero-filled, and no all-rank amortized compatibility fields are included in the initial result model.
+- Sparse text and CSV reporting entry points are deferred to #171; current MPI report functions remain strict-summary report paths.
 - `print_mpi_summary()` and `write_mpi_summary()` are the first-class MPI reporting paths. They perform the collective MPI summary build and emit one abbreviated report from communicator root. The printed per-entry table is not a serialization of every `ftimer_mpi_summary_t` field; inspect `mpi_summary()` results for min/max self time, self imbalance, min/max call counts, min/max rank-local `% Total`, and explicit `node_id`/`parent_id` tree links.
 - `write_mpi_summary_csv()` and `ftimer_write_mpi_summary_csv()` perform the same collective MPI summary build and write one CSV artifact from communicator root. The CSV includes the complete reduced MPI entry fields, including explicit tree links and inclusive-time extrema ranks.
 - In MPI text reports, `Avg %` means the arithmetic mean of each rank's local `% Total` for that timer, not `100*Avg Incl/Avg total time`.
@@ -322,14 +327,14 @@ Use a separate build directory for each compiler or mode. Reconfiguring the same
 - MPI summary reductions select MPI datatypes with `MPI_Type_match_size` for fTimer's actual `real(wp)` and `integer(int64)` storage sizes instead of assuming fixed `MPI_DOUBLE_PRECISION`, `MPI_2DOUBLE_PRECISION`, or `MPI_INTEGER8` mappings. The compile-time MPI probe validates that this API is available through the `mpi_f08` path; if the API exists but no matching runtime datatype can be returned, `mpi_summary()` temporarily requests MPI error returns for the datatype lookup, fails with `FTIMER_ERR_UNKNOWN`, and leaves the MPI result empty.
 - `mpi_summary()` now returns a distinct `ftimer_mpi_summary_t`; it does not fall back to a local `ftimer_summary_t` on MPI-disabled or MPI-error paths. Call `get_summary()` separately if you need local data in those cases.
 - Descriptor-preflight failures inside one communicator now report the disagreeing communicator-local ranks in the omitted-`ierr` diagnostic path when possible.
-- Rank-conditional timer reductions are not supported by the current strict `mpi_summary()` API. Sparse/union MPI summaries are planned as a separate opt-in path; see [`docs/mpi-sparse-summary-decision.md`](docs/mpi-sparse-summary-decision.md).
+- Rank-conditional timer reductions are not supported by the current strict `mpi_summary()` API. Sparse/union MPI summaries are defined as the separate opt-in `mpi_union_summary()` / `ftimer_mpi_union_summary()` API with `ftimer_mpi_union_summary_t`; the descriptor-union builder is deferred to #170. See [`docs/mpi-sparse-summary-decision.md`](docs/mpi-sparse-summary-decision.md).
 - Local summary `node_id` values are not a cross-run identity contract. Treat them as explicit links inside one produced summary object, not as durable ids across separate runs or independently produced summaries.
 - All ranks that participate in `mpi_summary()` must agree on the communicator captured by `init`. If would-be participants diverge onto different communicators, the library cannot safely discover that mistake after the split; the practical failure mode is a hang, not a clean local fallback.
 - `FTIMER_USE_OPENMP=ON` enables only limited master-thread-only guards. Worker-thread timer calls inside an OpenMP parallel region are silent no-ops. To time a parallel region as a whole, place `start`/`stop` outside the `!$omp parallel` block.
 - The OpenMP path does not make fTimer thread-safe, does not provide thread-local timer instances, and should not be read as a general hybrid MPI+OpenMP timing model.
 - Future real hybrid MPI+OpenMP timing is deferred pending concrete adopter demand; see [`docs/openmp-hybrid-strategy-decision.md`](docs/openmp-hybrid-strategy-decision.md).
 - `on_event` remains a lightweight intra-run hook, not a serious profiler-backend integration contract with stable semantic timer identity.
-- If `FTIMER_USE_MPI=OFF`, `mpi_summary()` returns `FTIMER_ERR_NOT_IMPLEMENTED` and leaves the MPI result empty.
+- If `FTIMER_USE_MPI=OFF`, `mpi_summary()` and `mpi_union_summary()` return `FTIMER_ERR_NOT_IMPLEMENTED` and leave their MPI result objects empty.
 - Formatted local and MPI report output are separate paths: `print_summary()`/`write_summary()` are local, while `print_mpi_summary()`/`write_mpi_summary()` emit communicator-level MPI reports from root. MPI reports are deliberately abbreviated; `ftimer_mpi_summary_t` remains the complete structured data model.
 
 ## Performance Measurement

--- a/docs/design.md
+++ b/docs/design.md
@@ -114,7 +114,7 @@ The CMake source order reflects the real dependency order:
 
 `ftimer_summary.F90` is an internal summary/report helper module. It turns timer state into structured local summaries and formatted report text. This is where entry ordering, explicit summary-tree linkage (`node_id`/`parent_id`), depth attribution, percentages, and self-time computation are assembled for local reporting.
 
-`ftimer_mpi.F90` is an internal MPI summary helper module. It adds cross-rank behavior on top of local summaries, uses communicator-wide preflight collectives to verify that all ranks agree on the timer descriptor set, and then populates reduced MPI fields only where that contract allows.
+`ftimer_mpi.F90` is an internal MPI summary helper module. It adds cross-rank behavior on top of local summaries, uses communicator-wide preflight collectives to verify that all ranks agree on the timer descriptor set, and then populates reduced MPI fields only where that contract allows. It also owns the #169 sparse/union API skeleton so the future descriptor-union builder can share the same communicator and datatype-validation contracts without weakening strict `mpi_summary()`.
 
 `ftimer.F90` exposes the procedural API by forwarding to the default saved `ftimer_t` instance. Shared types and constants still come from `ftimer_types`; they are not re-exported from `ftimer`.
 
@@ -131,6 +131,7 @@ The current implementation is organized around a few design choices that show up
 - Per-segment context selection remains fully context-sensitive, but it now uses a per-segment parent-stack index in steady state instead of rescanning the known parent-stack variants for that timer on every hit.
 - Callback hooks are lightweight intra-run hooks for normal start/stop events only; internal mismatch repair transitions must stay invisible to callback consumers, and current `main` does not define a stronger profiler-backend identity contract.
 - MPI summary-field reductions are descriptor-validated first, and reduced cross-rank fields are valid only in the documented result shape. The validation itself uses MPI collectives over the init communicator before any timer-data reduction assumes matching canonical entries.
+- Sparse/union MPI summaries are a separate opt-in result shape. They will build a descriptor union with participation-aware entry statistics; the current code intentionally stops at the public API and data model pending #170.
 - MPI timed regions are rank-local wall-clock intervals unless the caller adds
   synchronization; `mpi_summary()` reduces the recorded intervals but does not
   imply phase-entry or phase-exit barriers.
@@ -162,6 +163,7 @@ The currently exported procedural entry points are:
 - `ftimer_reset`
 - `ftimer_get_summary`
 - `ftimer_mpi_summary`
+- `ftimer_mpi_union_summary`
 - `ftimer_print_summary`
 - `ftimer_write_summary`
 - `ftimer_write_summary_csv`
@@ -184,11 +186,12 @@ Important current-state API notes:
 - `print_summary()` and `write_summary()` format local report text.
 - `write_summary_csv()` exports local summaries in the versioned CSV record format for non-Fortran tooling.
 - `mpi_summary()` returns a distinct `ftimer_mpi_summary_t` whose fields are globally meaningful on every participating rank.
+- `mpi_union_summary()` is the separate opt-in sparse/union MPI API. Its public result model is `ftimer_mpi_union_summary_t`; the descriptor-union builder is deferred to #170 and the current skeleton returns `FTIMER_ERR_NOT_IMPLEMENTED` after the same prerequisite checks used by MPI summaries.
 - `print_mpi_summary()` and `write_mpi_summary()` are the first-class communicator-level MPI reporting paths.
 - `write_mpi_summary_csv()` exports the full reduced MPI summary fields as the same versioned CSV record format from communicator root.
 - `set_clock()` / `clear_clock()` and `set_callback()` / `clear_callback()` are the supported configuration entry points; direct mutation of raw runtime internals is no longer part of the public contract.
 - `on_event` remains a lightweight intra-run hook; the current public surface does not promise stable semantic timer identity for external-profiler integrations.
-- `ftimer_types` owns `ftimer_summary_t`, `ftimer_mpi_summary_t`, `ftimer_metadata_t`, and mismatch constants.
+- `ftimer_types` owns `ftimer_summary_t`, `ftimer_mpi_summary_t`, `ftimer_mpi_union_summary_t`, `ftimer_metadata_t`, and mismatch constants.
 
 ## Build, Test, and CI Reality
 

--- a/docs/mpi-sparse-summary-decision.md
+++ b/docs/mpi-sparse-summary-decision.md
@@ -14,6 +14,12 @@ Follow-up work is split into:
 - #170: implement the descriptor-union summary builder
 - #171: add sparse MPI reporting, docs, and adoption tests
 
+Issue #169 chooses the public shape for that follow-up:
+
+- Sparse MPI summaries use a separate opt-in API: `mpi_union_summary()` on `type(ftimer_t)` and `ftimer_mpi_union_summary()` for the procedural default instance.
+- Sparse MPI summaries use a distinct result type: `ftimer_mpi_union_summary_t` with `ftimer_mpi_union_summary_entry_t` entries. The strict `ftimer_mpi_summary_t` shape is not extended with sparse-only fields.
+- The #169 API skeleton is public and compile-checked, but the descriptor-union builder is still deferred to #170. Until that builder lands, `mpi_union_summary()` returns `FTIMER_ERR_NOT_IMPLEMENTED` after preserving the same stopped-timer, communicator, datatype-validation, no-local-fallback, and `ierr`/stderr preconditions as the strict MPI summary path.
+
 ## Evidence
 
 The current implementation is strict by construction:
@@ -56,10 +62,13 @@ The sparse path should differ from strict `mpi_summary()` in these ways:
 - Missing-rank count is a required semantic, but it does not need to be stored redundantly: `absent_rank_count = num_ranks - participating_rank_count`.
 - A present zero-call entry, if the sparse data model materializes one, is still participating. It contributes zero calls and its recorded time values to participating-rank statistics.
 - An absent rank does not participate in per-entry min, max, or participating-rank averages.
+- `min_*`, `avg_*`, `max_*`, imbalance, call-count, and rank-local percent statistics in `ftimer_mpi_union_summary_entry_t` are defined over participating ranks only.
 - Initial per-entry rank-attributed extrema should preserve parity with the current strict MPI result by covering inclusive-time extrema; additional rank-attributed extrema for self time, call count, or percent time should wait for a concrete consumer need.
 - Communicator total-time fields remain all-rank fields because every rank has a local summary window even when some entries are sparse.
 
-The first sparse implementation should not provide an implicit zero-filled compatibility mode. Zero filling makes absence too easy to confuse with real zero work. If an all-rank amortized view is added later, it should be explicitly named and derived from participation-aware data rather than replacing participating-rank statistics.
+The first sparse implementation should not provide an implicit zero-filled compatibility mode. Zero filling makes absence too easy to confuse with real zero work. If an all-rank amortized view is added later, it should be explicitly named and derived from participation-aware data rather than replacing participating-rank statistics. No all-rank zero-filled fields are part of the #169 result type.
+
+The sparse API follows the same `mpi_f08` primary contract as strict MPI summaries: communicator choice is captured at `init` as `type(MPI_Comm)` on the validated path, with legacy integer communicator capture remaining only as transitional compatibility until #187 removes it. No sparse API overload is added for per-call communicator selection, so #187 does not need to change the sparse summary entry point.
 
 ## Non-Goals
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -4,7 +4,7 @@
 
 This document describes the current runtime contract on `main`.
 
-Current `main` implements the Phase 2 core timer behavior, Phase 3 local summary/reporting behavior, Phase 4 procedural wrappers, Phase 5 MPI structured summaries, and the Phase 6 OpenMP guard behavior: stack-based start/stop timing, context-sensitive accounting, strict/warn/repair mismatch handling, `lookup`, `reset`, the procedural `ftimer_scope` scoped guard, the `ierr` vs stderr error contract, `get_summary()`, `print_summary()`, `write_summary()`, `write_summary_csv()`, `mpi_summary()`, `print_mpi_summary()`, `write_mpi_summary()`, `write_mpi_summary_csv()`, self-time computation, callback suppression during repair, descriptor-hash MPI preflight, globally meaningful MPI min/avg/max summary fields on every participating rank, and limited master-thread-only OpenMP guards in `ftimer_core` when built with `FTIMER_USE_OPENMP=ON`. In non-MPI builds, `mpi_summary()` returns `FTIMER_ERR_NOT_IMPLEMENTED` with an empty MPI summary result.
+Current `main` implements the Phase 2 core timer behavior, Phase 3 local summary/reporting behavior, Phase 4 procedural wrappers, Phase 5 MPI structured summaries, and the Phase 6 OpenMP guard behavior: stack-based start/stop timing, context-sensitive accounting, strict/warn/repair mismatch handling, `lookup`, `reset`, the procedural `ftimer_scope` scoped guard, the `ierr` vs stderr error contract, `get_summary()`, `print_summary()`, `write_summary()`, `write_summary_csv()`, `mpi_summary()`, `mpi_union_summary()` API/data-model skeletons, `print_mpi_summary()`, `write_mpi_summary()`, `write_mpi_summary_csv()`, self-time computation, callback suppression during repair, descriptor-hash MPI preflight, globally meaningful MPI min/avg/max summary fields on every participating rank, and limited master-thread-only OpenMP guards in `ftimer_core` when built with `FTIMER_USE_OPENMP=ON`. In non-MPI builds, `mpi_summary()` and `mpi_union_summary()` return `FTIMER_ERR_NOT_IMPLEMENTED` with empty MPI summary results.
 
 This contract is strongest for disciplined serial and pure-MPI wall-clock timing. The OpenMP path is a narrow master-thread-only carve-out for bracketing a parallel region as a whole, not a general hybrid-thread timing contract. Likewise, `on_event` is a lightweight intra-run hook, not a stable external-profiler integration API.
 
@@ -192,7 +192,7 @@ This disabled-facade behavior is an application integration contract, not an alt
 - Hash-based timer-descriptor preflight before the reduction phase
 - The strict MPI preflight compares rank-local descriptor hashes against a rank-0 reference hash, then reduces a mismatch flag across the communicator. Successful summaries do not allgather every rank's hashes or exchange exact descriptor strings.
 - Extra timers, missing timers, renamed timers, and hierarchy/context mismatches fail the MPI summary with `FTIMER_ERR_MPI_INCON`; they do not fall back to a local summary object through the MPI API
-- Rank-conditional timer reductions are not supported by the current strict `mpi_summary()` API. Sparse/union MPI summaries are planned as a separate opt-in path; see [`docs/mpi-sparse-summary-decision.md`](mpi-sparse-summary-decision.md).
+- Rank-conditional timer reductions are not supported by the current strict `mpi_summary()` API. Sparse/union MPI summaries are defined as the separate opt-in `mpi_union_summary()` / `ftimer_mpi_union_summary()` API and `ftimer_mpi_union_summary_t` result model; the descriptor-union builder is deferred to #170, so the current API skeleton returns `FTIMER_ERR_NOT_IMPLEMENTED`. See [`docs/mpi-sparse-summary-decision.md`](mpi-sparse-summary-decision.md).
 - When that descriptor preflight fails inside one communicator, the omitted-`ierr` diagnostic reports the disagreeing communicator-local ranks when possible
 - MPI descriptor matching is based on the local summary tree shape and names, not on raw local `node_id` values
 - The MPI descriptor preflight materializes deterministic length-prefixed path strings at summary time so names that differ only after the legacy 64-character threshold remain distinguishable. This is outside the start/stop hot path, but its memory and sort cost scales with summary entry count and encoded path length for very large timer trees.
@@ -217,6 +217,20 @@ The supported pattern is simple: capture one communicator consistently at `init`
 - The MPI summary tree order is canonical across ranks. It does not depend on the local timer creation order on one chosen rank.
 - `mpi_summary()` does not return local fallback data on errors. If the caller needs local data after an MPI-disabled or MPI-error path, it must call `get_summary()` separately.
 - This datatype selection remains the portability guard for the current `mpi_f08` implementation and preserves the reduction-datatype work completed before the interface migration.
+
+## Sparse/Union MPI Summary Contract
+
+`mpi_union_summary()` is the explicit opt-in path reserved for rank-conditional timers. It is a separate API from strict `mpi_summary()`, not a mode argument, so existing strict calls cannot silently relax descriptor consistency. The procedural wrapper is `ftimer_mpi_union_summary()`.
+
+- The sparse result type is `ftimer_mpi_union_summary_t`, with `ftimer_mpi_union_summary_entry_t` entries. It does not reuse or extend `ftimer_mpi_summary_t`, whose semantics remain strict identical-tree semantics.
+- Top-level communicator total-time fields remain all-rank fields because every rank contributes a local summary window.
+- Per-entry `participating_rank_count` records how many communicator ranks materialized that descriptor. Missing rank count is derived as `num_ranks - participating_rank_count` and is not stored redundantly.
+- Descriptors are materialized from the local summary emitted on each rank. Lookup-only timer definitions do not count as present unless a future issue adds a first-class registration contract.
+- A materialized present zero-call entry is participating and contributes zero calls plus its recorded time values to participating-rank statistics. An absent rank contributes only to the derived missing-rank count.
+- Entry min/avg/max time, call-count, percent, and imbalance fields are defined over participating ranks only. Absent ranks are not zero-filled.
+- No all-rank zero-filled or amortized entry fields are part of the initial result model. If such a view is added later, it must be explicitly named as all-rank or amortized.
+- The sparse API keeps the same init-captured communicator model as strict MPI summaries. The primary path is `mpi_f08` `type(MPI_Comm)`; transitional integer communicator capture remains only through `init` until #187 removes it.
+- The current #169 implementation defines and compile-checks the public API and data model. The descriptor-union builder is #170, and sparse report output is #171.
 
 ## MPI Reporting Contract
 

--- a/src/ftimer.F90
+++ b/src/ftimer.F90
@@ -2,7 +2,7 @@ module ftimer
    use, intrinsic :: iso_fortran_env, only: error_unit, int64
    use ftimer_core, only: ftimer_internal_start_scope_activation, ftimer_internal_stop_scope_activation, ftimer_t
    use ftimer_types, only: FTIMER_ERR_ACTIVE, FTIMER_SUCCESS, ftimer_metadata_t, ftimer_mpi_summary_t, &
-                           ftimer_summary_t
+                           ftimer_mpi_union_summary_t, ftimer_summary_t
 #ifdef FTIMER_USE_MPI
    use mpi_f08, only: MPI_Comm
 #endif
@@ -21,6 +21,7 @@ module ftimer
    public :: ftimer_reset
    public :: ftimer_get_summary
    public :: ftimer_mpi_summary
+   public :: ftimer_mpi_union_summary
    public :: ftimer_print_summary
    public :: ftimer_write_summary
    public :: ftimer_write_summary_csv
@@ -216,6 +217,13 @@ contains
 
       call ftimer_default_instance%mpi_summary(summary, ierr=ierr)
    end subroutine ftimer_mpi_summary
+
+   subroutine ftimer_mpi_union_summary(summary, ierr)
+      type(ftimer_mpi_union_summary_t), intent(out) :: summary
+      integer, intent(out), optional :: ierr
+
+      call ftimer_default_instance%mpi_union_summary(summary, ierr=ierr)
+   end subroutine ftimer_mpi_union_summary
 
    subroutine ftimer_print_summary(unit, metadata, ierr)
       integer, intent(in), optional :: unit

--- a/src/ftimer_core.F90
+++ b/src/ftimer_core.F90
@@ -6,7 +6,7 @@ module ftimer_core
                            FTIMER_ERR_NOT_INIT, FTIMER_ERR_UNKNOWN, FTIMER_EVENT_START, FTIMER_EVENT_STOP, &
                            FTIMER_MISMATCH_REPAIR, FTIMER_MISMATCH_STRICT, FTIMER_MISMATCH_WARN, FTIMER_SUCCESS, &
                            ftimer_call_stack_t, ftimer_clock_func, ftimer_hook_proc, ftimer_metadata_t, &
-                           ftimer_mpi_summary_t, ftimer_segment_t, ftimer_summary_t, wp
+                           ftimer_mpi_summary_t, ftimer_mpi_union_summary_t, ftimer_segment_t, ftimer_summary_t, wp
 #ifdef FTIMER_USE_MPI
    use mpi_f08, only: MPI_Comm, MPI_COMM_WORLD
 #endif
@@ -95,6 +95,7 @@ module ftimer_core
       procedure :: reset
       procedure :: get_summary
       procedure :: mpi_summary
+      procedure :: mpi_union_summary
       procedure :: print_summary
       procedure :: write_summary
       procedure :: write_summary_csv
@@ -118,6 +119,12 @@ module ftimer_core
          type(ftimer_mpi_summary_t), intent(out) :: summary
          integer, intent(out), optional :: ierr
       end subroutine mpi_summary
+
+      module subroutine mpi_union_summary(self, summary, ierr)
+         class(ftimer_t), intent(in) :: self
+         type(ftimer_mpi_union_summary_t), intent(out) :: summary
+         integer, intent(out), optional :: ierr
+      end subroutine mpi_union_summary
 
       module subroutine print_summary(self, unit, metadata, ierr)
          class(ftimer_t), intent(in) :: self

--- a/src/ftimer_core_summary_bindings.F90
+++ b/src/ftimer_core_summary_bindings.F90
@@ -1,11 +1,12 @@
 submodule(ftimer_core) ftimer_core_summary_bindings
    use, intrinsic :: iso_fortran_env, only: error_unit, output_unit
    use ftimer_clock, only: ftimer_date_string
-   use ftimer_mpi, only: build_mpi_summary, check_mpi_summary_prereqs, get_mpi_summary_comm_info
+   use ftimer_mpi, only: build_mpi_summary, build_mpi_union_summary, check_mpi_summary_prereqs, &
+                         get_mpi_summary_comm_info
    use ftimer_summary, only: build_summary, format_mpi_summary, format_summary
    use ftimer_types, only: FTIMER_ERR_MPI_INCON, FTIMER_ERR_NOT_IMPLEMENTED, FTIMER_ERR_UNKNOWN, &
                            ftimer_metadata_t, ftimer_mpi_summary_entry_t, ftimer_mpi_summary_t, &
-                           ftimer_summary_entry_t, ftimer_summary_t, wp
+                           ftimer_mpi_union_summary_t, ftimer_summary_entry_t, ftimer_summary_t, wp
 #ifdef FTIMER_USE_MPI
    use mpi_f08, only: MPI_Bcast, MPI_CHARACTER, MPI_INTEGER, MPI_SUCCESS
 #endif
@@ -42,6 +43,25 @@ contains
 
    if (present(ierr)) ierr = FTIMER_SUCCESS
    end procedure mpi_summary
+
+   module procedure mpi_union_summary
+   character(len=256) :: diagnostic
+   integer :: status
+
+   if (.not. self%initialized) then
+      call reset_mpi_union_summary(summary)
+      call report_summary_status(ierr, FTIMER_ERR_NOT_INIT, "ftimer mpi_union_summary before init")
+      return
+   end if
+
+   call build_current_mpi_union_summary(self, summary, status, diagnostic)
+   if (status /= FTIMER_SUCCESS) then
+      call report_mpi_union_summary_error(ierr, status, diagnostic)
+      return
+   end if
+
+   if (present(ierr)) ierr = FTIMER_SUCCESS
+   end procedure mpi_union_summary
 
    module procedure print_summary
    type(ftimer_summary_t) :: summary
@@ -502,6 +522,43 @@ contains
       if (status /= FTIMER_SUCCESS) call reset_mpi_summary(summary)
    end subroutine build_current_mpi_summary
 
+   subroutine build_current_mpi_union_summary(self, summary, status, diagnostic)
+      class(ftimer_t), intent(in) :: self
+      type(ftimer_mpi_union_summary_t), intent(out) :: summary
+      integer, intent(out) :: status
+      character(len=*), intent(out) :: diagnostic
+      type(ftimer_summary_t) :: local_summary
+      logical :: local_has_active_timers
+
+      diagnostic = ''
+      local_has_active_timers = self%call_stack%depth > 0
+      call build_current_summary(self, local_summary)
+#ifdef FTIMER_USE_MPI
+      if (self%mpi_comm_was_present) then
+         call check_mpi_summary_prereqs(local_has_active_timers, self%mpi_comm, status)
+      else
+         call check_mpi_summary_prereqs(local_has_active_timers, status=status)
+      end if
+#else
+      call check_mpi_summary_prereqs(local_has_active_timers, status=status)
+#endif
+      if (status /= FTIMER_SUCCESS) then
+         call reset_mpi_union_summary(summary)
+         return
+      end if
+
+#ifdef FTIMER_USE_MPI
+      if (self%mpi_comm_was_present) then
+         call build_mpi_union_summary(local_summary, self%mpi_comm, summary, status, diagnostic)
+      else
+         call build_mpi_union_summary(local_summary, summary=summary, status=status, diagnostic=diagnostic)
+      end if
+#else
+      call build_mpi_union_summary(local_summary, summary=summary, status=status, diagnostic=diagnostic)
+#endif
+      if (status /= FTIMER_SUCCESS) call reset_mpi_union_summary(summary)
+   end subroutine build_current_mpi_union_summary
+
    subroutine format_summary_csv(summary, text, metadata, include_header)
       type(ftimer_summary_t), intent(in) :: summary
       character(len=:), allocatable, intent(out) :: text
@@ -820,6 +877,20 @@ contains
       summary%total_time_imbalance = 1.0_wp
    end subroutine reset_mpi_summary
 
+   subroutine reset_mpi_union_summary(summary)
+      type(ftimer_mpi_union_summary_t), intent(out) :: summary
+
+      if (allocated(summary%entries)) deallocate (summary%entries)
+      summary%num_ranks = 0
+      summary%num_entries = 0
+      summary%min_total_time = 0.0_wp
+      summary%max_total_time = 0.0_wp
+      summary%avg_total_time = 0.0_wp
+      summary%min_total_time_rank = -1
+      summary%max_total_time_rank = -1
+      summary%total_time_imbalance = 1.0_wp
+   end subroutine reset_mpi_union_summary
+
    subroutine report_summary_status(ierr, code, message)
       integer, intent(out), optional :: ierr
       integer, intent(in) :: code
@@ -860,6 +931,39 @@ contains
          end if
       end select
    end subroutine report_mpi_summary_error
+
+   subroutine report_mpi_union_summary_error(ierr, status, diagnostic)
+      integer, intent(out), optional :: ierr
+      integer, intent(in) :: status
+      character(len=*), intent(in) :: diagnostic
+
+      select case (status)
+      case (FTIMER_ERR_NOT_IMPLEMENTED)
+         if (len_trim(diagnostic) > 0) then
+            call report_summary_status(ierr, status, trim(diagnostic))
+         else
+            call report_summary_status(ierr, status, "ftimer mpi_union_summary requires FTIMER_USE_MPI=ON")
+         end if
+      case (FTIMER_ERR_ACTIVE)
+         call report_summary_status(ierr, status, &
+                                    "ftimer mpi_union_summary requires all timers stopped before reduction on "// &
+                                    "the init communicator")
+      case (FTIMER_ERR_MPI_INCON)
+         if (len_trim(diagnostic) > 0) then
+            call report_summary_status(ierr, status, trim(diagnostic))
+         else
+            call report_summary_status(ierr, status, &
+                                       "ftimer mpi_union_summary detected invalid sparse timer descriptors across "// &
+                                       "ranks in the init communicator")
+         end if
+      case default
+         if (len_trim(diagnostic) > 0) then
+            call report_summary_status(ierr, status, trim(diagnostic))
+         else
+            call report_summary_status(ierr, status, "ftimer mpi_union_summary MPI reduction failed")
+         end if
+      end select
+   end subroutine report_mpi_union_summary_error
 
    subroutine get_csv_header_mode(filename, append_mode, include_header, status, iomsg)
       character(len=*), intent(in) :: filename

--- a/src/ftimer_mpi.F90
+++ b/src/ftimer_mpi.F90
@@ -1,8 +1,8 @@
 module ftimer_mpi
    use, intrinsic :: iso_fortran_env, only: int64
    use ftimer_types, only: FTIMER_ERR_ACTIVE, FTIMER_ERR_MPI_INCON, FTIMER_ERR_NOT_IMPLEMENTED, &
-                           FTIMER_ERR_UNKNOWN, FTIMER_SUCCESS, ftimer_mpi_summary_t, ftimer_summary_entry_t, &
-                           ftimer_summary_t, wp
+                           FTIMER_ERR_UNKNOWN, FTIMER_SUCCESS, ftimer_mpi_summary_t, ftimer_mpi_union_summary_t, &
+                           ftimer_summary_entry_t, ftimer_summary_t, wp
 #ifdef FTIMER_USE_MPI
    use mpi_f08, only: MPI_Allgather, MPI_Allreduce, MPI_Bcast, MPI_CHARACTER, MPI_Comm, MPI_COMM_NULL, &
                       MPI_COMM_SELF, MPI_COMM_WORLD, MPI_Datatype, MPI_DATATYPE_NULL, MPI_Errhandler, &
@@ -15,6 +15,7 @@ module ftimer_mpi
    private
 
    public :: build_mpi_summary
+   public :: build_mpi_union_summary
    public :: check_mpi_summary_prereqs
    public :: ftimer_mpi_enabled
    public :: get_mpi_summary_comm_info
@@ -543,6 +544,59 @@ contains
 #endif
    end subroutine build_mpi_summary
 
+   subroutine build_mpi_union_summary(local_summary, comm, summary, status, diagnostic)
+      type(ftimer_summary_t), intent(in) :: local_summary
+#ifdef FTIMER_USE_MPI
+      type(MPI_Comm), intent(in), optional :: comm
+#else
+      integer, intent(in), optional :: comm
+#endif
+      type(ftimer_mpi_union_summary_t), intent(out) :: summary
+      integer, intent(out) :: status
+      character(len=*), intent(out), optional :: diagnostic
+#ifdef FTIMER_USE_MPI
+      type(MPI_Comm) :: active_comm
+      integer :: all_datatypes_ready
+      integer :: datatypes_ready
+      integer :: mpierr
+      integer :: nprocs
+      integer :: rank
+      type(MPI_Datatype) :: mpi_int64_type
+      type(MPI_Datatype) :: mpi_wp_type
+
+      call clear_mpi_union_summary(summary)
+      if (present(diagnostic)) diagnostic = ''
+
+      call get_mpi_summary_comm_info(comm, active_comm, rank, nprocs, status)
+      if (status /= FTIMER_SUCCESS) return
+
+      call resolve_mpi_summary_datatypes(mpi_wp_type, mpi_int64_type, status, diagnostic)
+      datatypes_ready = 0
+      if (status == FTIMER_SUCCESS) datatypes_ready = 1
+      call ftimer_mpi_allreduce(datatypes_ready, all_datatypes_ready, 1, MPI_INTEGER, MPI_MIN, active_comm, mpierr)
+      if (mpierr /= MPI_SUCCESS) then
+         status = FTIMER_ERR_UNKNOWN
+         return
+      end if
+      if (all_datatypes_ready /= 1) then
+         if (status == FTIMER_SUCCESS) then
+            status = FTIMER_ERR_UNKNOWN
+            if (present(diagnostic)) diagnostic = &
+               "ftimer mpi_union_summary datatype validation failed on another rank"
+         end if
+         return
+      end if
+
+      if (present(diagnostic)) diagnostic = &
+         "ftimer mpi_union_summary descriptor-union builder is not implemented yet"
+      status = FTIMER_ERR_NOT_IMPLEMENTED
+#else
+      call clear_mpi_union_summary(summary)
+      if (present(diagnostic)) diagnostic = ''
+      status = FTIMER_ERR_NOT_IMPLEMENTED
+#endif
+   end subroutine build_mpi_union_summary
+
    subroutine clear_mpi_summary(summary)
       type(ftimer_mpi_summary_t), intent(out) :: summary
 
@@ -556,6 +610,20 @@ contains
       summary%max_total_time_rank = -1
       summary%total_time_imbalance = 1.0_wp
    end subroutine clear_mpi_summary
+
+   subroutine clear_mpi_union_summary(summary)
+      type(ftimer_mpi_union_summary_t), intent(out) :: summary
+
+      if (allocated(summary%entries)) deallocate (summary%entries)
+      summary%num_ranks = 0
+      summary%num_entries = 0
+      summary%min_total_time = 0.0_wp
+      summary%max_total_time = 0.0_wp
+      summary%avg_total_time = 0.0_wp
+      summary%min_total_time_rank = -1
+      summary%max_total_time_rank = -1
+      summary%total_time_imbalance = 1.0_wp
+   end subroutine clear_mpi_union_summary
 
 #ifdef FTIMER_USE_MPI
    subroutine resolve_mpi_summary_datatypes(mpi_wp_type, mpi_int64_type, status, diagnostic)

--- a/src/ftimer_types.F90
+++ b/src/ftimer_types.F90
@@ -25,6 +25,8 @@ module ftimer_types
    public :: ftimer_summary_t
    public :: ftimer_mpi_summary_entry_t
    public :: ftimer_mpi_summary_t
+   public :: ftimer_mpi_union_summary_entry_t
+   public :: ftimer_mpi_union_summary_t
    public :: ftimer_call_stack_t
    public :: ftimer_context_list_t
    public :: ftimer_segment_t
@@ -119,6 +121,45 @@ module ftimer_types
       integer :: max_total_time_rank = -1
       type(ftimer_mpi_summary_entry_t), allocatable :: entries(:)
    end type ftimer_mpi_summary_t
+
+   type :: ftimer_mpi_union_summary_entry_t
+      character(len=:), allocatable :: name
+      integer :: depth = 0
+      integer :: participating_rank_count = 0
+      ! Missing ranks are derived as summary%num_ranks - participating_rank_count.
+      ! Per-entry min/avg/max fields are over participating ranks only.
+      real(wp) :: min_inclusive_time = 0.0_wp
+      real(wp) :: max_inclusive_time = 0.0_wp
+      real(wp) :: avg_inclusive_time = 0.0_wp
+      real(wp) :: inclusive_imbalance = 1.0_wp
+      real(wp) :: min_self_time = 0.0_wp
+      real(wp) :: max_self_time = 0.0_wp
+      real(wp) :: avg_self_time = 0.0_wp
+      real(wp) :: self_imbalance = 1.0_wp
+      integer :: min_call_count = 0
+      integer :: max_call_count = 0
+      real(wp) :: avg_call_count = 0.0_wp
+      real(wp) :: min_pct_time = 0.0_wp
+      real(wp) :: max_pct_time = 0.0_wp
+      real(wp) :: avg_pct_time = 0.0_wp
+      ! Stable only within one produced summary object. Root nodes use parent_id = 0.
+      integer :: node_id = 0
+      integer :: parent_id = 0
+      integer :: min_inclusive_time_rank = -1
+      integer :: max_inclusive_time_rank = -1
+   end type ftimer_mpi_union_summary_entry_t
+
+   type :: ftimer_mpi_union_summary_t
+      integer :: num_ranks = 0
+      integer :: num_entries = 0
+      real(wp) :: min_total_time = 0.0_wp
+      real(wp) :: max_total_time = 0.0_wp
+      real(wp) :: avg_total_time = 0.0_wp
+      real(wp) :: total_time_imbalance = 1.0_wp
+      integer :: min_total_time_rank = -1
+      integer :: max_total_time_rank = -1
+      type(ftimer_mpi_union_summary_entry_t), allocatable :: entries(:)
+   end type ftimer_mpi_union_summary_t
 
    type :: ftimer_call_stack_t
       integer :: depth = 0

--- a/tests/install-consumer/mpi_main.F90
+++ b/tests/install-consumer/mpi_main.F90
@@ -1,7 +1,7 @@
 program ftimer_installed_mpi_consumer
-   use ftimer, only: ftimer_finalize, ftimer_init, ftimer_mpi_summary, ftimer_write_mpi_summary, &
-                     ftimer_start, ftimer_stop
-   use ftimer_types, only: ftimer_mpi_summary_t, wp
+   use ftimer, only: ftimer_finalize, ftimer_init, ftimer_mpi_summary, ftimer_mpi_union_summary, &
+                     ftimer_write_mpi_summary, ftimer_start, ftimer_stop
+   use ftimer_types, only: FTIMER_ERR_NOT_IMPLEMENTED, ftimer_mpi_summary_t, ftimer_mpi_union_summary_t, wp
    use mpi_f08
    implicit none
    integer :: ierr
@@ -9,6 +9,7 @@ program ftimer_installed_mpi_consumer
    integer :: rank
    real :: accumulator
    type(ftimer_mpi_summary_t) :: summary
+   type(ftimer_mpi_union_summary_t) :: union_summary
 
    call MPI_Init(ierr)
    if (ierr /= MPI_SUCCESS) error stop 1
@@ -40,14 +41,19 @@ program ftimer_installed_mpi_consumer
    if (summary%entries(1)%avg_inclusive_time < summary%entries(1)%min_inclusive_time) error stop 12
    if (summary%entries(1)%avg_call_count < 1.0_wp) error stop 13
 
+   call ftimer_mpi_union_summary(union_summary, ierr=ierr)
+   if (ierr /= FTIMER_ERR_NOT_IMPLEMENTED) error stop 14
+   if (union_summary%num_ranks /= 0) error stop 15
+   if (union_summary%num_entries /= 0) error stop 16
+
    call ftimer_write_mpi_summary("consumer_mpi_summary.txt", ierr=ierr)
-   if (ierr /= 0) error stop 14
+   if (ierr /= 0) error stop 17
 
    call ftimer_finalize(ierr=ierr)
-   if (ierr /= 0) error stop 15
+   if (ierr /= 0) error stop 18
 
    call MPI_Finalize(ierr)
-   if (ierr /= MPI_SUCCESS) error stop 16
+   if (ierr /= MPI_SUCCESS) error stop 19
 
    if (accumulator < 0.0) print *, accumulator
 end program ftimer_installed_mpi_consumer

--- a/tests/mpi/test_mpi_summary.pf
+++ b/tests/mpi/test_mpi_summary.pf
@@ -93,7 +93,6 @@ contains
       class(mpi_summary_case), intent(inout) :: this
       type(ftimer_t) :: timer
       type(ftimer_mpi_summary_t) :: summary
-      type(ftimer_mpi_union_summary_t) :: union_summary
       integer :: ierr
 
       call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
@@ -367,6 +366,7 @@ contains
       @assertEqual(FTIMER_ERR_ACTIVE, ierr)
       @assertEqual(0, union_summary%num_ranks)
       @assertEqual(0, union_summary%num_entries)
+      call assert_union_summary_empty(union_summary)
 
       fake_time = fake_time + 1.0_wp
       call timer%stop("active", ierr=ierr)
@@ -449,6 +449,39 @@ contains
       call ftimer_finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
    end subroutine test_mpi_union_summary_api_is_separate_from_strict_summary
+
+   @test
+   subroutine test_mpi_union_summary_sparse_input_is_not_strict_inconsistency(this)
+      class(mpi_summary_case), intent(inout) :: this
+      type(ftimer_t) :: timer
+      type(ftimer_mpi_union_summary_t) :: union_summary
+      integer :: ierr
+      integer :: rank
+
+      rank = this%getProcessRank()
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(timer)
+
+      if (rank == 0) then
+         fake_time = 0.0_wp
+         call timer%start("rank_zero_only", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = 2.0_wp
+         call timer%stop("rank_zero_only", ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+      else
+         fake_time = 2.0_wp
+      end if
+
+      call timer%mpi_union_summary(union_summary, ierr=ierr)
+
+      @assertEqual(FTIMER_ERR_NOT_IMPLEMENTED, ierr)
+      call assert_union_summary_empty(union_summary)
+
+      call timer%finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_mpi_union_summary_sparse_input_is_not_strict_inconsistency
 
    @test
    subroutine test_transitional_integer_comm_compatibility(this)
@@ -1397,7 +1430,9 @@ contains
 
    subroutine assert_union_summary_empty(summary)
       type(ftimer_mpi_union_summary_t), intent(in) :: summary
+      logical :: entries_allocated
 
+      entries_allocated = allocated(summary%entries)
       @assertEqual(0, summary%num_ranks)
       @assertEqual(0, summary%num_entries)
       @assertEqual(0.0_wp, summary%min_total_time)
@@ -1406,6 +1441,7 @@ contains
       @assertEqual(-1, summary%min_total_time_rank)
       @assertEqual(-1, summary%max_total_time_rank)
       @assertEqual(1.0_wp, summary%total_time_imbalance)
+      @assertFalse(entries_allocated)
    end subroutine assert_union_summary_empty
 
 end module test_mpi_summary

--- a/tests/mpi/test_mpi_summary.pf
+++ b/tests/mpi/test_mpi_summary.pf
@@ -8,10 +8,11 @@ module test_mpi_summary
                       MPI_F08_MAX => MPI_MAX, MPI_F08_MIN => MPI_MIN, MPI_F08_SUCCESS => MPI_SUCCESS, &
                       MPI_F08_SUM => MPI_SUM
    use ftimer, only: ftimer_default_instance, ftimer_finalize, ftimer_init, ftimer_mpi_summary, &
-                     ftimer_print_mpi_summary, ftimer_start, ftimer_stop
+                     ftimer_mpi_union_summary, ftimer_print_mpi_summary, ftimer_start, ftimer_stop
    use ftimer_core, only: ftimer_t
-   use ftimer_types, only: FTIMER_ERR_ACTIVE, FTIMER_ERR_IO, FTIMER_NAME_LEN, FTIMER_SUCCESS, ftimer_metadata_t, &
-                           ftimer_mpi_summary_t, wp
+   use ftimer_types, only: FTIMER_ERR_ACTIVE, FTIMER_ERR_IO, FTIMER_ERR_NOT_IMPLEMENTED, FTIMER_NAME_LEN, &
+                           FTIMER_SUCCESS, ftimer_metadata_t, ftimer_mpi_summary_t, &
+                           ftimer_mpi_union_summary_t, wp
    use test_support, only: attach_mock_clock, csv_column_index, csv_field_value, csv_line_at, csv_record_count, &
                            fake_time, read_file_text, summary_node_ids_unique, summary_parent_index
    implicit none
@@ -92,6 +93,7 @@ contains
       class(mpi_summary_case), intent(inout) :: this
       type(ftimer_t) :: timer
       type(ftimer_mpi_summary_t) :: summary
+      type(ftimer_mpi_union_summary_t) :: union_summary
       integer :: ierr
 
       call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
@@ -342,6 +344,7 @@ contains
       class(mpi_summary_case), intent(inout) :: this
       type(ftimer_t) :: timer
       type(ftimer_mpi_summary_t) :: summary
+      type(ftimer_mpi_union_summary_t) :: union_summary
       integer :: ierr
 
       call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
@@ -358,6 +361,12 @@ contains
       @assertEqual(FTIMER_ERR_ACTIVE, ierr)
       @assertEqual(0, summary%num_ranks)
       @assertEqual(0, summary%num_entries)
+
+      call timer%mpi_union_summary(union_summary, ierr=ierr)
+
+      @assertEqual(FTIMER_ERR_ACTIVE, ierr)
+      @assertEqual(0, union_summary%num_ranks)
+      @assertEqual(0, union_summary%num_entries)
 
       fake_time = fake_time + 1.0_wp
       call timer%stop("active", ierr=ierr)
@@ -399,6 +408,47 @@ contains
       call ftimer_finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
    end subroutine test_procedural_mpi_summary_matches_oop_api
+
+   @test
+   subroutine test_mpi_union_summary_api_is_separate_from_strict_summary(this)
+      class(mpi_summary_case), intent(inout) :: this
+      type(ftimer_t) :: oop_timer
+      type(ftimer_mpi_summary_t) :: strict_summary
+      type(ftimer_mpi_union_summary_t) :: oop_union_summary
+      type(ftimer_mpi_union_summary_t) :: procedural_union_summary
+      integer :: ierr
+
+      call oop_timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(oop_timer)
+
+      call build_nested_timers(oop_timer, this%getProcessRank(), ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call oop_timer%mpi_summary(strict_summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      @assertEqual(2, strict_summary%num_entries)
+
+      call oop_timer%mpi_union_summary(oop_union_summary, ierr=ierr)
+      @assertEqual(FTIMER_ERR_NOT_IMPLEMENTED, ierr)
+      call assert_union_summary_empty(oop_union_summary)
+
+      call ftimer_init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+      call build_nested_timers_procedural(this%getProcessRank(), ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call ftimer_mpi_union_summary(procedural_union_summary, ierr=ierr)
+      @assertEqual(FTIMER_ERR_NOT_IMPLEMENTED, ierr)
+      call assert_union_summary_empty(procedural_union_summary)
+
+      call oop_timer%finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_mpi_union_summary_api_is_separate_from_strict_summary
 
    @test
    subroutine test_transitional_integer_comm_compatibility(this)
@@ -1344,5 +1394,18 @@ contains
          call assert_real_close(lhs%entries(i)%avg_pct_time, rhs%entries(i)%avg_pct_time)
       end do
    end subroutine assert_summary_equal
+
+   subroutine assert_union_summary_empty(summary)
+      type(ftimer_mpi_union_summary_t), intent(in) :: summary
+
+      @assertEqual(0, summary%num_ranks)
+      @assertEqual(0, summary%num_entries)
+      @assertEqual(0.0_wp, summary%min_total_time)
+      @assertEqual(0.0_wp, summary%max_total_time)
+      @assertEqual(0.0_wp, summary%avg_total_time)
+      @assertEqual(-1, summary%min_total_time_rank)
+      @assertEqual(-1, summary%max_total_time_rank)
+      @assertEqual(1.0_wp, summary%total_time_imbalance)
+   end subroutine assert_union_summary_empty
 
 end module test_mpi_summary

--- a/tests/test_basic.pf
+++ b/tests/test_basic.pf
@@ -2,7 +2,8 @@ module test_basic
    use, intrinsic :: iso_c_binding, only: c_associated, c_loc, c_ptr
    use pfunit
    use ftimer_core, only: ftimer_t, ftimer_test_state_t
-   use ftimer_types, only: FTIMER_MISMATCH_STRICT, FTIMER_SUCCESS, wp
+   use ftimer_types, only: FTIMER_MISMATCH_STRICT, FTIMER_SUCCESS, ftimer_mpi_union_summary_entry_t, &
+                           ftimer_mpi_union_summary_t, wp
    use test_support, only: attach_mock_clock, fake_time, find_context_idx, snapshot_timer
    implicit none
 
@@ -56,6 +57,28 @@ contains
       initialized = state%initialized
       @assertTrue(initialized)
    end subroutine test_init_without_ierr_still_initializes
+
+   @test
+   subroutine test_mpi_union_summary_entry_model_defaults()
+      type(ftimer_mpi_union_summary_t) :: summary
+      integer :: missing_rank_count
+      logical :: name_allocated
+
+      allocate (summary%entries(1))
+      summary%num_ranks = 4
+      summary%num_entries = 1
+
+      missing_rank_count = summary%num_ranks - summary%entries(1)%participating_rank_count
+      name_allocated = allocated(summary%entries(1)%name)
+
+      @assertEqual(4, summary%num_ranks)
+      @assertEqual(1, summary%num_entries)
+      @assertFalse(name_allocated)
+      @assertEqual(0, summary%entries(1)%participating_rank_count)
+      @assertEqual(4, missing_rank_count)
+
+      call assert_mpi_union_entry_defaults(summary%entries(1))
+   end subroutine test_mpi_union_summary_entry_model_defaults
 
    @test
    subroutine test_start_stop_auto_creates_and_accumulates()
@@ -207,5 +230,29 @@ contains
    subroutine reset_finalize_callback_count()
       finalize_callback_count = 0
    end subroutine reset_finalize_callback_count
+
+   subroutine assert_mpi_union_entry_defaults(entry)
+      type(ftimer_mpi_union_summary_entry_t), intent(in) :: entry
+
+      @assertEqual(0, entry%depth)
+      @assertEqual(0.0_wp, entry%min_inclusive_time)
+      @assertEqual(0.0_wp, entry%max_inclusive_time)
+      @assertEqual(0.0_wp, entry%avg_inclusive_time)
+      @assertEqual(1.0_wp, entry%inclusive_imbalance)
+      @assertEqual(0.0_wp, entry%min_self_time)
+      @assertEqual(0.0_wp, entry%max_self_time)
+      @assertEqual(0.0_wp, entry%avg_self_time)
+      @assertEqual(1.0_wp, entry%self_imbalance)
+      @assertEqual(0, entry%min_call_count)
+      @assertEqual(0, entry%max_call_count)
+      @assertEqual(0.0_wp, entry%avg_call_count)
+      @assertEqual(0.0_wp, entry%min_pct_time)
+      @assertEqual(0.0_wp, entry%max_pct_time)
+      @assertEqual(0.0_wp, entry%avg_pct_time)
+      @assertEqual(0, entry%node_id)
+      @assertEqual(0, entry%parent_id)
+      @assertEqual(-1, entry%min_inclusive_time_rank)
+      @assertEqual(-1, entry%max_inclusive_time_rank)
+   end subroutine assert_mpi_union_entry_defaults
 
 end module test_basic

--- a/tests/test_mpi_disabled.pf
+++ b/tests/test_mpi_disabled.pf
@@ -3,9 +3,9 @@ module test_mpi_disabled
    use ftimer, only: ftimer_default_instance, ftimer_finalize, ftimer_init, ftimer_mpi_summary, &
                      ftimer_mpi_union_summary, ftimer_start, ftimer_stop
    use ftimer_core, only: ftimer_t
-   use ftimer_types, only: FTIMER_ERR_NOT_IMPLEMENTED, FTIMER_SUCCESS, ftimer_mpi_summary_t, &
+   use ftimer_types, only: FTIMER_ERR_NOT_IMPLEMENTED, FTIMER_ERR_NOT_INIT, FTIMER_SUCCESS, ftimer_mpi_summary_t, &
                            ftimer_mpi_union_summary_t, wp
-   use test_support, only: attach_mock_clock, fake_time
+   use test_support, only: attach_mock_clock, begin_stderr_capture, end_stderr_capture, fake_time
    implicit none
 
 contains
@@ -105,6 +105,55 @@ contains
       @assertEqual(FTIMER_SUCCESS, ierr)
    end subroutine test_mpi_union_summary_api_is_explicit_and_empty_when_disabled
 
+   @test
+   subroutine test_mpi_union_summary_before_init_error_contract()
+      character(len=:), allocatable :: oop_stderr
+      character(len=:), allocatable :: procedural_stderr
+      type(ftimer_t) :: oop_timer
+      type(ftimer_mpi_union_summary_t) :: oop_summary
+      type(ftimer_mpi_union_summary_t) :: procedural_summary
+      integer :: capture_ierr
+      integer :: ierr
+      integer :: saved_fd
+      logical :: oop_warned
+      logical :: procedural_warned
+
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call seed_union_summary(oop_summary)
+      call oop_timer%mpi_union_summary(oop_summary, ierr=ierr)
+      @assertEqual(FTIMER_ERR_NOT_INIT, ierr)
+      call assert_union_summary_empty(oop_summary)
+
+      call seed_union_summary(procedural_summary)
+      call ftimer_mpi_union_summary(procedural_summary, ierr=ierr)
+      @assertEqual(FTIMER_ERR_NOT_INIT, ierr)
+      call assert_union_summary_empty(procedural_summary)
+
+      call seed_union_summary(oop_summary)
+      call begin_stderr_capture('test_mpi_union_before_init_oop_warn.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+      call oop_timer%mpi_union_summary(oop_summary)
+      call end_stderr_capture('test_mpi_union_before_init_oop_warn.err', saved_fd, oop_stderr, capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      call seed_union_summary(procedural_summary)
+      call begin_stderr_capture('test_mpi_union_before_init_procedural_warn.err', saved_fd, capture_ierr)
+      @assertEqual(0, capture_ierr)
+      call ftimer_mpi_union_summary(procedural_summary)
+      call end_stderr_capture('test_mpi_union_before_init_procedural_warn.err', saved_fd, procedural_stderr, &
+                              capture_ierr)
+      @assertEqual(0, capture_ierr)
+
+      oop_warned = index(oop_stderr, 'ftimer mpi_union_summary before init') > 0
+      procedural_warned = index(procedural_stderr, 'ftimer mpi_union_summary before init') > 0
+      @assertTrue(oop_warned)
+      @assertTrue(procedural_warned)
+      call assert_union_summary_empty(oop_summary)
+      call assert_union_summary_empty(procedural_summary)
+   end subroutine test_mpi_union_summary_before_init_error_contract
+
    subroutine build_single_timer(timer, ierr)
       class(ftimer_t), intent(inout) :: timer
       integer, intent(out) :: ierr
@@ -142,9 +191,25 @@ contains
       @assertEqual(rhs%total_time_imbalance, lhs%total_time_imbalance)
    end subroutine assert_summary_equal
 
+   subroutine seed_union_summary(summary)
+      type(ftimer_mpi_union_summary_t), intent(out) :: summary
+
+      summary%num_ranks = 99
+      summary%num_entries = 1
+      summary%min_total_time = 1.0_wp
+      summary%max_total_time = 2.0_wp
+      summary%avg_total_time = 1.5_wp
+      summary%min_total_time_rank = 7
+      summary%max_total_time_rank = 8
+      allocate (summary%entries(1))
+      summary%entries(1)%participating_rank_count = 1
+   end subroutine seed_union_summary
+
    subroutine assert_union_summary_empty(summary)
       type(ftimer_mpi_union_summary_t), intent(in) :: summary
+      logical :: entries_allocated
 
+      entries_allocated = allocated(summary%entries)
       @assertEqual(0, summary%num_ranks)
       @assertEqual(0, summary%num_entries)
       @assertEqual(0.0_wp, summary%min_total_time)
@@ -153,6 +218,7 @@ contains
       @assertEqual(-1, summary%min_total_time_rank)
       @assertEqual(-1, summary%max_total_time_rank)
       @assertEqual(1.0_wp, summary%total_time_imbalance)
+      @assertFalse(entries_allocated)
    end subroutine assert_union_summary_empty
 
 end module test_mpi_disabled

--- a/tests/test_mpi_disabled.pf
+++ b/tests/test_mpi_disabled.pf
@@ -1,8 +1,10 @@
 module test_mpi_disabled
    use pfunit
-   use ftimer, only: ftimer_default_instance, ftimer_finalize, ftimer_init, ftimer_mpi_summary, ftimer_start, ftimer_stop
+   use ftimer, only: ftimer_default_instance, ftimer_finalize, ftimer_init, ftimer_mpi_summary, &
+                     ftimer_mpi_union_summary, ftimer_start, ftimer_stop
    use ftimer_core, only: ftimer_t
-   use ftimer_types, only: FTIMER_ERR_NOT_IMPLEMENTED, FTIMER_SUCCESS, ftimer_mpi_summary_t, wp
+   use ftimer_types, only: FTIMER_ERR_NOT_IMPLEMENTED, FTIMER_SUCCESS, ftimer_mpi_summary_t, &
+                           ftimer_mpi_union_summary_t, wp
    use test_support, only: attach_mock_clock, fake_time
    implicit none
 
@@ -69,6 +71,40 @@ contains
       @assertEqual(FTIMER_SUCCESS, ierr)
    end subroutine test_procedural_mpi_summary_matches_oop_when_disabled
 
+   @test
+   subroutine test_mpi_union_summary_api_is_explicit_and_empty_when_disabled()
+      type(ftimer_t) :: oop_timer
+      type(ftimer_mpi_union_summary_t) :: oop_summary
+      type(ftimer_mpi_union_summary_t) :: procedural_summary
+      integer :: ierr
+
+      call oop_timer%init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(oop_timer)
+
+      call ftimer_init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(ftimer_default_instance)
+
+      call build_single_timer(oop_timer, ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call build_single_timer_procedural(ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      call oop_timer%mpi_union_summary(oop_summary, ierr=ierr)
+      @assertEqual(FTIMER_ERR_NOT_IMPLEMENTED, ierr)
+      call ftimer_mpi_union_summary(procedural_summary, ierr=ierr)
+      @assertEqual(FTIMER_ERR_NOT_IMPLEMENTED, ierr)
+
+      call assert_union_summary_empty(oop_summary)
+      call assert_union_summary_empty(procedural_summary)
+
+      call oop_timer%finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call ftimer_finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_mpi_union_summary_api_is_explicit_and_empty_when_disabled
+
    subroutine build_single_timer(timer, ierr)
       class(ftimer_t), intent(inout) :: timer
       integer, intent(out) :: ierr
@@ -105,5 +141,18 @@ contains
       @assertEqual(rhs%max_total_time_rank, lhs%max_total_time_rank)
       @assertEqual(rhs%total_time_imbalance, lhs%total_time_imbalance)
    end subroutine assert_summary_equal
+
+   subroutine assert_union_summary_empty(summary)
+      type(ftimer_mpi_union_summary_t), intent(in) :: summary
+
+      @assertEqual(0, summary%num_ranks)
+      @assertEqual(0, summary%num_entries)
+      @assertEqual(0.0_wp, summary%min_total_time)
+      @assertEqual(0.0_wp, summary%max_total_time)
+      @assertEqual(0.0_wp, summary%avg_total_time)
+      @assertEqual(-1, summary%min_total_time_rank)
+      @assertEqual(-1, summary%max_total_time_rank)
+      @assertEqual(1.0_wp, summary%total_time_imbalance)
+   end subroutine assert_union_summary_empty
 
 end module test_mpi_disabled


### PR DESCRIPTION
## Summary

Closes #169.

- Adds the explicit opt-in sparse MPI API skeleton: `mpi_union_summary()` and `ftimer_mpi_union_summary()`.
- Adds the distinct `ftimer_mpi_union_summary_t` / entry data model with participation-aware fields while leaving strict `mpi_summary()` semantics unchanged.
- Documents the #169 design decision and keeps descriptor-union construction (#170) and sparse reporting (#171) deferred.

## Validation

- `ctest --test-dir build-mpi-tests --output-on-failure -R ftimer_mpi_tests`
- `ctest --test-dir build-smoke --output-on-failure`
- `ctest --test-dir build-serial-tests --output-on-failure -R ftimer_serial_tests`