### PR TITLE
Support absolute CMAKE_INSTALL_INCLUDEDIR

### DIFF
--- a/cmake/install_ftimer_modules.cmake.in
+++ b/cmake/install_ftimer_modules.cmake.in
@@ -6,11 +6,10 @@
 
 set(ftimer_install_includedir "@CMAKE_INSTALL_INCLUDEDIR@")
 if(IS_ABSOLUTE "${ftimer_install_includedir}")
-  set(ftimer_install_module_dir "$ENV{DESTDIR}${ftimer_install_includedir}/ftimer")
+  set(ftimer_install_module_dir "${ftimer_install_includedir}/ftimer")
 else()
-  set(ftimer_install_module_dir "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${ftimer_install_includedir}/ftimer")
+  set(ftimer_install_module_dir "${CMAKE_INSTALL_PREFIX}/${ftimer_install_includedir}/ftimer")
 endif()
-file(MAKE_DIRECTORY "${ftimer_install_module_dir}")
 
 set(ftimer_installed_module_artifact_names
   ftimer

--- a/cmake/install_ftimer_modules.cmake.in
+++ b/cmake/install_ftimer_modules.cmake.in
@@ -4,7 +4,12 @@
 # modules; see the installed API stability note for the supported import
 # contract.
 
-set(ftimer_install_module_dir "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@/ftimer")
+set(ftimer_install_includedir "@CMAKE_INSTALL_INCLUDEDIR@")
+if(IS_ABSOLUTE "${ftimer_install_includedir}")
+  set(ftimer_install_module_dir "$ENV{DESTDIR}${ftimer_install_includedir}/ftimer")
+else()
+  set(ftimer_install_module_dir "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${ftimer_install_includedir}/ftimer")
+endif()
 file(MAKE_DIRECTORY "${ftimer_install_module_dir}")
 
 set(ftimer_installed_module_artifact_names

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,8 +7,8 @@ if(FTIMER_BUILD_SMOKE_TESTS)
 endif()
 
 function(ftimer_add_installed_consumer_test test_name test_binary_dir)
-  set(options ENABLE_MPI ENABLE_OPENMP)
-  set(oneValueArgs REQUIRED_COMPILER_NAMES)
+  set(options CLEAN_INSTALL_INCLUDEDIR ENABLE_MPI ENABLE_OPENMP)
+  set(oneValueArgs INSTALL_INCLUDEDIR REQUIRED_COMPILER_NAMES)
   cmake_parse_arguments(FTIMER_CONSUMER "${options}" "${oneValueArgs}" "" ${ARGN})
 
   add_test(NAME ${test_name}
@@ -22,6 +22,8 @@ function(ftimer_add_installed_consumer_test test_name test_binary_dir)
       -DTEST_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       "-DTEST_CONFIG=$<CONFIG>"
       -DTEST_REQUIRED_COMPILER_NAMES=${FTIMER_CONSUMER_REQUIRED_COMPILER_NAMES}
+      -DTEST_INSTALL_INCLUDEDIR=${FTIMER_CONSUMER_INSTALL_INCLUDEDIR}
+      -DTEST_CLEAN_INSTALL_INCLUDEDIR=${FTIMER_CONSUMER_CLEAN_INSTALL_INCLUDEDIR}
       -DTEST_ENABLE_MPI=${FTIMER_CONSUMER_ENABLE_MPI}
       -DTEST_ENABLE_OPENMP=${FTIMER_CONSUMER_ENABLE_OPENMP}
       -DTEST_EXECUTABLE_SUFFIX=${CMAKE_EXECUTABLE_SUFFIX}
@@ -51,9 +53,23 @@ add_test(NAME ftimer_public_symbol_allowlist
 )
 
 if(FTIMER_BUILD_SMOKE_TESTS)
+  get_filename_component(
+    ftimer_absolute_includedir_test_root
+    "${CMAKE_CURRENT_BINARY_DIR}/../../../ftimer-absolute-includedir"
+    ABSOLUTE
+  )
+
   ftimer_add_installed_consumer_test(
     ftimer_installed_package_consumer
     ${CMAKE_CURRENT_BINARY_DIR}/installed_package_consumer
+  )
+
+  ftimer_add_installed_consumer_test(
+    ftimer_installed_package_consumer_absolute_includedir
+    ${CMAKE_CURRENT_BINARY_DIR}/installed_package_consumer_absolute_includedir
+    INSTALL_INCLUDEDIR
+      ${ftimer_absolute_includedir_test_root}/installed_package_consumer_absolute_includedir/include
+    CLEAN_INSTALL_INCLUDEDIR
   )
 
   ftimer_add_installed_consumer_test(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,13 @@ if(FTIMER_BUILD_SMOKE_TESTS)
 endif()
 
 function(ftimer_add_installed_consumer_test test_name test_binary_dir)
-  set(options CLEAN_INSTALL_INCLUDEDIR ENABLE_MPI ENABLE_OPENMP)
+  set(options
+    CLEAN_INSTALL_INCLUDEDIR
+    ENABLE_MPI
+    ENABLE_OPENMP
+    INSTALL_ONLY
+    USE_DESTDIR
+  )
   set(oneValueArgs INSTALL_INCLUDEDIR REQUIRED_COMPILER_NAMES)
   cmake_parse_arguments(FTIMER_CONSUMER "${options}" "${oneValueArgs}" "" ${ARGN})
 
@@ -24,6 +30,8 @@ function(ftimer_add_installed_consumer_test test_name test_binary_dir)
       -DTEST_REQUIRED_COMPILER_NAMES=${FTIMER_CONSUMER_REQUIRED_COMPILER_NAMES}
       -DTEST_INSTALL_INCLUDEDIR=${FTIMER_CONSUMER_INSTALL_INCLUDEDIR}
       -DTEST_CLEAN_INSTALL_INCLUDEDIR=${FTIMER_CONSUMER_CLEAN_INSTALL_INCLUDEDIR}
+      -DTEST_INSTALL_ONLY=${FTIMER_CONSUMER_INSTALL_ONLY}
+      -DTEST_USE_DESTDIR=${FTIMER_CONSUMER_USE_DESTDIR}
       -DTEST_ENABLE_MPI=${FTIMER_CONSUMER_ENABLE_MPI}
       -DTEST_ENABLE_OPENMP=${FTIMER_CONSUMER_ENABLE_OPENMP}
       -DTEST_EXECUTABLE_SUFFIX=${CMAKE_EXECUTABLE_SUFFIX}
@@ -53,10 +61,24 @@ add_test(NAME ftimer_public_symbol_allowlist
 )
 
 if(FTIMER_BUILD_SMOKE_TESTS)
+  if(DEFINED ENV{TMPDIR} AND NOT "$ENV{TMPDIR}" STREQUAL "")
+    set(ftimer_absolute_includedir_base "$ENV{TMPDIR}")
+  elseif(DEFINED ENV{TEMP} AND NOT "$ENV{TEMP}" STREQUAL "")
+    set(ftimer_absolute_includedir_base "$ENV{TEMP}")
+  elseif(UNIX)
+    set(ftimer_absolute_includedir_base "/tmp")
+  else()
+    set(ftimer_absolute_includedir_base "${CMAKE_CURRENT_BINARY_DIR}")
+  endif()
   get_filename_component(
-    ftimer_absolute_includedir_test_root
-    "${CMAKE_CURRENT_BINARY_DIR}/../../../ftimer-absolute-includedir"
+    ftimer_absolute_includedir_base
+    "${ftimer_absolute_includedir_base}"
     ABSOLUTE
+  )
+  string(SHA256 ftimer_absolute_includedir_hash "${CMAKE_CURRENT_BINARY_DIR}")
+  string(SUBSTRING "${ftimer_absolute_includedir_hash}" 0 12 ftimer_absolute_includedir_hash)
+  set(ftimer_absolute_includedir_test_root
+    "${ftimer_absolute_includedir_base}/ftimer-absolute-includedir-${ftimer_absolute_includedir_hash}"
   )
 
   ftimer_add_installed_consumer_test(
@@ -70,6 +92,16 @@ if(FTIMER_BUILD_SMOKE_TESTS)
     INSTALL_INCLUDEDIR
       ${ftimer_absolute_includedir_test_root}/installed_package_consumer_absolute_includedir/include
     CLEAN_INSTALL_INCLUDEDIR
+  )
+
+  ftimer_add_installed_consumer_test(
+    ftimer_absolute_includedir_destdir_install
+    ${CMAKE_CURRENT_BINARY_DIR}/absolute_includedir_destdir_install
+    INSTALL_INCLUDEDIR
+      ${ftimer_absolute_includedir_test_root}/absolute_includedir_destdir_install/include
+    CLEAN_INSTALL_INCLUDEDIR
+    INSTALL_ONLY
+    USE_DESTDIR
   )
 
   ftimer_add_installed_consumer_test(

--- a/tests/check_installed_package_consumer.cmake
+++ b/tests/check_installed_package_consumer.cmake
@@ -4,8 +4,6 @@ set(install_prefix "${TEST_BINARY_DIR}/prefix")
 set(consumer_build_dir "${TEST_BINARY_DIR}/consumer-build")
 set(consumer_source_dir "${REPO_ROOT}/tests/install-consumer")
 set(test_name "${TEST_NAME}")
-set(installed_api_note_path "${install_prefix}/share/doc/fTimer/installed-api.md")
-set(installed_license_path "${install_prefix}/share/doc/fTimer/LICENSE")
 
 if(DEFINED TEST_INSTALL_INCLUDEDIR AND NOT TEST_INSTALL_INCLUDEDIR STREQUAL "")
   set(test_install_includedir "${TEST_INSTALL_INCLUDEDIR}")
@@ -13,14 +11,33 @@ else()
   set(test_install_includedir "include")
 endif()
 
-if(IS_ABSOLUTE "${test_install_includedir}")
-  set(installed_module_dir "${test_install_includedir}/ftimer")
-  set(misinstalled_prefixed_module_dir
-    "${install_prefix}${test_install_includedir}/ftimer"
-  )
+if(TEST_USE_DESTDIR)
+  set(test_destdir "${TEST_BINARY_DIR}/destdir")
+  set(effective_install_prefix "${test_destdir}${install_prefix}")
 else()
-  set(installed_module_dir "${install_prefix}/${test_install_includedir}/ftimer")
-  set(misinstalled_prefixed_module_dir "")
+  set(test_destdir "")
+  set(effective_install_prefix "${install_prefix}")
+endif()
+
+set(installed_api_note_path "${effective_install_prefix}/share/doc/fTimer/installed-api.md")
+set(installed_license_path "${effective_install_prefix}/share/doc/fTimer/LICENSE")
+
+set(misinstalled_module_dirs)
+if(IS_ABSOLUTE "${test_install_includedir}")
+  if(TEST_USE_DESTDIR)
+    set(installed_module_dir "${test_destdir}${test_install_includedir}/ftimer")
+    list(APPEND misinstalled_module_dirs
+      "${test_install_includedir}/ftimer"
+      "${test_destdir}${install_prefix}${test_install_includedir}/ftimer"
+    )
+  else()
+    set(installed_module_dir "${test_install_includedir}/ftimer")
+    list(APPEND misinstalled_module_dirs
+      "${install_prefix}${test_install_includedir}/ftimer"
+    )
+  endif()
+else()
+  set(installed_module_dir "${effective_install_prefix}/${test_install_includedir}/ftimer")
 endif()
 
 if(test_name STREQUAL "")
@@ -34,7 +51,7 @@ if(TEST_CLEAN_INSTALL_INCLUDEDIR AND IS_ABSOLUTE "${test_install_includedir}")
       "Refusing to clean unsafe TEST_INSTALL_INCLUDEDIR path '${test_install_includedir}'."
     )
   endif()
-  if(NOT clean_install_includedir MATCHES "/ftimer-absolute-includedir/")
+  if(NOT clean_install_includedir MATCHES "ftimer-absolute-includedir-[0-9a-f]+")
     message(FATAL_ERROR
       "Refusing to clean TEST_INSTALL_INCLUDEDIR path outside the test-owned absolute include root: '${test_install_includedir}'."
     )
@@ -122,12 +139,98 @@ if(DEFINED TEST_CONFIG AND NOT TEST_CONFIG STREQUAL "")
   list(APPEND producer_install_args --config "${TEST_CONFIG}")
 endif()
 
+if(TEST_USE_DESTDIR)
+  set(producer_install_command
+    "${CMAKE_COMMAND}" -E env "DESTDIR=${test_destdir}" "${CMAKE_COMMAND}" ${producer_install_args}
+  )
+else()
+  set(producer_install_command "${CMAKE_COMMAND}" ${producer_install_args})
+endif()
+
 execute_process(
-  COMMAND "${CMAKE_COMMAND}" ${producer_install_args}
+  COMMAND ${producer_install_command}
   RESULT_VARIABLE producer_install_result
 )
 if(NOT producer_install_result EQUAL 0)
   message(FATAL_ERROR "Failed to install the producer package.")
+endif()
+
+function(ftimer_verify_installed_artifacts)
+  set(expected_installed_module_artifacts
+    ftimer.mod
+    ftimer_clock.mod
+    ftimer_core.mod
+    ftimer_mpi.mod
+    ftimer_summary.mod
+    ftimer_types.mod
+  )
+
+  file(GLOB installed_module_artifact_paths LIST_DIRECTORIES FALSE "${installed_module_dir}/*")
+  set(installed_module_artifact_names)
+  foreach(installed_module_artifact_path IN LISTS installed_module_artifact_paths)
+    get_filename_component(installed_module_artifact_name "${installed_module_artifact_path}" NAME)
+    list(APPEND installed_module_artifact_names "${installed_module_artifact_name}")
+  endforeach()
+
+  list(SORT expected_installed_module_artifacts)
+  list(SORT installed_module_artifact_names)
+
+  if(NOT installed_module_artifact_names STREQUAL expected_installed_module_artifacts)
+    list(JOIN expected_installed_module_artifacts ", " expected_installed_module_artifacts_text)
+    list(JOIN installed_module_artifact_names ", " installed_module_artifact_names_text)
+    message(FATAL_ERROR
+      "Installed module artifact set mismatch.\n"
+      "Expected: ${expected_installed_module_artifacts_text}\n"
+      "Actual: ${installed_module_artifact_names_text}"
+    )
+  endif()
+
+  foreach(misinstalled_module_dir IN LISTS misinstalled_module_dirs)
+    if(EXISTS "${misinstalled_module_dir}")
+      file(GLOB misinstalled_module_artifact_paths
+        LIST_DIRECTORIES FALSE
+        "${misinstalled_module_dir}/*.mod"
+      )
+      if(misinstalled_module_artifact_paths)
+        message(FATAL_ERROR
+          "Absolute CMAKE_INSTALL_INCLUDEDIR module artifacts were installed under an unexpected path '${misinstalled_module_dir}'."
+        )
+      endif()
+    endif()
+  endforeach()
+
+  if(NOT EXISTS "${installed_api_note_path}")
+    message(FATAL_ERROR
+      "Installed API stability note was not found at '${installed_api_note_path}'."
+    )
+  endif()
+
+  file(READ "${REPO_ROOT}/docs/installed-api.md" expected_installed_api_note)
+  file(READ "${installed_api_note_path}" installed_api_note)
+  if(NOT installed_api_note STREQUAL expected_installed_api_note)
+    message(FATAL_ERROR
+      "Installed API stability note does not match docs/installed-api.md."
+    )
+  endif()
+
+  if(NOT EXISTS "${installed_license_path}")
+    message(FATAL_ERROR
+      "Installed BSD license was not found at '${installed_license_path}'."
+    )
+  endif()
+
+  file(READ "${REPO_ROOT}/LICENSE" expected_license)
+  file(READ "${installed_license_path}" installed_license)
+  if(NOT installed_license STREQUAL expected_license)
+    message(FATAL_ERROR
+      "Installed BSD license does not match LICENSE."
+    )
+  endif()
+endfunction()
+
+if(TEST_INSTALL_ONLY)
+  ftimer_verify_installed_artifacts()
+  return()
 endif()
 
 if(NOT DEFINED TEST_PACKAGE_VERSION OR TEST_PACKAGE_VERSION STREQUAL "")
@@ -310,75 +413,7 @@ ftimer_check_package_version_request(
   "${future_minor_prefix}"
 )
 
-set(expected_installed_module_artifacts
-  ftimer.mod
-  ftimer_clock.mod
-  ftimer_core.mod
-  ftimer_mpi.mod
-  ftimer_summary.mod
-  ftimer_types.mod
-)
-
-file(GLOB installed_module_artifact_paths LIST_DIRECTORIES FALSE "${installed_module_dir}/*")
-set(installed_module_artifact_names)
-foreach(installed_module_artifact_path IN LISTS installed_module_artifact_paths)
-  get_filename_component(installed_module_artifact_name "${installed_module_artifact_path}" NAME)
-  list(APPEND installed_module_artifact_names "${installed_module_artifact_name}")
-endforeach()
-
-list(SORT expected_installed_module_artifacts)
-list(SORT installed_module_artifact_names)
-
-if(NOT installed_module_artifact_names STREQUAL expected_installed_module_artifacts)
-  list(JOIN expected_installed_module_artifacts ", " expected_installed_module_artifacts_text)
-  list(JOIN installed_module_artifact_names ", " installed_module_artifact_names_text)
-  message(FATAL_ERROR
-    "Installed module artifact set mismatch.\n"
-    "Expected: ${expected_installed_module_artifacts_text}\n"
-    "Actual: ${installed_module_artifact_names_text}"
-  )
-endif()
-
-if(NOT misinstalled_prefixed_module_dir STREQUAL ""
-    AND EXISTS "${misinstalled_prefixed_module_dir}")
-  file(GLOB misinstalled_module_artifact_paths
-    LIST_DIRECTORIES FALSE
-    "${misinstalled_prefixed_module_dir}/*.mod"
-  )
-  if(misinstalled_module_artifact_paths)
-    message(FATAL_ERROR
-      "Absolute CMAKE_INSTALL_INCLUDEDIR module artifacts were installed under the prefix-joined path '${misinstalled_prefixed_module_dir}'."
-    )
-  endif()
-endif()
-
-if(NOT EXISTS "${installed_api_note_path}")
-  message(FATAL_ERROR
-    "Installed API stability note was not found at '${installed_api_note_path}'."
-  )
-endif()
-
-file(READ "${REPO_ROOT}/docs/installed-api.md" expected_installed_api_note)
-file(READ "${installed_api_note_path}" installed_api_note)
-if(NOT installed_api_note STREQUAL expected_installed_api_note)
-  message(FATAL_ERROR
-    "Installed API stability note does not match docs/installed-api.md."
-  )
-endif()
-
-if(NOT EXISTS "${installed_license_path}")
-  message(FATAL_ERROR
-    "Installed BSD license was not found at '${installed_license_path}'."
-  )
-endif()
-
-file(READ "${REPO_ROOT}/LICENSE" expected_license)
-file(READ "${installed_license_path}" installed_license)
-if(NOT installed_license STREQUAL expected_license)
-  message(FATAL_ERROR
-    "Installed BSD license does not match LICENSE."
-  )
-endif()
+ftimer_verify_installed_artifacts()
 
 set(consumer_configure_args
   -S "${consumer_source_dir}"

--- a/tests/check_installed_package_consumer.cmake
+++ b/tests/check_installed_package_consumer.cmake
@@ -4,12 +4,42 @@ set(install_prefix "${TEST_BINARY_DIR}/prefix")
 set(consumer_build_dir "${TEST_BINARY_DIR}/consumer-build")
 set(consumer_source_dir "${REPO_ROOT}/tests/install-consumer")
 set(test_name "${TEST_NAME}")
-set(installed_module_dir "${install_prefix}/include/ftimer")
 set(installed_api_note_path "${install_prefix}/share/doc/fTimer/installed-api.md")
 set(installed_license_path "${install_prefix}/share/doc/fTimer/LICENSE")
 
+if(DEFINED TEST_INSTALL_INCLUDEDIR AND NOT TEST_INSTALL_INCLUDEDIR STREQUAL "")
+  set(test_install_includedir "${TEST_INSTALL_INCLUDEDIR}")
+else()
+  set(test_install_includedir "include")
+endif()
+
+if(IS_ABSOLUTE "${test_install_includedir}")
+  set(installed_module_dir "${test_install_includedir}/ftimer")
+  set(misinstalled_prefixed_module_dir
+    "${install_prefix}${test_install_includedir}/ftimer"
+  )
+else()
+  set(installed_module_dir "${install_prefix}/${test_install_includedir}/ftimer")
+  set(misinstalled_prefixed_module_dir "")
+endif()
+
 if(test_name STREQUAL "")
   set(test_name "ftimer_installed_package_consumer")
+endif()
+
+if(TEST_CLEAN_INSTALL_INCLUDEDIR AND IS_ABSOLUTE "${test_install_includedir}")
+  get_filename_component(clean_install_includedir "${test_install_includedir}" ABSOLUTE)
+  if(clean_install_includedir STREQUAL "/" OR clean_install_includedir STREQUAL "")
+    message(FATAL_ERROR
+      "Refusing to clean unsafe TEST_INSTALL_INCLUDEDIR path '${test_install_includedir}'."
+    )
+  endif()
+  if(NOT clean_install_includedir MATCHES "/ftimer-absolute-includedir/")
+    message(FATAL_ERROR
+      "Refusing to clean TEST_INSTALL_INCLUDEDIR path outside the test-owned absolute include root: '${test_install_includedir}'."
+    )
+  endif()
+  file(REMOVE_RECURSE "${clean_install_includedir}")
 endif()
 
 if(DEFINED TEST_REQUIRED_COMPILER_NAMES AND NOT TEST_REQUIRED_COMPILER_NAMES STREQUAL "")
@@ -35,6 +65,7 @@ set(configure_args
   -B "${TEST_BINARY_DIR}/producer-build"
   -G "${CMAKE_GENERATOR}"
   -DCMAKE_INSTALL_PREFIX=${install_prefix}
+  -DCMAKE_INSTALL_INCLUDEDIR=${test_install_includedir}
   -DFTIMER_BUILD_SMOKE_TESTS=OFF
   -DFTIMER_BUILD_TESTS=OFF
   -DFTIMER_BUILD_EXAMPLES=OFF
@@ -306,6 +337,19 @@ if(NOT installed_module_artifact_names STREQUAL expected_installed_module_artifa
     "Expected: ${expected_installed_module_artifacts_text}\n"
     "Actual: ${installed_module_artifact_names_text}"
   )
+endif()
+
+if(NOT misinstalled_prefixed_module_dir STREQUAL ""
+    AND EXISTS "${misinstalled_prefixed_module_dir}")
+  file(GLOB misinstalled_module_artifact_paths
+    LIST_DIRECTORIES FALSE
+    "${misinstalled_prefixed_module_dir}/*.mod"
+  )
+  if(misinstalled_module_artifact_paths)
+    message(FATAL_ERROR
+      "Absolute CMAKE_INSTALL_INCLUDEDIR module artifacts were installed under the prefix-joined path '${misinstalled_prefixed_module_dir}'."
+    )
+  endif()
 endif()
 
 if(NOT EXISTS "${installed_api_note_path}")


### PR DESCRIPTION
## Summary

- Phase / issue: Phase 1 production-readiness remediation, closes #208
- Scope: Fix custom Fortran module installation so absolute `CMAKE_INSTALL_INCLUDEDIR` destinations are honored, and add an installed-consumer smoke regression for that layout.

## Checks

- [x] Linked to the relevant GitHub issue
- [ ] Codex review routing has applied the expected automatic review labels, or I added any missing ones manually
- [ ] Added any extra Codex review labels needed beyond the automatic set
- [x] Docs updated to match behavior changes
- [x] Tests or smoke-path coverage updated as appropriate
- [ ] Workflow/bootstrap docs updated if repo process changed

## Validation

- Confirmed new `ftimer_installed_package_consumer_absolute_includedir` regression fails before the installer fix because `.mod` files are written under `prefix/<absolute-includedir>/ftimer`.
- `cmake --fresh -B build-smoke`
- `cmake --build build-smoke`
- `ctest --test-dir build-smoke --output-on-failure` (13/13 passed)
- `git diff --check`

## Notes

- Follow-up work: none
- Deferred items: none