### PR TITLE
Pin and verify CI dependencies

### DIFF
--- a/.github/constraints/lint.txt
+++ b/.github/constraints/lint.txt
@@ -1,0 +1,2 @@
+# CI lint tool pins. Keep exact versions and update docs/maintainer.md when changing.
+fprettify==0.3.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,12 +104,26 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gfortran cmake libopenmpi-dev openmpi-bin
 
+      - name: Capture pFUnit cache identity
+        id: pfunit-identity
+        run: |
+          {
+            cat /etc/os-release
+            uname -a
+            gfortran --version
+            mpifort --version
+            mpirun --version
+            cmake --version
+          } > /tmp/pfunit-cache-identity.txt
+          identity="$(sha256sum /tmp/pfunit-cache-identity.txt | cut -d ' ' -f1)"
+          echo "key=$identity" >> "$GITHUB_OUTPUT"
+
       - name: Cache pFUnit
         uses: actions/cache@v4
         id: pfunit-cache
         with:
           path: /opt/pfunit
-          key: pfunit-${{ runner.os }}-gfortran-openmpi-${{ env.PFUNIT_VERSION }}-${{ env.PFUNIT_SHA256 }}
+          key: pfunit-${{ runner.os }}-${{ steps.pfunit-identity.outputs.key }}-${{ env.PFUNIT_VERSION }}-${{ env.PFUNIT_SHA256 }}
 
       - name: Build pFUnit
         if: steps.pfunit-cache.outputs.cache-hit != 'true'
@@ -146,12 +160,26 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gfortran cmake libopenmpi-dev openmpi-bin
 
+      - name: Capture pFUnit cache identity
+        id: pfunit-identity
+        run: |
+          {
+            cat /etc/os-release
+            uname -a
+            gfortran --version
+            mpifort --version
+            mpirun --version
+            cmake --version
+          } > /tmp/pfunit-cache-identity.txt
+          identity="$(sha256sum /tmp/pfunit-cache-identity.txt | cut -d ' ' -f1)"
+          echo "key=$identity" >> "$GITHUB_OUTPUT"
+
       - name: Cache pFUnit
         uses: actions/cache@v4
         id: pfunit-cache
         with:
           path: /opt/pfunit
-          key: pfunit-${{ runner.os }}-gfortran-openmpi-${{ env.PFUNIT_VERSION }}-${{ env.PFUNIT_SHA256 }}
+          key: pfunit-${{ runner.os }}-${{ steps.pfunit-identity.outputs.key }}-${{ env.PFUNIT_VERSION }}-${{ env.PFUNIT_SHA256 }}
 
       - name: Build pFUnit
         if: steps.pfunit-cache.outputs.cache-hit != 'true'
@@ -224,12 +252,26 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gfortran cmake libopenmpi-dev openmpi-bin
 
+      - name: Capture pFUnit cache identity
+        id: pfunit-identity
+        run: |
+          {
+            cat /etc/os-release
+            uname -a
+            gfortran --version
+            mpifort --version
+            mpirun --version
+            cmake --version
+          } > /tmp/pfunit-cache-identity.txt
+          identity="$(sha256sum /tmp/pfunit-cache-identity.txt | cut -d ' ' -f1)"
+          echo "key=$identity" >> "$GITHUB_OUTPUT"
+
       - name: Cache pFUnit
         uses: actions/cache@v4
         id: pfunit-cache
         with:
           path: /opt/pfunit
-          key: pfunit-${{ runner.os }}-gfortran-openmpi-${{ env.PFUNIT_VERSION }}-${{ env.PFUNIT_SHA256 }}
+          key: pfunit-${{ runner.os }}-${{ steps.pfunit-identity.outputs.key }}-${{ env.PFUNIT_VERSION }}-${{ env.PFUNIT_SHA256 }}
 
       - name: Build pFUnit
         if: steps.pfunit-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: read
 
+env:
+  PFUNIT_VERSION: v4.16.0
+  PFUNIT_SHA256: 314381ff08dc99e87a4da5862501053d112babaf73244b1c04b77065d3fd3091
+  PFUNIT_ARCHIVE_URL: https://github.com/Goddard-Fortran-Ecosystem/pFUnit/releases/download/v4.16.0/pFUnit-v4.16.0.tar
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -104,13 +109,15 @@ jobs:
         id: pfunit-cache
         with:
           path: /opt/pfunit
-          key: pfunit-${{ runner.os }}-gfortran-openmpi-v4.16.0
+          key: pfunit-${{ runner.os }}-gfortran-openmpi-${{ env.PFUNIT_VERSION }}-${{ env.PFUNIT_SHA256 }}
 
       - name: Build pFUnit
         if: steps.pfunit-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p /tmp/pfunit-src
-          curl -fsSL https://github.com/Goddard-Fortran-Ecosystem/pFUnit/releases/download/v4.16.0/pFUnit-v4.16.0.tar | tar x --strip-components=1 -C /tmp/pfunit-src
+          curl -fsSL "$PFUNIT_ARCHIVE_URL" -o /tmp/pfunit.tar
+          printf '%s  %s\n' "$PFUNIT_SHA256" /tmp/pfunit.tar | sha256sum -c -
+          tar -xf /tmp/pfunit.tar --strip-components=1 -C /tmp/pfunit-src
           FC=mpifort cmake -B /tmp/pfunit-build -S /tmp/pfunit-src -DCMAKE_INSTALL_PREFIX=/opt/pfunit -DMPI=YES
           cmake --build /tmp/pfunit-build -j$(nproc)
           cmake --install /tmp/pfunit-build
@@ -144,13 +151,15 @@ jobs:
         id: pfunit-cache
         with:
           path: /opt/pfunit
-          key: pfunit-${{ runner.os }}-gfortran-openmpi-v4.16.0
+          key: pfunit-${{ runner.os }}-gfortran-openmpi-${{ env.PFUNIT_VERSION }}-${{ env.PFUNIT_SHA256 }}
 
       - name: Build pFUnit
         if: steps.pfunit-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p /tmp/pfunit-src
-          curl -fsSL https://github.com/Goddard-Fortran-Ecosystem/pFUnit/releases/download/v4.16.0/pFUnit-v4.16.0.tar | tar x --strip-components=1 -C /tmp/pfunit-src
+          curl -fsSL "$PFUNIT_ARCHIVE_URL" -o /tmp/pfunit.tar
+          printf '%s  %s\n' "$PFUNIT_SHA256" /tmp/pfunit.tar | sha256sum -c -
+          tar -xf /tmp/pfunit.tar --strip-components=1 -C /tmp/pfunit-src
           FC=mpifort cmake -B /tmp/pfunit-build -S /tmp/pfunit-src -DCMAKE_INSTALL_PREFIX=/opt/pfunit -DMPI=YES
           cmake --build /tmp/pfunit-build -j$(nproc)
           cmake --install /tmp/pfunit-build
@@ -220,13 +229,15 @@ jobs:
         id: pfunit-cache
         with:
           path: /opt/pfunit
-          key: pfunit-${{ runner.os }}-gfortran-openmpi-v4.16.0
+          key: pfunit-${{ runner.os }}-gfortran-openmpi-${{ env.PFUNIT_VERSION }}-${{ env.PFUNIT_SHA256 }}
 
       - name: Build pFUnit
         if: steps.pfunit-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p /tmp/pfunit-src
-          curl -fsSL https://github.com/Goddard-Fortran-Ecosystem/pFUnit/releases/download/v4.16.0/pFUnit-v4.16.0.tar | tar x --strip-components=1 -C /tmp/pfunit-src
+          curl -fsSL "$PFUNIT_ARCHIVE_URL" -o /tmp/pfunit.tar
+          printf '%s  %s\n' "$PFUNIT_SHA256" /tmp/pfunit.tar | sha256sum -c -
+          tar -xf /tmp/pfunit.tar --strip-components=1 -C /tmp/pfunit-src
           FC=mpifort cmake -B /tmp/pfunit-build -S /tmp/pfunit-src -DCMAKE_INSTALL_PREFIX=/opt/pfunit -DMPI=YES
           cmake --build /tmp/pfunit-build -j$(nproc)
           cmake --install /tmp/pfunit-build
@@ -265,7 +276,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install fprettify
-        run: pip install fprettify
+        run: python3 -m pip install --constraint .github/constraints/lint.txt fprettify
 
       - name: Check formatting
         run: |

--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -28,6 +28,28 @@ This document routes to phase-specific workflow docs. Shared coding-agent contex
   - blocks direct pushes and force pushes
   - requires conversation resolution
 
+## CI Dependency Pins
+
+CI treats third-party tooling as part of the release trust boundary. Keep the
+download identity and cache identity together when updating pinned tools.
+
+- pFUnit:
+  - Update `PFUNIT_VERSION`, `PFUNIT_ARCHIVE_URL`, and `PFUNIT_SHA256` together
+    in `.github/workflows/ci.yml`.
+  - Compute `PFUNIT_SHA256` from the release archive before merging the update,
+    for example by downloading the intended `pFUnit-vX.Y.Z.tar` release asset
+    from `Goddard-Fortran-Ecosystem/pFUnit` and running `sha256sum`.
+  - The pFUnit cache key includes both version and SHA. Changing either value
+    intentionally creates a new cache lineage.
+- fprettify:
+  - Update `.github/constraints/lint.txt` when changing the lint tool version.
+  - Keep the CI install command constraint-based so `pip` cannot float to a
+    newer formatter during release validation.
+- Validation:
+  - Run `git diff --check` after dependency pin updates.
+  - Let GitHub CI exercise the verified pFUnit download path and the pinned
+    lint install path before treating a release-boundary PR as ready.
+
 ## Workflow Phases
 
 Use the workflow docs below for phase-specific operating procedures. Load only the phase you need.

--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -39,8 +39,9 @@ download identity and cache identity together when updating pinned tools.
   - Compute `PFUNIT_SHA256` from the release archive before merging the update,
     for example by downloading the intended `pFUnit-vX.Y.Z.tar` release asset
     from `Goddard-Fortran-Ecosystem/pFUnit` and running `sha256sum`.
-  - The pFUnit cache key includes both version and SHA. Changing either value
-    intentionally creates a new cache lineage.
+  - The pFUnit cache key includes the runner/compiler/MPI/CMake identity, the
+    pFUnit version, and the archive SHA. Changing the toolchain image, version,
+    or SHA intentionally creates a new cache lineage.
 - fprettify:
   - Update `.github/constraints/lint.txt` when changing the lint tool version.
   - Keep the CI install command constraint-based so `pip` cannot float to a


### PR DESCRIPTION
Closes #209.

## Summary

- verify the pFUnit release archive SHA256 before extraction in every CI pFUnit build path
- include the pFUnit version and archive SHA in the pFUnit cache key
- pin the lint formatter through a checked-in `fprettify==0.3.7` constraints file
- document maintainer update steps for pFUnit and fprettify pins

## Validation

- `git diff --check`
- `ruby -e 'require "psych"; Psych.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/ci.yml`
- targeted grep check confirmed no remaining `curl | tar` pFUnit download pattern and no unpinned `pip install fprettify`

Note: `actionlint` is not installed in the local environment, and networked pFUnit/fprettify install paths are left to GitHub CI.