### PR TITLE
Clean up release-facing documentation drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This file provides guidance to Codex and other coding-agent workflows in this re
 
 ```bash
 # Performance measurement harness (serial, no pFUnit required)
-cmake --fresh -B build-bench -DFTIMER_BUILD_BENCH=ON -DCMAKE_BUILD_TYPE=Release
+cmake -S . -B build-bench -DFTIMER_BUILD_BENCH=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build build-bench --target ftimer_bench
 ./build-bench/bench/ftimer_bench
 
@@ -48,6 +48,10 @@ make test       # build + run tests
 make clean      # remove build/
 make install    # install to CMAKE_INSTALL_PREFIX
 ```
+
+For a clean benchmark reconfigure, remove or use a separate `build-bench/`
+directory first. With CMake 3.24 or newer, `cmake --fresh` may be added to the
+configure command as a convenience for a clean reconfigure.
 
 Supported toolchain matrix:
 
@@ -128,13 +132,13 @@ The call stack state CHANGES between start and stop — this is the most common 
 
 ## Development Workflow
 
-Current `main` is in Phase 6. The shared types/clock foundation, core timer runtime, local summary/report formatting, procedural convenience wrappers, MPI-reduced structured summaries, sparse/union MPI descriptor summaries, and limited OpenMP master-thread guards are implemented.
+Current `main` contains the shared types/clock foundation, core timer runtime, local summary/report formatting, procedural convenience wrappers, MPI-reduced structured summaries, sparse/union MPI descriptor summaries, and limited OpenMP master-thread guards.
 
-During Phase 6, keep the library, examples, install package, smoke tests, and pFUnit suite buildable. Keep the diff phase-bounded: preserve procedural-wrapper parity with the OOP core unless a tracked issue explicitly defers parity, keep MPI summary behavior correct and explicit, preserve the limited master-thread-only OpenMP guard model, and keep current-state docs/examples honest. Do not pull fuller post-Phase-6 design work or broader OpenMP support forward.
+During release-readiness work, keep the library, examples, install package, smoke tests, and pFUnit suite buildable. Keep diffs issue-bounded: preserve procedural-wrapper parity with the OOP core unless a tracked issue explicitly defers parity, keep MPI summary behavior correct and explicit, preserve the limited master-thread-only OpenMP guard model, and keep current-state docs/examples honest. Do not pull broader deferred design work or fuller OpenMP support forward without a linked issue.
 
 Detailed repository operations and PR/review handling live in `docs/maintainer.md`. Use that file for GitHub workflow details; keep this file focused on coding/build/test behavior and the short mandatory PR summary below.
 
-**Phase 1 exception:** the types/clock foundation was compile-first work, not an early pFUnit phase. Starting in Phase 2, test-driven development is mandatory: write tests first, confirm they fail, then implement. All behavioral tests use the injectable mock clock for deterministic results — tests never sleep or depend on wall-clock timing.
+Historical note: the original types/clock foundation was compile-first work before pFUnit coverage existed. For current behavioral changes, test-driven development is mandatory: write tests first, confirm they fail, then implement. All behavioral tests use the injectable mock clock for deterministic results — tests never sleep or depend on wall-clock timing.
 
 ### Source-of-Truth Order
 
@@ -161,18 +165,18 @@ Read additional docs only when the task requires them:
 - `docs/semantics.md` — when runtime behavior or contract is changing or unclear
 - `README.md` — when user-facing behavior, examples, or docs may need updates
 - `docs/design.md` — for architectural or repository-structure questions
-- `docs/implementation-history.md` — for historical phase-plan context or landed roadmap history
-- `docs/maintainer.md` — for workflow routing; then load only the phase-specific doc you need:
+- `docs/implementation-history.md` — for historical roadmap context or landed implementation history
+- `docs/maintainer.md` — for workflow routing; then load only the workflow-specific doc you need:
   - `docs/workflows/pr-open.md` — PR opening and review labels
   - `docs/workflows/review-monitoring.md` — monitoring and fallback review
   - `docs/workflows/findings-disposition.md` — responding to findings and merge criteria
 
 Context budget:
 
-- Read each file once per phase unless it changed or ambiguity remains.
+- Read each file once per work item unless it changed or ambiguity remains.
 - After the initial discovery pass, switch to implementation mode.
 - Prefer diff-based validation late in the task over broad repo sweeps.
-- Batch progress updates by phase, not by file or micro-step.
+- Batch progress updates by work stage, not by file or micro-step.
 
 ### GitHub Tooling Policy
 
@@ -242,8 +246,8 @@ The native Codex trigger comments are intentionally posted as single-line `@code
 ## Configuration
 
 - **`FTIMER_USE_MPI`** (CMake option, default OFF): Enables MPI support. When ON, `MPI_Wtime()` is used as the clock source and `mpi_summary()` / `mpi_union_summary()` can populate cross-rank fields. Use MPI-enabled fTimer only after `MPI_Init` and before `MPI_Finalize`. The supported path is an MPI wrapper compiler such as `mpifort`; configure now fails early if the active compiler cannot compile a minimal `mpi_f08` probe against the discovered MPI toolchain. When OFF, `mpi_summary()` and `mpi_union_summary()` return `FTIMER_ERR_NOT_IMPLEMENTED` with empty MPI result objects; they do not fall back to local summaries.
-- **`FTIMER_USE_OPENMP`** (CMake option, default OFF): Enables the Phase 6 `!$omp master` guards around the guarded `ftimer_core` entry points. This is limited master-thread-only protection, not full thread safety. The documented/supported build path is GNU Fortran (`gfortran`).
-- **`FTIMER_BUILD_SMOKE_TESTS`** (CMake option, default ON): Enables the current smoke-test baseline, including install/export consumer verification and the script-driven build-contract regression checks when their toolchain prerequisites are available.
+- **`FTIMER_USE_OPENMP`** (CMake option, default OFF): Enables limited `!$omp master` guards around the guarded `ftimer_core` entry points. This is master-thread-only protection, not full thread safety. The documented/supported build path is GNU Fortran (`gfortran`).
+- **`FTIMER_BUILD_SMOKE_TESTS`** (CMake option, default ON): Enables the smoke-test baseline, including install/export consumer verification and the script-driven build-contract regression checks when their toolchain prerequisites are available.
 - **`FTIMER_BUILD_TESTS`** (CMake option, default OFF): Enables the pFUnit-backed behavioral and MPI test suites.
 - **`CMAKE_INSTALL_PREFIX`**: Where `make install` places the library and module files.
 - **pFUnit**: Optional dependency for behavioral tests. Set `PFUNIT_DIR` explicitly when enabling `FTIMER_BUILD_TESTS`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,22 +17,22 @@ cmake --build build-bench --target ftimer_bench
 # Smoke-test-only build (includes install/export consumer verification)
 cmake -B build-smoke
 cmake --build build-smoke
-ctest --test-dir build-smoke --output-on-failure
+cmake -E chdir build-smoke ctest --output-on-failure
 
 # Serial build (documented path: GNU Fortran + matching pFUnit install)
 FC=gfortran cmake -B build -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build
-ctest --test-dir build --output-on-failure
+cmake -E chdir build ctest --output-on-failure
 
 # MPI build (documented path: MPI wrapper compiler)
 FC=mpifort cmake -B build-mpi -DFTIMER_USE_MPI=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build-mpi
-ctest --test-dir build-mpi --output-on-failure -L mpi
+cmake -E chdir build-mpi ctest --output-on-failure -L mpi
 
 # OpenMP guard build (currently supported with GNU Fortran)
 FC=gfortran cmake -B build-openmp -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build-openmp
-ctest --test-dir build-openmp --output-on-failure
+cmake -E chdir build-openmp ctest --output-on-failure
 
 # Lint / format check
 find src -name '*.F90' -exec fprettify --diff {} +

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,22 +17,22 @@ cmake --build build-bench --target ftimer_bench
 # Smoke-test-only build (includes install/export consumer verification)
 cmake -B build-smoke
 cmake --build build-smoke
-ctest --test-dir build-smoke --output-on-failure
+cmake -E chdir build-smoke ctest --output-on-failure
 
 # Serial build (documented path: GNU Fortran + matching pFUnit install)
 FC=gfortran cmake -B build -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build
-ctest --test-dir build --output-on-failure
+cmake -E chdir build ctest --output-on-failure
 
 # MPI build (documented path: MPI wrapper compiler)
 FC=mpifort cmake -B build-mpi -DFTIMER_USE_MPI=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build-mpi
-ctest --test-dir build-mpi --output-on-failure -L mpi
+cmake -E chdir build-mpi ctest --output-on-failure -L mpi
 
 # OpenMP guard build (currently supported with GNU Fortran)
 FC=gfortran cmake -B build-openmp -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build-openmp
-ctest --test-dir build-openmp --output-on-failure
+cmake -E chdir build-openmp ctest --output-on-failure
 
 # Lint / format check
 find src -name '*.F90' -exec fprettify --diff {} +

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```bash
 # Performance measurement harness (serial, no pFUnit required)
-cmake --fresh -B build-bench -DFTIMER_BUILD_BENCH=ON -DCMAKE_BUILD_TYPE=Release
+cmake -S . -B build-bench -DFTIMER_BUILD_BENCH=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build build-bench --target ftimer_bench
 ./build-bench/bench/ftimer_bench
 
@@ -48,6 +48,10 @@ make test       # build + run tests
 make clean      # remove build/
 make install    # install to CMAKE_INSTALL_PREFIX
 ```
+
+For a clean benchmark reconfigure, remove or use a separate `build-bench/`
+directory first. With CMake 3.24 or newer, `cmake --fresh` may be added to the
+configure command as a convenience for a clean reconfigure.
 
 Supported toolchain matrix:
 
@@ -128,13 +132,13 @@ The call stack state CHANGES between start and stop — this is the most common 
 
 ## Development Workflow
 
-Current `main` is in Phase 6. The shared types/clock foundation, core timer runtime, local summary/report formatting, procedural convenience wrappers, MPI-reduced structured summaries, sparse/union MPI descriptor summaries, and limited OpenMP master-thread guards are implemented.
+Current `main` contains the shared types/clock foundation, core timer runtime, local summary/report formatting, procedural convenience wrappers, MPI-reduced structured summaries, sparse/union MPI descriptor summaries, and limited OpenMP master-thread guards.
 
-During Phase 6, keep the library, examples, install package, smoke tests, and pFUnit suite buildable. Keep the diff phase-bounded: preserve procedural-wrapper parity with the OOP core unless a tracked issue explicitly defers parity, keep MPI summary behavior correct and explicit, preserve the limited master-thread-only OpenMP guard model, and keep current-state docs/examples honest. Do not pull fuller post-Phase-6 design work or broader OpenMP support forward.
+During release-readiness work, keep the library, examples, install package, smoke tests, and pFUnit suite buildable. Keep diffs issue-bounded: preserve procedural-wrapper parity with the OOP core unless a tracked issue explicitly defers parity, keep MPI summary behavior correct and explicit, preserve the limited master-thread-only OpenMP guard model, and keep current-state docs/examples honest. Do not pull broader deferred design work or fuller OpenMP support forward without a linked issue.
 
 Detailed repository operations and PR/review handling live in `docs/maintainer.md`. Use that file for GitHub workflow details; keep this file focused on coding/build/test behavior and the short mandatory PR summary below.
 
-**Phase 1 exception:** the types/clock foundation was compile-first work, not an early pFUnit phase. Starting in Phase 2, test-driven development is mandatory: write tests first, confirm they fail, then implement. All behavioral tests use the injectable mock clock for deterministic results — tests never sleep or depend on wall-clock timing.
+Historical note: the original types/clock foundation was compile-first work before pFUnit coverage existed. For current behavioral changes, test-driven development is mandatory: write tests first, confirm they fail, then implement. All behavioral tests use the injectable mock clock for deterministic results — tests never sleep or depend on wall-clock timing.
 
 ### Source-of-Truth Order
 
@@ -161,18 +165,18 @@ Read additional docs only when the task requires them:
 - `docs/semantics.md` — when runtime behavior or contract is changing or unclear
 - `README.md` — when user-facing behavior, examples, or docs may need updates
 - `docs/design.md` — for architectural or repository-structure questions
-- `docs/implementation-history.md` — for historical phase-plan context or landed roadmap history
-- `docs/maintainer.md` — for workflow routing; then load only the phase-specific doc you need:
+- `docs/implementation-history.md` — for historical roadmap context or landed implementation history
+- `docs/maintainer.md` — for workflow routing; then load only the workflow-specific doc you need:
   - `docs/workflows/pr-open.md` — PR opening and review labels
   - `docs/workflows/review-monitoring.md` — monitoring and fallback review
   - `docs/workflows/findings-disposition.md` — responding to findings and merge criteria
 
 Context budget:
 
-- Read each file once per phase unless it changed or ambiguity remains.
+- Read each file once per work item unless it changed or ambiguity remains.
 - After the initial discovery pass, switch to implementation mode.
 - Prefer diff-based validation late in the task over broad repo sweeps.
-- Batch progress updates by phase, not by file or micro-step.
+- Batch progress updates by work stage, not by file or micro-step.
 
 ### GitHub Tooling Policy
 
@@ -242,8 +246,8 @@ The native Codex trigger comments are intentionally posted as single-line `@code
 ## Configuration
 
 - **`FTIMER_USE_MPI`** (CMake option, default OFF): Enables MPI support. When ON, `MPI_Wtime()` is used as the clock source and `mpi_summary()` / `mpi_union_summary()` can populate cross-rank fields. Use MPI-enabled fTimer only after `MPI_Init` and before `MPI_Finalize`. The supported path is an MPI wrapper compiler such as `mpifort`; configure now fails early if the active compiler cannot compile a minimal `mpi_f08` probe against the discovered MPI toolchain. When OFF, `mpi_summary()` and `mpi_union_summary()` return `FTIMER_ERR_NOT_IMPLEMENTED` with empty MPI result objects; they do not fall back to local summaries.
-- **`FTIMER_USE_OPENMP`** (CMake option, default OFF): Enables the Phase 6 `!$omp master` guards around the guarded `ftimer_core` entry points. This is limited master-thread-only protection, not full thread safety. The documented/supported build path is GNU Fortran (`gfortran`).
-- **`FTIMER_BUILD_SMOKE_TESTS`** (CMake option, default ON): Enables the current smoke-test baseline, including install/export consumer verification and the script-driven build-contract regression checks when their toolchain prerequisites are available.
+- **`FTIMER_USE_OPENMP`** (CMake option, default OFF): Enables limited `!$omp master` guards around the guarded `ftimer_core` entry points. This is master-thread-only protection, not full thread safety. The documented/supported build path is GNU Fortran (`gfortran`).
+- **`FTIMER_BUILD_SMOKE_TESTS`** (CMake option, default ON): Enables the smoke-test baseline, including install/export consumer verification and the script-driven build-contract regression checks when their toolchain prerequisites are available.
 - **`FTIMER_BUILD_TESTS`** (CMake option, default OFF): Enables the pFUnit-backed behavioral and MPI test suites.
 - **`CMAKE_INSTALL_PREFIX`**: Where `make install` places the library and module files.
 - **pFUnit**: Optional dependency for behavioral tests. Set `PFUNIT_DIR` explicitly when enabling `FTIMER_BUILD_TESTS`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ The default local smoke path is:
 ```bash
 cmake -B build-smoke
 cmake --build build-smoke
-ctest --test-dir build-smoke --output-on-failure
+cmake -E chdir build-smoke ctest --output-on-failure
 ```
 
 Behavioral tests require pFUnit and a matching compiler/toolchain:
@@ -34,7 +34,7 @@ Behavioral tests require pFUnit and a matching compiler/toolchain:
 ```bash
 FC=gfortran cmake -B build -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build
-ctest --test-dir build --output-on-failure
+cmake -E chdir build ctest --output-on-failure
 ```
 
 MPI and OpenMP validation commands are listed in `AGENTS.md`, `README.md`, and

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ openmp:
 	cmake --build $(OPENMP_BUILD_DIR) -j$(NPROC)
 
 test: all
-	ctest --test-dir $(BUILD_DIR) --output-on-failure
+	cmake -E chdir $(BUILD_DIR) ctest --output-on-failure
 
 clean:
 	rm -rf $(BUILD_DIR) $(MPI_BUILD_DIR) $(OPENMP_BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -293,22 +293,22 @@ Minimum requirements:
 # Smoke-test path (includes install/export consumer verification)
 cmake -B build-smoke
 cmake --build build-smoke
-ctest --test-dir build-smoke --output-on-failure
+cmake -E chdir build-smoke ctest --output-on-failure
 
 # Serial build with pFUnit tests
 FC=gfortran cmake -B build -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build
-ctest --test-dir build --output-on-failure
+cmake -E chdir build ctest --output-on-failure
 
 # MPI build with pFUnit tests
 FC=mpifort cmake -B build-mpi -DFTIMER_USE_MPI=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build-mpi
-ctest --test-dir build-mpi --output-on-failure -L mpi
+cmake -E chdir build-mpi ctest --output-on-failure -L mpi
 
 # OpenMP build with pFUnit tests
 FC=gfortran cmake -B build-openmp -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build-openmp
-ctest --test-dir build-openmp --output-on-failure
+cmake -E chdir build-openmp ctest --output-on-failure
 
 # Convenience Makefile wrapper
 make

--- a/README.md
+++ b/README.md
@@ -358,10 +358,14 @@ Use a separate build directory for each compiler or mode. Reconfiguring the same
 The repository includes a standalone benchmark harness for measuring timer overhead and summary-generation cost:
 
 ```bash
-cmake --fresh -B build-bench -DFTIMER_BUILD_BENCH=ON -DCMAKE_BUILD_TYPE=Release
+cmake -S . -B build-bench -DFTIMER_BUILD_BENCH=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build build-bench --target ftimer_bench
 ./build-bench/bench/ftimer_bench
 ```
+
+For a clean benchmark reconfigure, remove or use a separate `build-bench/`
+directory first. With CMake 3.24 or newer, `cmake --fresh` may be added to the
+configure command as a convenience for a clean reconfigure.
 
 This is useful for before/after regression checks when changing hot-path timing behavior. Compare the name-based lookup-scaling rows across resident timer counts to confirm the mapped default path stays much flatter than the old linear-scan baseline, and compare the context-scaling rows across larger `C` values to see how one hot timer behaves when it is reused under many distinct parent stacks. The first-touch rows measure the remaining allocation/growth cost for newly discovered timer names and parent-stack contexts after setup has prebuilt labels and initialized independent timer objects. The long-name rows show the extra validation/hash cost for labels above the legacy threshold. The flat name-based/id-based rows still help judge whether the optional cached-id path is worth it for one especially hot loop.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -263,7 +263,7 @@ That means pFUnit-backed serial, MPI, and OpenMP test jobs are part of current C
 
 ## Maintainer Workflow
 
-Repository workflow guidance lives in [`docs/maintainer.md`](maintainer.md) and the phase-specific docs under [`docs/workflows/`](workflows/). The standard flow for scoped work on current `main` is:
+Repository workflow guidance lives in [`docs/maintainer.md`](maintainer.md) and the workflow-specific docs under [`docs/workflows/`](workflows/). The standard flow for scoped work on current `main` is:
 
 1. Create or link the GitHub issue first.
 2. Create a feature branch from updated local `main`.

--- a/docs/implementation-history.md
+++ b/docs/implementation-history.md
@@ -1,6 +1,6 @@
 # Implementation History
 
-The in-repo design reference for implementation is [docs/design.md](docs/design.md).
+The in-repo design reference for implementation is [design.md](design.md).
 
 This file preserves the historical phase roadmap that led to the current implementation on `main`. It is not the authoritative statement of what ships today. For the current user-facing contract, use `README.md`, `docs/semantics.md`, and the implementation in `src/`.
 

--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -1,8 +1,8 @@
-> **When to read this:** When you need repository workflow guidance: issue setup, PR opening, review monitoring, findings disposition. Do not load this during routine coding tasks unless the task is in an issue/PR/review/disposition phase.
+> **When to read this:** When you need repository workflow guidance: issue setup, PR opening, review monitoring, findings disposition. Do not load this during routine coding tasks unless the task is in an issue/PR/review/disposition stage.
 
 # Maintainer Guide
 
-This document routes to phase-specific workflow docs. Shared coding-agent context lives in `CLAUDE.md` / `AGENTS.md`; this file is for maintainer workflow, not implementation guidance.
+This document routes to workflow-specific docs. Shared coding-agent context lives in `CLAUDE.md` / `AGENTS.md`; this file is for maintainer workflow, not implementation guidance.
 
 ## Repository Bootstrap
 
@@ -62,9 +62,9 @@ download identity and cache identity together when updating pinned tools.
   - Let GitHub CI exercise the verified pFUnit download path and the pinned
     lint install path before treating a release-boundary PR as ready.
 
-## Workflow Phases
+## Workflow Docs
 
-Use the workflow docs below for phase-specific operating procedures. Load only the phase you need.
+Use the workflow docs below for workflow-specific operating procedures. Load only the workflow you need.
 
 - [`docs/workflows/pr-open.md`](workflows/pr-open.md) — opening a PR,
   applying review labels, review prompt library

--- a/docs/release.md
+++ b/docs/release.md
@@ -61,27 +61,27 @@ Reference commands:
 ```bash
 cmake -B build-smoke
 cmake --build build-smoke
-ctest --test-dir build-smoke --output-on-failure
+cmake -E chdir build-smoke ctest --output-on-failure
 
 FC=gfortran cmake -B build \
   -DFTIMER_BUILD_TESTS=ON \
   -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build
-ctest --test-dir build --output-on-failure
+cmake -E chdir build ctest --output-on-failure
 
 FC=mpifort cmake -B build-mpi \
   -DFTIMER_USE_MPI=ON \
   -DFTIMER_BUILD_TESTS=ON \
   -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build-mpi
-ctest --test-dir build-mpi --output-on-failure -L mpi
+cmake -E chdir build-mpi ctest --output-on-failure -L mpi
 
 FC=gfortran cmake -B build-openmp \
   -DFTIMER_USE_OPENMP=ON \
   -DFTIMER_BUILD_TESTS=ON \
   -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build-openmp
-ctest --test-dir build-openmp --output-on-failure
+cmake -E chdir build-openmp ctest --output-on-failure
 
 cmake -S . -B build-bench \
   -DFTIMER_BUILD_BENCH=ON \

--- a/docs/release.md
+++ b/docs/release.md
@@ -83,7 +83,7 @@ FC=gfortran cmake -B build-openmp \
 cmake --build build-openmp
 ctest --test-dir build-openmp --output-on-failure
 
-cmake --fresh -B build-bench \
+cmake -S . -B build-bench \
   -DFTIMER_BUILD_BENCH=ON \
   -DCMAKE_BUILD_TYPE=Release
 cmake --build build-bench --target ftimer_bench
@@ -94,6 +94,10 @@ git diff --check
 
 If a toolchain is unavailable locally, record the skip reason in the release-prep
 PR and rely on the corresponding required CI job before tagging.
+
+For a clean benchmark reconfigure, remove or use a separate `build-bench/`
+directory first. With CMake 3.24 or newer, `cmake --fresh` may be added to the
+benchmark configure command as a convenience for a clean reconfigure.
 
 ## Artifact Policy
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -320,7 +320,7 @@ enforcement should pass `ierr` and check it.
 - OpenMP guard behavior is enabled only when the library is built with `FTIMER_USE_OPENMP=ON`
 - The CMake option is the source-level switch; global OpenMP compiler flags alone do not enable these guards when `FTIMER_USE_OPENMP=OFF`
 - This is a narrow master-thread-only carve-out for bracketing a parallel region as a whole; it is not general hybrid MPI+OpenMP timing support
-- The implemented model is master-thread-only timing; this phase does not make `fTimer` generally thread-safe
+- The implemented model is master-thread-only timing; the current implementation does not make `fTimer` generally thread-safe
 - Inside OpenMP parallel regions, the guarded `ftimer_core` timer operations run only on the master thread
 - Non-master calls to those guarded core timer operations become no-ops instead of mutating shared timer state
 - Suppressed non-master calls are skipped before normal validation, emit no stderr warning, and leave any caller-provided `ierr` unchanged

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -4,7 +4,7 @@
 
 This document describes the current runtime contract on `main`.
 
-Current `main` implements the Phase 2 core timer behavior, Phase 3 local summary/reporting behavior, Phase 4 procedural wrappers, Phase 5 MPI structured summaries, and the Phase 6 OpenMP guard behavior: stack-based start/stop timing, context-sensitive accounting, strict/warn/repair mismatch handling, `lookup`, `reset`, the procedural `ftimer_scope` scoped guard, the `ierr` vs stderr error contract, `get_summary()`, `print_summary()`, `write_summary()`, `write_summary_csv()`, `mpi_summary()`, `mpi_union_summary()` sparse descriptor-union summaries, `print_mpi_summary()`, `write_mpi_summary()`, `write_mpi_summary_csv()`, `print_mpi_union_summary()`, `write_mpi_union_summary()`, self-time computation, callback suppression during repair, descriptor-hash MPI preflight, globally meaningful MPI min/avg/max summary fields on every participating rank, and limited master-thread-only OpenMP guards in `ftimer_core` when built with `FTIMER_USE_OPENMP=ON`. In non-MPI builds, `mpi_summary()` and `mpi_union_summary()` return `FTIMER_ERR_NOT_IMPLEMENTED` with empty MPI summary results; MPI report APIs, including sparse union reports, return `FTIMER_ERR_NOT_IMPLEMENTED` without emitting report output.
+Current `main` implements stack-based start/stop timing, context-sensitive accounting, strict/warn/repair mismatch handling, `lookup`, `reset`, the procedural `ftimer_scope` scoped guard, the `ierr` vs stderr error contract, `get_summary()`, `print_summary()`, `write_summary()`, `write_summary_csv()`, `mpi_summary()`, `mpi_union_summary()` sparse descriptor-union summaries, `print_mpi_summary()`, `write_mpi_summary()`, `write_mpi_summary_csv()`, `print_mpi_union_summary()`, `write_mpi_union_summary()`, self-time computation, callback suppression during repair, descriptor-hash MPI preflight, globally meaningful MPI min/avg/max summary fields on every participating rank, and limited master-thread-only OpenMP guards in `ftimer_core` when built with `FTIMER_USE_OPENMP=ON`. In non-MPI builds, `mpi_summary()` and `mpi_union_summary()` return `FTIMER_ERR_NOT_IMPLEMENTED` with empty MPI summary results; MPI report APIs, including sparse union reports, return `FTIMER_ERR_NOT_IMPLEMENTED` without emitting report output.
 
 This contract is strongest for disciplined serial and pure-MPI wall-clock timing. The OpenMP path is a narrow master-thread-only carve-out for bracketing a parallel region as a whole, not a general hybrid-thread timing contract. Likewise, `on_event` is a lightweight intra-run hook, not a stable external-profiler integration API.
 
@@ -94,7 +94,22 @@ wait on asynchronous offload work, or insert MPI barriers around timer regions.
 - `ierr` present: set code, no stderr
 - `ierr` absent: emit a diagnostic to stderr
 - Validation and lifecycle errors follow a warn-and-return contract: they leave timer state unchanged unless the caller explicitly selected a repair-capable mismatch mode
-- Error codes and their meanings
+
+### Public Status And Error Codes
+
+These constants are public from `ftimer_types` and are the canonical status values returned through optional `ierr` arguments.
+
+| Constant | Code | Meaning |
+| --- | --- | --- |
+| `FTIMER_SUCCESS` | `0` | Operation completed successfully. |
+| `FTIMER_ERR_NOT_INIT` | `1` | The timer instance or default procedural instance has not been initialized for the requested operation. |
+| `FTIMER_ERR_NOT_IMPLEMENTED` | `2` | The requested API is unavailable in this build, such as MPI summary/report APIs when `FTIMER_USE_MPI=OFF`. |
+| `FTIMER_ERR_UNKNOWN` | `3` | Generic failure for an unsupported or unexpected condition that does not have a more specific public code. |
+| `FTIMER_ERR_ACTIVE` | `4` | Active timers or already-recorded timing data prevent the requested lifecycle or configuration operation. |
+| `FTIMER_ERR_MISMATCH` | `5` | Strict nesting, cached-id, or scoped-guard ownership checks detected a start/stop mismatch. |
+| `FTIMER_ERR_MPI_INCON` | `6` | MPI participants have inconsistent timer descriptor trees for a strict MPI summary/report operation. |
+| `FTIMER_ERR_IO` | `7` | File, unit, or CSV append validation failed. |
+| `FTIMER_ERR_INVALID_NAME` | `8` | A timer name failed public name validation. |
 
 ## Compile-Out / No-Op Instrumentation Pattern
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -105,7 +105,7 @@ These constants are public from `ftimer_types` and are the canonical status valu
 | `FTIMER_ERR_NOT_INIT` | `1` | The timer instance or default procedural instance has not been initialized for the requested operation. |
 | `FTIMER_ERR_NOT_IMPLEMENTED` | `2` | The requested API is unavailable in this build, such as MPI summary/report APIs when `FTIMER_USE_MPI=OFF`. |
 | `FTIMER_ERR_UNKNOWN` | `3` | Generic failure for an unsupported or unexpected condition that does not have a more specific public code. |
-| `FTIMER_ERR_ACTIVE` | `4` | Active timers or already-recorded timing data prevent the requested lifecycle or configuration operation. |
+| `FTIMER_ERR_ACTIVE` | `4` | An active timer, active scoped guard, or already-recorded timing data prevents the requested lifecycle, configuration, or report operation. |
 | `FTIMER_ERR_MISMATCH` | `5` | Strict nesting, cached-id, or scoped-guard ownership checks detected a start/stop mismatch. |
 | `FTIMER_ERR_MPI_INCON` | `6` | MPI participants have inconsistent timer descriptor trees for a strict MPI summary/report operation. |
 | `FTIMER_ERR_IO` | `7` | File, unit, or CSV append validation failed. |

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,12 @@ add_test(NAME ftimer_public_symbol_allowlist
     -P ${CMAKE_CURRENT_SOURCE_DIR}/check_public_symbol_allowlist.cmake
 )
 
+add_test(NAME ftimer_release_docs_contract
+  COMMAND ${CMAKE_COMMAND}
+    -DREPO_ROOT=${CMAKE_SOURCE_DIR}
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/check_release_docs_contract.cmake
+)
+
 if(FTIMER_BUILD_SMOKE_TESTS)
   if(DEFINED ENV{TMPDIR} AND NOT "$ENV{TMPDIR}" STREQUAL "")
     set(ftimer_absolute_includedir_base "$ENV{TMPDIR}")

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -153,10 +153,20 @@ foreach(benchmark_doc IN LISTS benchmark_docs)
   endif()
 endforeach()
 
+foreach(command_doc IN LISTS benchmark_docs)
+  file(READ "${REPO_ROOT}/${command_doc}" command_doc_text)
+  if(command_doc_text MATCHES "ctest[ \t]+--test-dir")
+    message(FATAL_ERROR
+      "${command_doc} must use CTest 3.16-compatible test commands instead of ctest --test-dir."
+    )
+  endif()
+endforeach()
+
 set(current_contract_docs
   AGENTS.md
   CLAUDE.md
   README.md
+  docs/design.md
   docs/semantics.md
 )
 
@@ -164,6 +174,7 @@ set(forbidden_current_contract_phrases
   "Current `main` is in Phase"
   "Current `main` implements the Phase"
   "During Phase"
+  "phase-specific docs"
   "this phase does not make"
 )
 

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -165,23 +165,18 @@ foreach(benchmark_doc IN LISTS benchmark_docs)
 
   file(STRINGS "${REPO_ROOT}/${benchmark_doc}" benchmark_doc_lines)
   foreach(benchmark_doc_line IN LISTS benchmark_doc_lines)
-    if(benchmark_doc_line MATCHES "^[ \t]*cmake[ \t]+--fresh")
+    if(benchmark_doc_line MATCHES "(^|[ \t])cmake[ \t]+--fresh" AND
+       NOT benchmark_doc_line MATCHES "CMake[ \t]+3\\.24")
       message(FATAL_ERROR
-        "${benchmark_doc} must not use cmake --fresh as a primary benchmark command."
+        "${benchmark_doc} must mark cmake --fresh as a CMake 3.24+ convenience on the same line and must not use it as a primary benchmark command."
       )
     endif()
   endforeach()
-
-  string(FIND "${benchmark_doc_text}" "CMake 3.24" cmake_fresh_note_found)
-  if(cmake_fresh_note_found EQUAL -1 AND benchmark_doc_text MATCHES "cmake[ \t]+--fresh")
-    message(FATAL_ERROR
-      "${benchmark_doc} must mark cmake --fresh as a CMake 3.24+ convenience when mentioning it."
-    )
-  endif()
 endforeach()
 
 set(release_command_paths
   ${benchmark_docs}
+  CONTRIBUTING.md
   Makefile
 )
 

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -165,7 +165,7 @@ foreach(benchmark_doc IN LISTS benchmark_docs)
 
   file(STRINGS "${REPO_ROOT}/${benchmark_doc}" benchmark_doc_lines)
   foreach(benchmark_doc_line IN LISTS benchmark_doc_lines)
-    if(benchmark_doc_line MATCHES "(^|[ \t])cmake([ \t]+[^`[:space:]]+)*[ \t]+--fresh($|[ \t])" AND
+    if(benchmark_doc_line MATCHES "(^|[ \t`])cmake([ \t]+[^`[:space:]]+)*[ \t]+--fresh($|[ \t`])" AND
        NOT benchmark_doc_line MATCHES "CMake[ \t]+3\\.24")
       message(FATAL_ERROR
         "${benchmark_doc} must mark cmake --fresh as a CMake 3.24+ convenience on the same line and must not use it as a primary benchmark command."

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -1,0 +1,108 @@
+cmake_minimum_required(VERSION 3.16)
+
+set(required_paths
+  AGENTS.md
+  CLAUDE.md
+  README.md
+  docs/design.md
+  docs/implementation-history.md
+  docs/release.md
+  docs/semantics.md
+  CONTRIBUTING.md
+  SECURITY.md
+  SUPPORT.md
+)
+
+foreach(required_path IN LISTS required_paths)
+  if(NOT EXISTS "${REPO_ROOT}/${required_path}")
+    message(FATAL_ERROR "Release-facing documentation path is missing: ${required_path}")
+  endif()
+endforeach()
+
+foreach(markdown_path IN LISTS required_paths)
+  set(markdown_abs "${REPO_ROOT}/${markdown_path}")
+  get_filename_component(markdown_dir "${markdown_abs}" DIRECTORY)
+  file(STRINGS "${markdown_abs}" markdown_lines)
+
+  foreach(markdown_line IN LISTS markdown_lines)
+    set(remaining_line "${markdown_line}")
+    while(remaining_line MATCHES "\\[[^]]*\\]\\(([^)]+)\\)")
+      set(link_target "${CMAKE_MATCH_1}")
+      string(REGEX REPLACE "^[ \t]*<([^>]+)>.*$" "\\1" link_target "${link_target}")
+      string(REGEX REPLACE "^[ \t]*([^ \t\"']+).*$" "\\1" link_target "${link_target}")
+      string(REGEX REPLACE "#.*$" "" link_path "${link_target}")
+
+      if(link_path STREQUAL "" OR
+         link_path MATCHES "^[A-Za-z][A-Za-z0-9+.-]*:" OR
+         link_path MATCHES "^#")
+        string(REGEX REPLACE "^[^[]*\\[[^]]*\\]\\([^)]+\\)" "" remaining_line "${remaining_line}")
+        continue()
+      endif()
+
+      get_filename_component(link_abs "${markdown_dir}/${link_path}" ABSOLUTE)
+      if(NOT EXISTS "${link_abs}")
+        message(FATAL_ERROR
+          "${markdown_path} links to '${link_target}', but '${link_abs}' does not exist."
+        )
+      endif()
+
+      string(REGEX REPLACE "^[^[]*\\[[^]]*\\]\\([^)]+\\)" "" remaining_line "${remaining_line}")
+    endwhile()
+  endforeach()
+endforeach()
+
+file(READ "${REPO_ROOT}/src/ftimer_types.F90" ftimer_types_text)
+file(STRINGS "${REPO_ROOT}/src/ftimer_types.F90" ftimer_types_lines)
+file(READ "${REPO_ROOT}/docs/semantics.md" semantics_text)
+
+set(public_status_constants)
+foreach(source_line IN LISTS ftimer_types_lines)
+  string(REGEX REPLACE "!.*$" "" source_line_no_comment "${source_line}")
+  string(STRIP "${source_line_no_comment}" source_line_no_comment)
+  if(NOT source_line_no_comment MATCHES "^[Pp][Uu][Bb][Ll][Ii][Cc][ \t]*::")
+    continue()
+  endif()
+
+  string(REGEX REPLACE "^[Pp][Uu][Bb][Ll][Ii][Cc][ \t]*::[ \t]*" "" public_list "${source_line_no_comment}")
+  string(REPLACE "," ";" public_symbols "${public_list}")
+  foreach(public_symbol IN LISTS public_symbols)
+    string(STRIP "${public_symbol}" public_symbol)
+    if(public_symbol MATCHES "^FTIMER_(SUCCESS|ERR_[A-Za-z0-9_]+)$")
+      list(APPEND public_status_constants "${public_symbol}")
+    endif()
+  endforeach()
+endforeach()
+
+list(SORT public_status_constants)
+
+foreach(status_constant IN LISTS public_status_constants)
+  if(NOT ftimer_types_text MATCHES "integer,[^\n]*parameter[^\n]*::[ \t]*${status_constant}[ \t]*=[ \t]*([0-9]+)")
+    message(FATAL_ERROR "Could not find parameter value for ${status_constant}.")
+  endif()
+  set(status_value "${CMAKE_MATCH_1}")
+  string(FIND
+    "${semantics_text}"
+    "| `${status_constant}` | `${status_value}` |"
+    documented_status
+  )
+  if(documented_status EQUAL -1)
+    message(FATAL_ERROR
+      "docs/semantics.md must list public status/error constant ${status_constant} with code ${status_value}."
+    )
+  endif()
+endforeach()
+
+file(READ "${REPO_ROOT}/README.md" readme_text)
+string(FIND "${readme_text}" "cmake -S . -B build-bench" benchmark_configure_found)
+if(benchmark_configure_found EQUAL -1)
+  message(FATAL_ERROR
+    "README.md benchmark instructions must include a CMake 3.16-compatible configure command."
+  )
+endif()
+
+string(FIND "${readme_text}" "CMake 3.24" cmake_fresh_note_found)
+if(cmake_fresh_note_found EQUAL -1 AND readme_text MATCHES "cmake[ \t]+--fresh")
+  message(FATAL_ERROR
+    "README.md must mark cmake --fresh as a CMake 3.24+ convenience when mentioning it."
+  )
+endif()

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -53,7 +53,7 @@ endforeach()
 
 file(READ "${REPO_ROOT}/src/ftimer_types.F90" ftimer_types_text)
 file(STRINGS "${REPO_ROOT}/src/ftimer_types.F90" ftimer_types_lines)
-file(READ "${REPO_ROOT}/docs/semantics.md" semantics_text)
+file(STRINGS "${REPO_ROOT}/docs/semantics.md" semantics_lines)
 
 set(public_status_constants)
 foreach(source_line IN LISTS ftimer_types_lines)
@@ -73,36 +73,108 @@ foreach(source_line IN LISTS ftimer_types_lines)
   endforeach()
 endforeach()
 
+if(NOT public_status_constants)
+  message(FATAL_ERROR "No public fTimer status/error constants were extracted from src/ftimer_types.F90.")
+endif()
+
 list(SORT public_status_constants)
 
+set(public_status_entries)
 foreach(status_constant IN LISTS public_status_constants)
   if(NOT ftimer_types_text MATCHES "integer,[^\n]*parameter[^\n]*::[ \t]*${status_constant}[ \t]*=[ \t]*([0-9]+)")
     message(FATAL_ERROR "Could not find parameter value for ${status_constant}.")
   endif()
   set(status_value "${CMAKE_MATCH_1}")
-  string(FIND
-    "${semantics_text}"
-    "| `${status_constant}` | `${status_value}` |"
-    documented_status
+  list(APPEND public_status_entries "${status_constant}|${status_value}")
+endforeach()
+
+set(documented_status_entries)
+foreach(semantics_line IN LISTS semantics_lines)
+  string(STRIP "${semantics_line}" semantics_line)
+  if(semantics_line MATCHES "^\\|[ \t]*`(FTIMER_(SUCCESS|ERR_[A-Za-z0-9_]+))`[ \t]*\\|[ \t]*`([0-9]+)`[ \t]*\\|")
+    list(APPEND documented_status_entries "${CMAKE_MATCH_1}|${CMAKE_MATCH_3}")
+  endif()
+endforeach()
+
+if(NOT documented_status_entries)
+  message(FATAL_ERROR "docs/semantics.md must include a public fTimer status/error-code table.")
+endif()
+
+list(SORT public_status_entries)
+list(SORT documented_status_entries)
+
+set(missing_status_entries)
+foreach(public_status_entry IN LISTS public_status_entries)
+  list(FIND documented_status_entries "${public_status_entry}" found_index)
+  if(found_index EQUAL -1)
+    list(APPEND missing_status_entries "${public_status_entry}")
+  endif()
+endforeach()
+
+set(extra_status_entries)
+foreach(documented_status_entry IN LISTS documented_status_entries)
+  list(FIND public_status_entries "${documented_status_entry}" found_index)
+  if(found_index EQUAL -1)
+    list(APPEND extra_status_entries "${documented_status_entry}")
+  endif()
+endforeach()
+
+if(missing_status_entries OR extra_status_entries)
+  string(REPLACE ";" "\n  " missing_text "${missing_status_entries}")
+  string(REPLACE ";" "\n  " extra_text "${extra_status_entries}")
+  message(FATAL_ERROR
+    "docs/semantics.md public status/error-code table must exactly match src/ftimer_types.F90.\n"
+    "Missing or wrong in docs:\n  ${missing_text}\n"
+    "Extra or stale in docs:\n  ${extra_text}"
   )
-  if(documented_status EQUAL -1)
+endif()
+
+set(benchmark_docs
+  README.md
+  AGENTS.md
+  CLAUDE.md
+  docs/release.md
+)
+
+foreach(benchmark_doc IN LISTS benchmark_docs)
+  file(READ "${REPO_ROOT}/${benchmark_doc}" benchmark_doc_text)
+  string(FIND "${benchmark_doc_text}" "cmake -S . -B build-bench" benchmark_configure_found)
+  if(benchmark_configure_found EQUAL -1)
     message(FATAL_ERROR
-      "docs/semantics.md must list public status/error constant ${status_constant} with code ${status_value}."
+      "${benchmark_doc} benchmark instructions must include a CMake 3.16-compatible configure command."
+    )
+  endif()
+
+  string(FIND "${benchmark_doc_text}" "CMake 3.24" cmake_fresh_note_found)
+  if(cmake_fresh_note_found EQUAL -1 AND benchmark_doc_text MATCHES "cmake[ \t]+--fresh")
+    message(FATAL_ERROR
+      "${benchmark_doc} must mark cmake --fresh as a CMake 3.24+ convenience when mentioning it."
     )
   endif()
 endforeach()
 
-file(READ "${REPO_ROOT}/README.md" readme_text)
-string(FIND "${readme_text}" "cmake -S . -B build-bench" benchmark_configure_found)
-if(benchmark_configure_found EQUAL -1)
-  message(FATAL_ERROR
-    "README.md benchmark instructions must include a CMake 3.16-compatible configure command."
-  )
-endif()
+set(current_contract_docs
+  AGENTS.md
+  CLAUDE.md
+  README.md
+  docs/semantics.md
+)
 
-string(FIND "${readme_text}" "CMake 3.24" cmake_fresh_note_found)
-if(cmake_fresh_note_found EQUAL -1 AND readme_text MATCHES "cmake[ \t]+--fresh")
-  message(FATAL_ERROR
-    "README.md must mark cmake --fresh as a CMake 3.24+ convenience when mentioning it."
-  )
-endif()
+set(forbidden_current_contract_phrases
+  "Current `main` is in Phase"
+  "Current `main` implements the Phase"
+  "During Phase"
+  "this phase does not make"
+)
+
+foreach(current_contract_doc IN LISTS current_contract_docs)
+  file(READ "${REPO_ROOT}/${current_contract_doc}" current_contract_doc_text)
+  foreach(forbidden_phrase IN LISTS forbidden_current_contract_phrases)
+    string(FIND "${current_contract_doc_text}" "${forbidden_phrase}" forbidden_index)
+    if(NOT forbidden_index EQUAL -1)
+      message(FATAL_ERROR
+        "${current_contract_doc} contains stale phase-oriented current-state wording: ${forbidden_phrase}"
+      )
+    endif()
+  endforeach()
+endforeach()

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -165,7 +165,7 @@ foreach(benchmark_doc IN LISTS benchmark_docs)
 
   file(STRINGS "${REPO_ROOT}/${benchmark_doc}" benchmark_doc_lines)
   foreach(benchmark_doc_line IN LISTS benchmark_doc_lines)
-    if(benchmark_doc_line MATCHES "(^|[ \t])cmake[ \t]+--fresh" AND
+    if(benchmark_doc_line MATCHES "(^|[ \t])cmake([ \t]+[^`[:space:]]+)*[ \t]+--fresh($|[ \t])" AND
        NOT benchmark_doc_line MATCHES "CMake[ \t]+3\\.24")
       message(FATAL_ERROR
         "${benchmark_doc} must mark cmake --fresh as a CMake 3.24+ convenience on the same line and must not use it as a primary benchmark command."

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -6,6 +6,7 @@ set(required_paths
   README.md
   docs/design.md
   docs/implementation-history.md
+  docs/maintainer.md
   docs/release.md
   docs/semantics.md
   CONTRIBUTING.md
@@ -138,12 +139,38 @@ set(benchmark_docs
 
 foreach(benchmark_doc IN LISTS benchmark_docs)
   file(READ "${REPO_ROOT}/${benchmark_doc}" benchmark_doc_text)
-  string(FIND "${benchmark_doc_text}" "cmake -S . -B build-bench" benchmark_configure_found)
-  if(benchmark_configure_found EQUAL -1)
+  string(REPLACE "\r\n" "\n" benchmark_doc_normalized "${benchmark_doc_text}")
+  string(REGEX REPLACE "\\\\[ \t]*\n[ \t]*" " " benchmark_doc_flat "${benchmark_doc_normalized}")
+  string(REGEX REPLACE "[ \t\n]+" " " benchmark_doc_flat "${benchmark_doc_flat}")
+
+  if(NOT benchmark_doc_flat MATCHES "cmake -S \\. -B build-bench -DFTIMER_BUILD_BENCH=ON -DCMAKE_BUILD_TYPE=Release")
     message(FATAL_ERROR
-      "${benchmark_doc} benchmark instructions must include a CMake 3.16-compatible configure command."
+      "${benchmark_doc} benchmark instructions must include the complete CMake 3.16-compatible configure command."
     )
   endif()
+
+  string(FIND "${benchmark_doc_text}" "cmake --build build-bench --target ftimer_bench" benchmark_build_found)
+  if(benchmark_build_found EQUAL -1)
+    message(FATAL_ERROR
+      "${benchmark_doc} benchmark instructions must include the ftimer_bench build target command."
+    )
+  endif()
+
+  string(FIND "${benchmark_doc_text}" "./build-bench/bench/ftimer_bench" benchmark_run_found)
+  if(benchmark_run_found EQUAL -1)
+    message(FATAL_ERROR
+      "${benchmark_doc} benchmark instructions must include the ftimer_bench executable command."
+    )
+  endif()
+
+  file(STRINGS "${REPO_ROOT}/${benchmark_doc}" benchmark_doc_lines)
+  foreach(benchmark_doc_line IN LISTS benchmark_doc_lines)
+    if(benchmark_doc_line MATCHES "^[ \t]*cmake[ \t]+--fresh")
+      message(FATAL_ERROR
+        "${benchmark_doc} must not use cmake --fresh as a primary benchmark command."
+      )
+    endif()
+  endforeach()
 
   string(FIND "${benchmark_doc_text}" "CMake 3.24" cmake_fresh_note_found)
   if(cmake_fresh_note_found EQUAL -1 AND benchmark_doc_text MATCHES "cmake[ \t]+--fresh")
@@ -153,11 +180,16 @@ foreach(benchmark_doc IN LISTS benchmark_docs)
   endif()
 endforeach()
 
-foreach(command_doc IN LISTS benchmark_docs)
-  file(READ "${REPO_ROOT}/${command_doc}" command_doc_text)
-  if(command_doc_text MATCHES "ctest[ \t]+--test-dir")
+set(release_command_paths
+  ${benchmark_docs}
+  Makefile
+)
+
+foreach(command_path IN LISTS release_command_paths)
+  file(READ "${REPO_ROOT}/${command_path}" command_text)
+  if(command_text MATCHES "ctest[ \t]+--test-dir")
     message(FATAL_ERROR
-      "${command_doc} must use CTest 3.16-compatible test commands instead of ctest --test-dir."
+      "${command_path} must use CTest 3.16-compatible test commands instead of ctest --test-dir."
     )
   endif()
 endforeach()
@@ -167,6 +199,7 @@ set(current_contract_docs
   CLAUDE.md
   README.md
   docs/design.md
+  docs/maintainer.md
   docs/semantics.md
 )
 
@@ -174,7 +207,9 @@ set(forbidden_current_contract_phrases
   "Current `main` is in Phase"
   "Current `main` implements the Phase"
   "During Phase"
-  "phase-specific docs"
+  "Phase 6"
+  "phase-specific"
+  "Load only the phase you need"
   "this phase does not make"
 )
 

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -208,7 +208,12 @@ set(forbidden_current_contract_phrases
   "Current `main` implements the Phase"
   "During Phase"
   "Phase 6"
+  "Phase 1 exception"
+  "Starting in Phase 2"
+  "phase-bounded"
   "phase-specific"
+  "per phase"
+  "by phase"
   "Load only the phase you need"
   "this phase does not make"
 )


### PR DESCRIPTION
Closes #215.

## Summary

- Makes `AGENTS.md` and `CLAUDE.md` current-state oriented by removing stale numbered-phase framing and the benchmark-only `cmake --fresh` default.
- Adds a canonical public status/error-code table to `docs/semantics.md` covering `FTIMER_SUCCESS` and every public `FTIMER_ERR*` constant from `ftimer_types`.
- Fixes the broken `docs/implementation-history.md` link to `design.md`.
- Updates benchmark instructions to use a CMake 3.16-compatible configure command and marks `cmake --fresh` as a CMake 3.24+ convenience.
- Adds `ftimer_release_docs_contract`, a lightweight docs check for selected release-facing local links, documented status/error codes, and benchmark configure guidance.

## Validation

- Test-first check: `ctest --test-dir build-smoke --output-on-failure -R ftimer_release_docs_contract` failed before the docs edits on the broken implementation-history link.
- `cmake -B build-smoke`
- `cmake --build build-smoke`
- `ctest --test-dir build-smoke --output-on-failure` (16/16)
- `git diff --check`
- `git diff --cached --check`

## Coordination

Kept scope out of #213 metadata trust-boundary docs/tests and #214 benchmark scale-row/output work. This PR changes benchmark instructions only for CMake minimum compatibility.