### PR TITLE
Add release governance and contributor intake docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,101 @@
+name: Bug report
+description: Report a reproducible fTimer defect or regression.
+title: "Bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug.
+        Please include enough detail for a maintainer to reproduce the behavior without guessing.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+      placeholder: fTimer returns an unexpected error code when ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: >-
+        Include the smallest code snippet, command sequence, or test case that
+        reproduces the issue.
+      placeholder: |
+        1. Configure with ...
+        2. Build ...
+        3. Run ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead? Include error codes, stderr, or relevant output.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: workflow
+    attributes:
+      label: Affected workflow
+      description: Choose the closest supported workflow.
+      options:
+        - Serial timing
+        - Pure-MPI timing
+        - OpenMP master-thread-only carve-out
+        - CMake install/package consumption
+        - Examples or smoke tests
+        - Documentation
+        - CI or release infrastructure
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >-
+        List compiler, MPI implementation if relevant, OS, CMake version, fTimer
+        version or commit, and build options.
+      placeholder: |
+        - fTimer commit or version:
+        - Compiler:
+        - MPI:
+        - OS:
+        - CMake:
+        - Options:
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation already tried
+      description: List any tests, smoke builds, or workarounds you tried.
+      placeholder: ctest --test-dir build-smoke --output-on-failure
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Add links, logs, screenshots, or related issues. Do not include security-sensitive details here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: Propose a bounded fTimer improvement.
+title: "Feature: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for concrete improvements.
+        If the main need is deciding product/API direction, use the strategic question template instead.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or workflow
+      description: What user workflow is blocked or painful today?
+      placeholder: I want to use fTimer for ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      description: Describe the smallest behavior, API, documentation, or tooling change that would help.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workarounds or different designs have you considered?
+    validations:
+      required: false
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope boundaries
+      description: What should this request include, and what should it not include?
+      placeholder: |
+        In scope:
+        - ...
+        Out of scope:
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Suggested validation
+      description: What test, example, docs update, or smoke-path evidence would prove this is done?
+    validations:
+      required: false
+
+  - type: textarea
+    id: related_context
+    attributes:
+      label: Related context
+      description: Link related issues, PRs, code paths, adopter needs, or documentation.
+    validations:
+      required: false

--- a/.github/codex-review-roles.json
+++ b/.github/codex-review-roles.json
@@ -53,8 +53,12 @@
         "path_regex_any": [
           "^AGENTS\\.md$",
           "^CLAUDE\\.md$",
+          "^CONTRIBUTING\\.md$",
           "^README\\.md$",
+          "^SECURITY\\.md$",
+          "^SUPPORT\\.md$",
           "^docs/",
+          "^\\.github/ISSUE_TEMPLATE/",
           "^examples/",
           "^\\.github/pull_request_template\\.md$",
           "^\\.github/workflows/codex-review\\.yml$",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing To fTimer
+
+Thanks for helping make fTimer more reliable. This project is currently focused
+on a small, auditable wall-clock timing library for serial and pure-MPI Fortran
+codes, with a narrow OpenMP master-thread-only carve-out.
+
+## Before Opening Work
+
+- Use the bug report template for reproducible failures.
+- Use the feature request template for bounded improvements.
+- Use the strategic question template when the next step is a product, API, or
+  scope decision rather than implementation.
+- Do not file security-sensitive details in a public issue. Follow
+  `SECURITY.md`.
+- Check for existing issues before opening duplicates, especially for deferred
+  topics such as FPM packaging, richer OpenMP timing, hardware counters, traces,
+  accelerator timelines, and profiler-backend integration.
+
+## Development Setup
+
+Use a separate build directory for each compiler and feature mode. Reconfiguring
+one CMake tree across compilers is not a supported workflow.
+
+The default local smoke path is:
+
+```bash
+cmake -B build-smoke
+cmake --build build-smoke
+ctest --test-dir build-smoke --output-on-failure
+```
+
+Behavioral tests require pFUnit and a matching compiler/toolchain:
+
+```bash
+FC=gfortran cmake -B build -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+MPI and OpenMP validation commands are listed in `AGENTS.md`, `README.md`, and
+`docs/release.md`.
+
+## Pull Requests
+
+For normal changes:
+
+- Link the relevant GitHub issue.
+- Keep the diff scoped to that issue.
+- Update docs when behavior, support boundaries, packaging, or workflow changes.
+- Add or update tests when behavior changes.
+- Run `git diff --check` before opening the PR.
+- Record any unavailable local validation with a reason.
+
+Repository PR handling, review labels, fallback review, and findings disposition
+are documented in `docs/maintainer.md` and `docs/workflows/`.
+
+## Coding And Documentation Expectations
+
+- Prefer correctness and explicit error handling over silent fallbacks.
+- Preserve deterministic tests by using the injectable mock clock instead of
+  sleeps or wall-clock timing assumptions.
+- Keep public API and installed-package docs aligned with implementation.
+- Keep release-scope docs honest about what current `main` supports and what is
+  deferred.
+- Use BSD-3-Clause-compatible contributions only. If you need to include copied
+  or generated third-party material, document the license basis in the PR.
+
+## Contributor Intake
+
+Maintainers triage incoming issues roughly as:
+
+- `bug`: reproducible defects or regressions.
+- `enhancement` / `improvement-issue`: bounded improvements.
+- `question` / `strategic-question`: decisions needed before implementation.
+- `release-blocker`: must be resolved before the next release claim.
+- `post-release`: regression or follow-up found after a release.
+
+Small, well-scoped PRs with clear validation are easiest to review and merge.

--- a/README.md
+++ b/README.md
@@ -368,6 +368,9 @@ This is useful for before/after regression checks when changing hot-path timing 
 
 - Runtime semantics: [`docs/semantics.md`](docs/semantics.md)
 - Current architecture reference: [`docs/design.md`](docs/design.md)
+- Release checklist and artifact policy: [`docs/release.md`](docs/release.md)
+- Contributor guidance: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Support and security reporting: [`SUPPORT.md`](SUPPORT.md), [`SECURITY.md`](SECURITY.md)
 
 When current-state sources disagree, use this repository-wide precedence order:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+fTimer is a timing library, not a security boundary. Still, maintainers want
+reports about vulnerabilities or release-integrity risks handled privately
+before public disclosure.
+
+## Supported Versions
+
+Pre-1.0 releases are supported on a best-effort basis. Security fixes normally
+target the latest release line and current `main` unless a maintainer documents
+another patch policy for a specific release.
+
+## Reporting A Vulnerability
+
+Do not include exploit details, sensitive logs, credentials, private repository
+data, or embargoed information in a public issue.
+
+Preferred reporting path:
+
+1. Use GitHub private vulnerability reporting if it is available for this
+   repository.
+2. If private vulnerability reporting is not available, open a public issue with
+   no sensitive details that asks the maintainer to establish a private contact
+   path.
+
+Include privately:
+
+- affected fTimer version or commit,
+- supported workflow involved, such as serial, MPI, OpenMP, install/package, or
+  CI/release infrastructure,
+- reproduction steps or proof of concept,
+- expected impact,
+- whether the report is already public anywhere else.
+
+## Handling Expectations
+
+Maintainers will triage whether the report is a vulnerability, a release
+integrity issue, a normal bug, or out of scope. Valid security fixes should land
+through a scoped PR with appropriate validation and release notes. Public
+disclosure should wait until a fix or maintainer disposition is available unless
+the issue is already public.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,24 @@
+# Support
+
+Use GitHub issues for public fTimer support and triage:
+
+- Bug reports: use the bug report template and include the compiler, build
+  options, platform, reproduction steps, expected behavior, and actual behavior.
+- Feature requests: use the feature request template and describe the workflow
+  that needs support.
+- Strategic questions: use the strategic question template when the issue is a
+  product, API, or scope decision.
+
+Please keep support requests inside the documented release scope unless you are
+explicitly asking to discuss a future direction. Current release-scoped support
+centers on serial timing, pure-MPI timing, the master-thread-only OpenMP
+carve-out, CMake package consumption, summaries, reports, CSV output, and the
+documented error contract.
+
+Security-sensitive reports should not be filed as public support issues. Follow
+`SECURITY.md`.
+
+This project does not currently offer commercial support, private SLAs, or
+guaranteed response times. Maintainers prioritize release blockers, confirmed
+regressions, security reports, and well-scoped issues with reproducible
+evidence.

--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -21,6 +21,17 @@ This document routes to phase-specific workflow docs. Shared coding-agent contex
   - `codex-pragmatic-design-review`
   - `codex-adoptability-review`
   - `codex-completion-audit-review`
+- Create or verify the ordinary issue-triage labels used by the issue templates,
+  release checklist, and contributor intake docs:
+  - `bug`
+  - `enhancement`
+  - `documentation`
+  - `question`
+  - `strategic-question`
+  - `improvement-issue`
+  - `release-audit`
+  - `release-blocker`
+  - `post-release`
 - Add a repository secret named `CODEX_TRIGGER_PAT` for the review-trigger workflow.
 - Configure a `main` ruleset that:
   - requires pull requests before merge

--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -55,9 +55,15 @@ download identity and cache identity together when updating pinned tools.
 
 Use the workflow docs below for phase-specific operating procedures. Load only the phase you need.
 
-- [`docs/workflows/pr-open.md`](workflows/pr-open.md) — opening a PR, applying review labels, review prompt library
-- [`docs/workflows/review-monitoring.md`](workflows/review-monitoring.md) — monitoring for review output, fallback review, inspection commands, known limitations
-- [`docs/workflows/findings-disposition.md`](workflows/findings-disposition.md) — responding to findings, deferral rules, merge-blocking criteria, PR closeout
+- [`docs/workflows/pr-open.md`](workflows/pr-open.md) — opening a PR,
+  applying review labels, review prompt library
+- [`docs/workflows/review-monitoring.md`](workflows/review-monitoring.md) —
+  monitoring for review output, fallback review, inspection commands, known
+  limitations
+- [`docs/workflows/findings-disposition.md`](workflows/findings-disposition.md)
+  — responding to findings, deferral rules, merge-blocking criteria, PR closeout
+- [`docs/release.md`](release.md) — release checklist, validation matrix,
+  artifact policy, tag steps, and post-release triage
 
 ## Standard Maintainer Flow
 
@@ -69,3 +75,7 @@ For every scoped piece of work:
 4. Monitor for review output — see [`review-monitoring.md`](workflows/review-monitoring.md).
 5. Address every finding — see [`findings-disposition.md`](workflows/findings-disposition.md).
 6. Do not merge while merge-blocking findings remain unresolved.
+
+For release preparation, use [`docs/release.md`](release.md) after the relevant
+issue/PR workflow is complete. A coding agent may prepare evidence and release
+notes, but a human maintainer owns the final tag and GitHub release.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,166 @@
+# Release Checklist
+
+This checklist keeps fTimer releases lightweight, auditable, and aligned with
+the current product scope. It is written for human maintainers. Coding agents
+may prepare evidence, PRs, and status updates, but a human maintainer owns the
+final release decision, tag, and GitHub release.
+
+## Release Scope
+
+Before starting a release candidate:
+
+- Confirm all release-blocking issues are closed or explicitly deferred with a
+  maintainer decision.
+- Confirm the release umbrella, if any, reflects the current state of child
+  issues and ready PRs.
+- Review open `release-blocker`, `release-audit`, `bug`, and `post-release`
+  issues for items that should affect the release notes or block the tag.
+- Keep the release claim within the documented support boundary: serial timing,
+  pure-MPI timing, the narrow master-thread-only OpenMP carve-out, and the
+  CMake package path.
+- Do not promote deferred non-goals into the release unless a linked issue has
+  changed scope. Current non-goals include broad hybrid OpenMP timing, full
+  profiler integration, FPM packaging, hardware counters, traces, accelerator
+  timelines, automatic MPI barriers, and stable callback semantic identity.
+
+## Version And Compatibility
+
+- Update the project version in `CMakeLists.txt`.
+- Confirm the pre-1.0 CMake package compatibility rule is still accurate in
+  `README.md` and `docs/installed-api.md`.
+- If a stable source-level symbol, installed module artifact, CSV schema field,
+  or package compatibility boundary changes, update the relevant docs and
+  smoke/contract checks in the same release-prep PR.
+- Treat release notes as part of the compatibility contract: describe
+  user-visible behavior changes, limitations, and migration notes directly.
+
+## Validation Matrix
+
+Run the strongest available local validation before opening a release-prep PR,
+then require GitHub CI to pass before tagging.
+
+| Area | Required before tag |
+| --- | --- |
+| Smoke/install path | Yes |
+| Serial pFUnit path | Yes when pFUnit is available |
+| MPI path | Yes when MPI and matching pFUnit are available |
+| OpenMP carve-out | Yes when OpenMP and matching pFUnit are available |
+| Bench harness | Yes for hot-path or summary-performance changes |
+| Formatting | Yes for source/test/example changes |
+| Diff hygiene | Yes |
+| CI | Yes |
+
+Use the commands from `AGENTS.md` and `README.md` for each build mode. Minimum
+release-prep evidence should include the exact commands run, the local toolchain
+used, and whether the corresponding required CI jobs passed. Include
+`git diff --check` in every release-prep PR. Include the benchmark harness when
+hot-path timing behavior or summary-generation performance changed.
+
+Reference commands:
+
+```bash
+cmake -B build-smoke
+cmake --build build-smoke
+ctest --test-dir build-smoke --output-on-failure
+
+FC=gfortran cmake -B build \
+  -DFTIMER_BUILD_TESTS=ON \
+  -DPFUNIT_DIR=/path/to/pfunit
+cmake --build build
+ctest --test-dir build --output-on-failure
+
+FC=mpifort cmake -B build-mpi \
+  -DFTIMER_USE_MPI=ON \
+  -DFTIMER_BUILD_TESTS=ON \
+  -DPFUNIT_DIR=/path/to/pfunit
+cmake --build build-mpi
+ctest --test-dir build-mpi --output-on-failure -L mpi
+
+FC=gfortran cmake -B build-openmp \
+  -DFTIMER_USE_OPENMP=ON \
+  -DFTIMER_BUILD_TESTS=ON \
+  -DPFUNIT_DIR=/path/to/pfunit
+cmake --build build-openmp
+ctest --test-dir build-openmp --output-on-failure
+
+cmake --fresh -B build-bench \
+  -DFTIMER_BUILD_BENCH=ON \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build-bench --target ftimer_bench
+./build-bench/bench/ftimer_bench
+
+git diff --check
+```
+
+If a toolchain is unavailable locally, record the skip reason in the release-prep
+PR and rely on the corresponding required CI job before tagging.
+
+## Artifact Policy
+
+A normal fTimer release publishes:
+
+- the signed or annotated Git tag,
+- the GitHub release notes,
+- GitHub-generated source archives,
+- the source tree's `LICENSE`,
+- installable CMake package files produced from source,
+- installed documentation under `share/doc/fTimer/`, including
+  `installed-api.md` and `LICENSE`.
+
+Do not attach binary packages, compiler module bundles, benchmark data, or
+generated reports to a release unless a release issue explicitly adds that
+artifact type and records how it was built, validated, and licensed.
+
+## License Expectations
+
+- fTimer is distributed under BSD-3-Clause. The root `LICENSE` is the source of
+  truth for the license text.
+- New source, test, script, documentation, and workflow files contributed to the
+  repository are expected to be compatible with BSD-3-Clause distribution.
+- Third-party snippets, generated files, vendored code, or copied examples need
+  a documented license basis before they can be included in a release.
+- The install/package smoke path must continue to install the license artifact
+  that downstream consumers receive.
+
+## Release Notes
+
+Release notes should be short and evidence-backed. Include:
+
+- the version and tag,
+- the intended audience and supported workflows,
+- user-visible API, packaging, CSV, MPI, OpenMP, or behavior changes,
+- compatibility and migration notes,
+- known limitations and deferred work,
+- validation summary and any toolchain skips,
+- links to important issues and PRs.
+
+Do not claim production readiness, broad compiler support, general hybrid
+OpenMP timing, profiler-backend integration, or binary package availability
+unless the release validation and docs support that exact claim.
+
+## Tag And Publish
+
+After the release-prep PR has merged and `main` is current:
+
+1. Verify the local checkout is clean and current with `origin/main`.
+2. Confirm required CI passed on the merge commit.
+3. Create an annotated tag, for example `git tag -a v0.2.0 -m "fTimer 0.2.0"`.
+4. Push the tag with `git push origin v0.2.0`.
+5. Create the GitHub release from that tag using the prepared release notes.
+6. Check the published release page, source archive links, and displayed license.
+
+If a serious release mistake is found after publication, prefer a documented
+patch release over silently rewriting a public tag.
+
+## Post-Release Triage
+
+After publishing:
+
+- Watch new bug, support, and security-contact issues for release regressions.
+- Label confirmed release regressions with `post-release`; add
+  `release-blocker` only when the issue blocks the next release or patch.
+- Update the release umbrella or milestone with any deferred follow-up state.
+- If a vulnerability is reported, follow `SECURITY.md` instead of public issue
+  triage.
+- Keep release-note corrections factual and timestamped when they materially
+  change user guidance.

--- a/docs/release.md
+++ b/docs/release.md
@@ -97,19 +97,24 @@ PR and rely on the corresponding required CI job before tagging.
 
 ## Artifact Policy
 
-A normal fTimer release publishes:
+A normal fTimer GitHub release publishes:
 
 - the signed or annotated Git tag,
 - the GitHub release notes,
-- GitHub-generated source archives,
-- the source tree's `LICENSE`,
-- installable CMake package files produced from source,
+- GitHub-generated source archives that include the source tree's `LICENSE`.
+
+The released source must continue to produce these install-tree outputs through
+the documented CMake install path:
+
+- installable CMake package config/version files,
+- compiler module artifacts needed by the supported installed package contract,
 - installed documentation under `share/doc/fTimer/`, including
   `installed-api.md` and `LICENSE`.
 
-Do not attach binary packages, compiler module bundles, benchmark data, or
-generated reports to a release unless a release issue explicitly adds that
-artifact type and records how it was built, validated, and licensed.
+Do not attach binary packages, generated install trees, compiler module bundles,
+benchmark data, or generated reports to a GitHub release unless a release issue
+explicitly adds that artifact type and records how it was built, validated, and
+licensed.
 
 ## License Expectations
 
@@ -156,7 +161,8 @@ patch release over silently rewriting a public tag.
 
 After publishing:
 
-- Watch new bug, support, and security-contact issues for release regressions.
+- Watch new bug reports and support requests for release regressions.
+- Route security-sensitive contact requests through `SECURITY.md`.
 - Label confirmed release regressions with `post-release`; add
   `release-blocker` only when the issue blocks the next release or patch.
 - Update the release umbrella or milestone with any deferred follow-up state.


### PR DESCRIPTION
## Summary

- Phase / issue: Phase 1, closes #211, refs #198.
- Scope: add a lightweight release checklist and artifact policy, contributor/support/security guidance, ordinary bug/feature issue forms, and review routing for the new governance/intake docs.

## Checks

- [x] Linked to the relevant GitHub issue
- [x] Codex review routing has applied the expected automatic review labels, or I added any missing ones manually
- [x] Added any extra Codex review labels needed beyond the automatic set
- [x] Docs updated to match behavior changes
- [x] Tests or smoke-path coverage updated as appropriate
- [x] Workflow/bootstrap docs updated if repo process changed

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }; puts "issue templates yaml ok"' .github/ISSUE_TEMPLATE/*.yml`
- `ruby -e 'require "json"; JSON.parse(File.read(".github/codex-review-roles.json")); puts "review roles json ok"'`
- `git diff --cached --check`

No compiled test suite was run locally because this is a docs/templates-only change.

## Notes

- Follow-up work: none identified.
- Deferred items: none.