### PR TITLE
Gate OpenMP guards on FTIMER_USE_OPENMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Use a separate build directory for each compiler or mode. Reconfiguring the same
 - Local summary `node_id` values are not a cross-run identity contract. Treat them as explicit links inside one produced summary object, not as durable ids across separate runs or independently produced summaries.
 - All ranks that participate in `mpi_summary()` must agree on the communicator captured by `init`. If would-be participants diverge onto different communicators, the library cannot safely discover that mistake after the split; the practical failure mode is a hang, not a clean local fallback.
 - `FTIMER_USE_OPENMP=ON` enables only limited master-thread-only guards. Worker-thread timer calls inside an OpenMP parallel region are silent no-ops. To time a parallel region as a whole, place `start`/`stop` outside the `!$omp parallel` block.
+- `FTIMER_USE_OPENMP` is the source-level switch for that carve-out; global OpenMP compiler flags alone do not enable the guards when the option is `OFF`.
 - The OpenMP path does not make fTimer thread-safe, does not provide thread-local timer instances, and should not be read as a general hybrid MPI+OpenMP timing model.
 - Future real hybrid MPI+OpenMP timing is deferred pending concrete adopter demand; see [`docs/openmp-hybrid-strategy-decision.md`](docs/openmp-hybrid-strategy-decision.md).
 - `on_event` remains a lightweight intra-run hook, not a serious profiler-backend integration contract with stable semantic timer identity.

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -279,6 +279,7 @@ enforcement should pass `ierr` and check it.
 ## OpenMP Carve-Out And Limitations
 
 - OpenMP guard behavior is enabled only when the library is built with `FTIMER_USE_OPENMP=ON`
+- The CMake option is the source-level switch; global OpenMP compiler flags alone do not enable these guards when `FTIMER_USE_OPENMP=OFF`
 - This is a narrow master-thread-only carve-out for bracketing a parallel region as a whole; it is not general hybrid MPI+OpenMP timing support
 - The implemented model is master-thread-only timing; this phase does not make `fTimer` generally thread-safe
 - Inside OpenMP parallel regions, the guarded `ftimer_core` timer operations run only on the master thread

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ if(FTIMER_USE_MPI)
 endif()
 
 if(FTIMER_USE_OPENMP)
+  target_compile_definitions(ftimer PUBLIC FTIMER_USE_OPENMP)
   target_link_libraries(ftimer PUBLIC OpenMP::OpenMP_Fortran)
 endif()
 
@@ -50,6 +51,7 @@ if(FTIMER_BUILD_TESTS)
   endif()
 
   if(FTIMER_USE_OPENMP)
+    target_compile_definitions(ftimer_test PUBLIC FTIMER_USE_OPENMP)
     target_link_libraries(ftimer_test PUBLIC OpenMP::OpenMP_Fortran)
   endif()
 

--- a/src/ftimer_core.F90
+++ b/src/ftimer_core.F90
@@ -201,9 +201,13 @@ contains
 
       id = 0
       activation_token = 0_int64
+#ifdef FTIMER_USE_OPENMP
 !$omp master
+#endif
       call start_scope_activation_impl(self, name, id, activation_token, ierr=ierr)
+#ifdef FTIMER_USE_OPENMP
 !$omp end master
+#endif
    end subroutine ftimer_internal_start_scope_activation
 
    integer function ftimer_internal_stop_scope_activation(self, id, activation_token, ierr) result(status)
@@ -213,9 +217,13 @@ contains
       integer, intent(out), optional :: ierr
 
       status = FTIMER_ERR_ACTIVE
+#ifdef FTIMER_USE_OPENMP
 !$omp master
+#endif
       status = stop_scope_activation_impl(self, id, activation_token, ierr=ierr)
+#ifdef FTIMER_USE_OPENMP
 !$omp end master
+#endif
    end function ftimer_internal_stop_scope_activation
 
    subroutine init_with_integer_comm(self, comm, mismatch_mode, ierr)
@@ -227,9 +235,13 @@ contains
       ! Contract: ierr is last to eliminate the positional intent(out) trap.
       ! A single positional integer still binds to the transitional legacy
       ! communicator path, not ierr. Keywords are recommended for readability.
+#ifdef FTIMER_USE_OPENMP
       !$omp master
+#endif
       call init_impl(self, ierr=ierr, legacy_comm=comm, mismatch_mode=mismatch_mode)
+#ifdef FTIMER_USE_OPENMP
 !$omp end master
+#endif
    end subroutine init_with_integer_comm
 
 #ifdef FTIMER_USE_MPI
@@ -239,9 +251,13 @@ contains
       integer, intent(in), optional :: mismatch_mode
       integer, intent(out), optional :: ierr
 
+#ifdef FTIMER_USE_OPENMP
 !$omp master
+#endif
       call init_impl(self, ierr=ierr, comm=comm, mismatch_mode=mismatch_mode)
+#ifdef FTIMER_USE_OPENMP
 !$omp end master
+#endif
    end subroutine init_with_mpi_comm
 #endif
 
@@ -311,9 +327,13 @@ contains
       class(ftimer_t), intent(inout) :: self
       integer, intent(out), optional :: ierr
 
+#ifdef FTIMER_USE_OPENMP
 !$omp master
+#endif
       call finalize_impl(self, ierr=ierr)
+#ifdef FTIMER_USE_OPENMP
 !$omp end master
+#endif
    end subroutine finalize
 
    subroutine finalize_impl(self, ierr)
@@ -340,9 +360,13 @@ contains
       procedure(ftimer_clock_func) :: clock
       integer, intent(out), optional :: ierr
 
+#ifdef FTIMER_USE_OPENMP
 !$omp master
+#endif
       call set_clock_impl(self, clock, ierr=ierr)
+#ifdef FTIMER_USE_OPENMP
 !$omp end master
+#endif
    end subroutine set_clock
 
    subroutine set_clock_impl(self, clock, ierr)
@@ -363,9 +387,13 @@ contains
       class(ftimer_t), intent(inout) :: self
       integer, intent(out), optional :: ierr
 
+#ifdef FTIMER_USE_OPENMP
 !$omp master
+#endif
       call clear_clock_impl(self, ierr=ierr)
+#ifdef FTIMER_USE_OPENMP
 !$omp end master
+#endif
    end subroutine clear_clock
 
    subroutine clear_clock_impl(self, ierr)
@@ -388,9 +416,13 @@ contains
       type(c_ptr), intent(in), optional :: user_data
       integer, intent(out), optional :: ierr
 
+#ifdef FTIMER_USE_OPENMP
 !$omp master
+#endif
       call set_callback_impl(self, on_event, user_data=user_data, ierr=ierr)
+#ifdef FTIMER_USE_OPENMP
 !$omp end master
+#endif
    end subroutine set_callback
 
    subroutine set_callback_impl(self, on_event, user_data, ierr)
@@ -418,9 +450,13 @@ contains
       class(ftimer_t), intent(inout) :: self
       integer, intent(out), optional :: ierr
 
+#ifdef FTIMER_USE_OPENMP
 !$omp master
+#endif
       call clear_callback_impl(self, ierr=ierr)
+#ifdef FTIMER_USE_OPENMP
 !$omp end master
+#endif
    end subroutine clear_callback
 
    subroutine clear_callback_impl(self, ierr)
@@ -441,9 +477,13 @@ contains
       character(len=*), intent(in) :: name
       integer, intent(out), optional :: ierr
 
+#ifdef FTIMER_USE_OPENMP
 !$omp master
+#endif
       call start_impl(self, name, ierr=ierr)
+#ifdef FTIMER_USE_OPENMP
 !$omp end master
+#endif
    end subroutine start
 
    subroutine start_impl(self, name, ierr, activation_token)
@@ -478,9 +518,13 @@ contains
       character(len=*), intent(in) :: name
       integer, intent(out), optional :: ierr
 
+#ifdef FTIMER_USE_OPENMP
 !$omp master
+#endif
       call stop_impl(self, name, ierr=ierr)
+#ifdef FTIMER_USE_OPENMP
 !$omp end master
+#endif
    end subroutine stop
 
    subroutine stop_impl(self, name, ierr)
@@ -518,9 +562,13 @@ contains
       integer, intent(in) :: id
       integer, intent(out), optional :: ierr
 
+#ifdef FTIMER_USE_OPENMP
 !$omp master
+#endif
       call start_id_impl(self, id, ierr=ierr)
+#ifdef FTIMER_USE_OPENMP
 !$omp end master
+#endif
    end subroutine start_id
 
    subroutine start_id_impl(self, id, ierr, activation_token)
@@ -568,9 +616,13 @@ contains
       integer, intent(in) :: id
       integer, intent(out), optional :: ierr
 
+#ifdef FTIMER_USE_OPENMP
 !$omp master
+#endif
       call stop_id_impl(self, id, ierr=ierr)
+#ifdef FTIMER_USE_OPENMP
 !$omp end master
+#endif
    end subroutine stop_id
 
    subroutine stop_id_impl(self, id, ierr)
@@ -635,9 +687,13 @@ contains
       integer, intent(out), optional :: ierr
 
       id = 0
+#ifdef FTIMER_USE_OPENMP
 !$omp master
+#endif
       id = lookup_impl(self, name, ierr)
+#ifdef FTIMER_USE_OPENMP
 !$omp end master
+#endif
    end function lookup
 
    integer function lookup_impl(self, name, ierr) result(id)
@@ -668,9 +724,13 @@ contains
       class(ftimer_t), intent(inout) :: self
       integer, intent(out), optional :: ierr
 
+#ifdef FTIMER_USE_OPENMP
 !$omp master
+#endif
       call reset_impl(self, ierr=ierr)
+#ifdef FTIMER_USE_OPENMP
 !$omp end master
+#endif
    end subroutine reset
 
    subroutine reset_impl(self, ierr)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,18 @@ if(FTIMER_BUILD_SMOKE_TESTS)
       -DTEST_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}/make_wrapper_contracts
       -P ${CMAKE_CURRENT_SOURCE_DIR}/check_make_wrapper_contracts.cmake
   )
+
+  add_test(NAME ftimer_openmp_option_off_ignores_global_flags
+    COMMAND ${CMAKE_COMMAND}
+      -DREPO_ROOT=${CMAKE_SOURCE_DIR}
+      -DTEST_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}/openmp_option_off_global_flags
+      -DCMAKE_GENERATOR=${CMAKE_GENERATOR}
+      -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
+      -DTEST_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+      "-DTEST_CONFIG=$<CONFIG>"
+      -DTEST_EXECUTABLE_SUFFIX=${CMAKE_EXECUTABLE_SUFFIX}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/check_openmp_option_off_global_flags.cmake
+  )
 endif()
 
 if(FTIMER_BUILD_TESTS)

--- a/tests/check_openmp_option_off_global_flags.cmake
+++ b/tests/check_openmp_option_off_global_flags.cmake
@@ -1,0 +1,141 @@
+cmake_minimum_required(VERSION 3.16)
+
+find_program(ftimer_gfortran_compiler NAMES gfortran)
+if(NOT ftimer_gfortran_compiler)
+  message(STATUS
+    "Skipping FTIMER_USE_OPENMP=OFF/global OpenMP regression: gfortran is not available on PATH."
+  )
+  return()
+endif()
+
+set(install_prefix "${TEST_BINARY_DIR}/prefix")
+set(producer_build_dir "${TEST_BINARY_DIR}/producer-build")
+set(consumer_source_dir "${REPO_ROOT}/tests/openmp-option-off-global-flags")
+set(consumer_build_dir "${TEST_BINARY_DIR}/consumer-build")
+
+file(REMOVE_RECURSE "${TEST_BINARY_DIR}")
+file(MAKE_DIRECTORY "${TEST_BINARY_DIR}")
+
+set(producer_configure_args
+  -S "${REPO_ROOT}"
+  -B "${producer_build_dir}"
+  -G "${CMAKE_GENERATOR}"
+  -DCMAKE_Fortran_COMPILER=${ftimer_gfortran_compiler}
+  -DCMAKE_Fortran_FLAGS=-fopenmp
+  -DCMAKE_INSTALL_PREFIX=${install_prefix}
+  -DFTIMER_USE_OPENMP=OFF
+  -DFTIMER_BUILD_SMOKE_TESTS=OFF
+  -DFTIMER_BUILD_TESTS=OFF
+  -DFTIMER_BUILD_EXAMPLES=OFF
+  -DFTIMER_BUILD_BENCH=OFF
+)
+
+if(DEFINED CMAKE_MAKE_PROGRAM AND NOT CMAKE_MAKE_PROGRAM STREQUAL "")
+  list(APPEND producer_configure_args -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM})
+endif()
+
+if(DEFINED TEST_BUILD_TYPE AND NOT TEST_BUILD_TYPE STREQUAL "")
+  list(APPEND producer_configure_args -DCMAKE_BUILD_TYPE=${TEST_BUILD_TYPE})
+endif()
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" ${producer_configure_args}
+  RESULT_VARIABLE producer_configure_result
+)
+if(NOT producer_configure_result EQUAL 0)
+  message(FATAL_ERROR
+    "Failed to configure fTimer with FTIMER_USE_OPENMP=OFF and global -fopenmp flags."
+  )
+endif()
+
+set(producer_build_args --build "${producer_build_dir}")
+if(DEFINED TEST_CONFIG AND NOT TEST_CONFIG STREQUAL "")
+  list(APPEND producer_build_args --config "${TEST_CONFIG}")
+endif()
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" ${producer_build_args}
+  RESULT_VARIABLE producer_build_result
+)
+if(NOT producer_build_result EQUAL 0)
+  message(FATAL_ERROR
+    "Failed to build fTimer with FTIMER_USE_OPENMP=OFF and global -fopenmp flags."
+  )
+endif()
+
+set(producer_install_args --install "${producer_build_dir}")
+if(DEFINED TEST_CONFIG AND NOT TEST_CONFIG STREQUAL "")
+  list(APPEND producer_install_args --config "${TEST_CONFIG}")
+endif()
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" ${producer_install_args}
+  RESULT_VARIABLE producer_install_result
+)
+if(NOT producer_install_result EQUAL 0)
+  message(FATAL_ERROR
+    "Failed to install fTimer built with FTIMER_USE_OPENMP=OFF and global -fopenmp flags."
+  )
+endif()
+
+set(consumer_configure_args
+  -S "${consumer_source_dir}"
+  -B "${consumer_build_dir}"
+  -G "${CMAKE_GENERATOR}"
+  -DCMAKE_PREFIX_PATH=${install_prefix}
+  -DCMAKE_Fortran_COMPILER=${ftimer_gfortran_compiler}
+)
+
+if(DEFINED CMAKE_MAKE_PROGRAM AND NOT CMAKE_MAKE_PROGRAM STREQUAL "")
+  list(APPEND consumer_configure_args -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM})
+endif()
+
+if(DEFINED TEST_BUILD_TYPE AND NOT TEST_BUILD_TYPE STREQUAL "")
+  list(APPEND consumer_configure_args -DCMAKE_BUILD_TYPE=${TEST_BUILD_TYPE})
+endif()
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" ${consumer_configure_args}
+  RESULT_VARIABLE consumer_configure_result
+)
+if(NOT consumer_configure_result EQUAL 0)
+  message(FATAL_ERROR
+    "Failed to configure the FTIMER_USE_OPENMP=OFF/global OpenMP regression consumer."
+  )
+endif()
+
+set(consumer_build_args --build "${consumer_build_dir}")
+if(DEFINED TEST_CONFIG AND NOT TEST_CONFIG STREQUAL "")
+  list(APPEND consumer_build_args --config "${TEST_CONFIG}")
+endif()
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" ${consumer_build_args}
+  RESULT_VARIABLE consumer_build_result
+)
+if(NOT consumer_build_result EQUAL 0)
+  message(FATAL_ERROR
+    "Failed to build the FTIMER_USE_OPENMP=OFF/global OpenMP regression consumer."
+  )
+endif()
+
+set(consumer_executable "${consumer_build_dir}/ftimer_openmp_option_off_global_flags${TEST_EXECUTABLE_SUFFIX}")
+if(DEFINED TEST_CONFIG AND NOT TEST_CONFIG STREQUAL "")
+  set(configured_consumer_executable
+    "${consumer_build_dir}/${TEST_CONFIG}/ftimer_openmp_option_off_global_flags${TEST_EXECUTABLE_SUFFIX}"
+  )
+  if(EXISTS "${configured_consumer_executable}")
+    set(consumer_executable "${configured_consumer_executable}")
+  endif()
+endif()
+
+execute_process(
+  COMMAND "${consumer_executable}"
+  WORKING_DIRECTORY "${consumer_build_dir}"
+  RESULT_VARIABLE consumer_run_result
+)
+if(NOT consumer_run_result EQUAL 0)
+  message(FATAL_ERROR
+    "FTIMER_USE_OPENMP=OFF/global OpenMP regression consumer exited with a nonzero status."
+  )
+endif()

--- a/tests/openmp-option-off-global-flags/CMakeLists.txt
+++ b/tests/openmp-option-off-global-flags/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(ftimer_openmp_option_off_global_flags LANGUAGES Fortran)
+
+find_package(fTimer REQUIRED CONFIG)
+find_package(OpenMP REQUIRED COMPONENTS Fortran)
+
+add_executable(ftimer_openmp_option_off_global_flags main.F90)
+target_link_libraries(ftimer_openmp_option_off_global_flags
+  PRIVATE
+    fTimer::ftimer
+    OpenMP::OpenMP_Fortran
+)

--- a/tests/openmp-option-off-global-flags/main.F90
+++ b/tests/openmp-option-off-global-flags/main.F90
@@ -1,45 +1,212 @@
 program ftimer_openmp_option_off_global_flags
    use omp_lib, only: omp_get_thread_num, omp_set_dynamic
-   use ftimer, only: ftimer_finalize, ftimer_get_summary, ftimer_init, ftimer_start, ftimer_stop
-   use ftimer_types, only: FTIMER_SUCCESS, ftimer_summary_t
+   use ftimer, only: ftimer_finalize, ftimer_get_summary, ftimer_guard_t, ftimer_init, &
+                     ftimer_reset, ftimer_scope, ftimer_start, ftimer_stop
+   use ftimer_core, only: ftimer_t
+   use ftimer_types, only: FTIMER_ERR_NOT_INIT, FTIMER_SUCCESS, ftimer_summary_t
    implicit none
 
-   type(ftimer_summary_t) :: summary
-   integer :: ierr
-   integer :: thread_num
-   logical :: thread_seen(2)
-   logical :: names_match
+   integer, parameter :: IERR_SENTINEL = -1000
 
    call omp_set_dynamic(.false.)
-   thread_seen = .false.
 
-   call ftimer_init(ierr=ierr)
-   if (ierr /= FTIMER_SUCCESS) error stop 1
+   call verify_procedural_worker_paths()
+   call verify_oop_worker_paths()
 
-!$omp parallel num_threads(2) default(shared) private(thread_num)
-   thread_num = omp_get_thread_num()
-   if (thread_num + 1 <= size(thread_seen)) thread_seen(thread_num + 1) = .true.
+contains
 
-   if (thread_num /= 0) then
-      call ftimer_start("worker_recorded", ierr=ierr)
-      if (ierr /= FTIMER_SUCCESS) error stop 2
+   subroutine verify_procedural_worker_paths()
+      type(ftimer_summary_t) :: summary
+      integer :: ierr
+      integer :: local_ierr
+      integer :: thread_num
+      integer :: worker_reset_ierr
+      integer :: worker_scope_ierr
+      integer :: worker_start_ierr
+      integer :: worker_stop_ierr
+      logical :: thread_seen(2)
 
-      call ftimer_stop("worker_recorded", ierr=ierr)
-      if (ierr /= FTIMER_SUCCESS) error stop 3
-   end if
+      thread_seen = .false.
+      worker_reset_ierr = IERR_SENTINEL
+      worker_scope_ierr = IERR_SENTINEL
+      worker_start_ierr = IERR_SENTINEL
+      worker_stop_ierr = IERR_SENTINEL
+
+      call ftimer_init(ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) error stop 1
+
+!$omp parallel num_threads(2) default(shared) private(local_ierr, thread_num)
+      thread_num = omp_get_thread_num()
+      if (thread_num + 1 <= size(thread_seen)) thread_seen(thread_num + 1) = .true.
+
+      if (thread_num /= 0) then
+         local_ierr = IERR_SENTINEL
+         call ftimer_start("worker_recorded", ierr=local_ierr)
+         worker_start_ierr = local_ierr
+
+         local_ierr = IERR_SENTINEL
+         call ftimer_stop("worker_recorded", ierr=local_ierr)
+         worker_stop_ierr = local_ierr
+
+         worker_scope: block
+            type(ftimer_guard_t) :: guard
+
+            local_ierr = IERR_SENTINEL
+            call ftimer_scope(guard, "worker_scope", ierr=local_ierr)
+            worker_scope_ierr = local_ierr
+         end block worker_scope
+      end if
 !$omp end parallel
 
-   if (.not. thread_seen(1)) error stop 4
-   if (.not. thread_seen(2)) error stop 5
+      if (.not. thread_seen(1)) error stop 2
+      if (.not. thread_seen(2)) error stop 3
+      if (worker_start_ierr /= FTIMER_SUCCESS) error stop 4
+      if (worker_stop_ierr /= FTIMER_SUCCESS) error stop 5
+      if (worker_scope_ierr /= FTIMER_SUCCESS) error stop 6
 
-   call ftimer_get_summary(summary, ierr=ierr)
-   if (ierr /= FTIMER_SUCCESS) error stop 6
-   if (summary%num_entries /= 1) error stop 7
+      call ftimer_get_summary(summary, ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) error stop 7
+      if (summary%has_active_timers) error stop 8
+      if (summary%num_entries /= 2) error stop 9
+      if (summary_call_count(summary, "worker_recorded") /= 1) error stop 10
+      if (summary_call_count(summary, "worker_scope") /= 1) error stop 11
 
-   names_match = trim(summary%entries(1)%name) == 'worker_recorded'
-   if (.not. names_match) error stop 8
-   if (summary%entries(1)%call_count /= 1) error stop 9
+      thread_seen = .false.
+!$omp parallel num_threads(2) default(shared) private(local_ierr, thread_num)
+      thread_num = omp_get_thread_num()
+      if (thread_num + 1 <= size(thread_seen)) thread_seen(thread_num + 1) = .true.
 
-   call ftimer_finalize(ierr=ierr)
-   if (ierr /= FTIMER_SUCCESS) error stop 10
+      if (thread_num /= 0) then
+         local_ierr = IERR_SENTINEL
+         call ftimer_reset(ierr=local_ierr)
+         worker_reset_ierr = local_ierr
+      end if
+!$omp end parallel
+
+      if (.not. thread_seen(1)) error stop 12
+      if (.not. thread_seen(2)) error stop 13
+      if (worker_reset_ierr /= FTIMER_SUCCESS) error stop 14
+
+      call ftimer_get_summary(summary, ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) error stop 15
+      if (summary%has_active_timers) error stop 16
+      if (summary%num_entries /= 0) error stop 17
+
+      call ftimer_finalize(ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) error stop 18
+   end subroutine verify_procedural_worker_paths
+
+   subroutine verify_oop_worker_paths()
+      type(ftimer_t) :: timer
+      type(ftimer_summary_t) :: summary
+      integer :: ierr
+      integer :: local_id
+      integer :: local_ierr
+      integer :: thread_num
+      integer :: worker_finalize_ierr
+      integer :: worker_id
+      integer :: worker_lookup_ierr
+      integer :: worker_reset_ierr
+      integer :: worker_start_id_ierr
+      integer :: worker_stop_id_ierr
+      logical :: thread_seen(2)
+
+      thread_seen = .false.
+      worker_finalize_ierr = IERR_SENTINEL
+      worker_id = 0
+      worker_lookup_ierr = IERR_SENTINEL
+      worker_reset_ierr = IERR_SENTINEL
+      worker_start_id_ierr = IERR_SENTINEL
+      worker_stop_id_ierr = IERR_SENTINEL
+
+      call timer%init(ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) error stop 19
+
+!$omp parallel num_threads(2) default(shared) private(local_id, local_ierr, thread_num)
+      thread_num = omp_get_thread_num()
+      if (thread_num + 1 <= size(thread_seen)) thread_seen(thread_num + 1) = .true.
+
+      if (thread_num /= 0) then
+         local_ierr = IERR_SENTINEL
+         local_id = timer%lookup("worker_id", ierr=local_ierr)
+         worker_id = local_id
+         worker_lookup_ierr = local_ierr
+
+         local_ierr = IERR_SENTINEL
+         call timer%start_id(local_id, ierr=local_ierr)
+         worker_start_id_ierr = local_ierr
+
+         local_ierr = IERR_SENTINEL
+         call timer%stop_id(local_id, ierr=local_ierr)
+         worker_stop_id_ierr = local_ierr
+      end if
+!$omp end parallel
+
+      if (.not. thread_seen(1)) error stop 20
+      if (.not. thread_seen(2)) error stop 21
+      if (worker_lookup_ierr /= FTIMER_SUCCESS) error stop 22
+      if (worker_id <= 0) error stop 23
+      if (worker_start_id_ierr /= FTIMER_SUCCESS) error stop 24
+      if (worker_stop_id_ierr /= FTIMER_SUCCESS) error stop 25
+
+      call timer%get_summary(summary, ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) error stop 26
+      if (summary%has_active_timers) error stop 27
+      if (summary%num_entries /= 1) error stop 28
+      if (summary_call_count(summary, "worker_id") /= 1) error stop 29
+
+      thread_seen = .false.
+!$omp parallel num_threads(2) default(shared) private(local_ierr, thread_num)
+      thread_num = omp_get_thread_num()
+      if (thread_num + 1 <= size(thread_seen)) thread_seen(thread_num + 1) = .true.
+
+      if (thread_num /= 0) then
+         local_ierr = IERR_SENTINEL
+         call timer%reset(ierr=local_ierr)
+         worker_reset_ierr = local_ierr
+      end if
+!$omp end parallel
+
+      if (.not. thread_seen(1)) error stop 30
+      if (.not. thread_seen(2)) error stop 31
+      if (worker_reset_ierr /= FTIMER_SUCCESS) error stop 32
+
+      call timer%get_summary(summary, ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) error stop 33
+      if (summary%has_active_timers) error stop 34
+      if (summary%num_entries /= 0) error stop 35
+
+      thread_seen = .false.
+!$omp parallel num_threads(2) default(shared) private(local_ierr, thread_num)
+      thread_num = omp_get_thread_num()
+      if (thread_num + 1 <= size(thread_seen)) thread_seen(thread_num + 1) = .true.
+
+      if (thread_num /= 0) then
+         local_ierr = IERR_SENTINEL
+         call timer%finalize(ierr=local_ierr)
+         worker_finalize_ierr = local_ierr
+      end if
+!$omp end parallel
+
+      if (.not. thread_seen(1)) error stop 36
+      if (.not. thread_seen(2)) error stop 37
+      if (worker_finalize_ierr /= FTIMER_SUCCESS) error stop 38
+
+      call timer%start("after_worker_finalize", ierr=ierr)
+      if (ierr /= FTIMER_ERR_NOT_INIT) error stop 39
+   end subroutine verify_oop_worker_paths
+
+   integer function summary_call_count(summary, name) result(call_count)
+      type(ftimer_summary_t), intent(in) :: summary
+      character(len=*), intent(in) :: name
+      integer :: i
+
+      call_count = -1
+      do i = 1, summary%num_entries
+         if (trim(summary%entries(i)%name) == name) then
+            call_count = summary%entries(i)%call_count
+            return
+         end if
+      end do
+   end function summary_call_count
 end program ftimer_openmp_option_off_global_flags

--- a/tests/openmp-option-off-global-flags/main.F90
+++ b/tests/openmp-option-off-global-flags/main.F90
@@ -1,0 +1,45 @@
+program ftimer_openmp_option_off_global_flags
+   use omp_lib, only: omp_get_thread_num, omp_set_dynamic
+   use ftimer, only: ftimer_finalize, ftimer_get_summary, ftimer_init, ftimer_start, ftimer_stop
+   use ftimer_types, only: FTIMER_SUCCESS, ftimer_summary_t
+   implicit none
+
+   type(ftimer_summary_t) :: summary
+   integer :: ierr
+   integer :: thread_num
+   logical :: thread_seen(2)
+   logical :: names_match
+
+   call omp_set_dynamic(.false.)
+   thread_seen = .false.
+
+   call ftimer_init(ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop 1
+
+!$omp parallel num_threads(2) default(shared) private(thread_num)
+   thread_num = omp_get_thread_num()
+   if (thread_num + 1 <= size(thread_seen)) thread_seen(thread_num + 1) = .true.
+
+   if (thread_num /= 0) then
+      call ftimer_start("worker_recorded", ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) error stop 2
+
+      call ftimer_stop("worker_recorded", ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) error stop 3
+   end if
+!$omp end parallel
+
+   if (.not. thread_seen(1)) error stop 4
+   if (.not. thread_seen(2)) error stop 5
+
+   call ftimer_get_summary(summary, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop 6
+   if (summary%num_entries /= 1) error stop 7
+
+   names_match = trim(summary%entries(1)%name) == 'worker_recorded'
+   if (.not. names_match) error stop 8
+   if (summary%entries(1)%call_count /= 1) error stop 9
+
+   call ftimer_finalize(ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop 10
+end program ftimer_openmp_option_off_global_flags


### PR DESCRIPTION
Fixes #199.

## Summary
- Define `FTIMER_USE_OPENMP` on fTimer library/test targets only when the CMake option is enabled.
- Preprocess the `ftimer_core` OpenMP master guards so global OpenMP compiler flags cannot activate them when `FTIMER_USE_OPENMP=OFF`.
- Add a smoke regression that builds fTimer with global `-fopenmp` flags and `FTIMER_USE_OPENMP=OFF`, then verifies worker-thread timer calls are still recorded.
- Clarify in README and `docs/semantics.md` that global OpenMP flags alone do not enable the guard carve-out.

## Validation
- `cmake --fresh -B build-smoke`
- `cmake --build build-smoke`
- `ctest --test-dir build-smoke --output-on-failure` — 11/11 passed
- `cmake --fresh -B build-openmp -DCMAKE_Fortran_COMPILER=gfortran -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/Users/hrh/.local/PFUNIT-4.15`
- `cmake --build build-openmp`
- `ctest --test-dir build-openmp --output-on-failure` — 12/12 passed
- `fprettify --diff src/ftimer_core.F90 tests/openmp-option-off-global-flags/main.F90`
- `git diff --check`