### PR TITLE
[codex] Optimize report formatter assembly

### DIFF
--- a/src/ftimer_core_summary_bindings.F90
+++ b/src/ftimer_core_summary_bindings.F90
@@ -15,6 +15,12 @@ submodule(ftimer_core) ftimer_core_summary_bindings
 
    character(len=*), parameter :: FTIMER_CSV_FORMAT_VERSION = '2'
    character(len=*), parameter :: FTIMER_MPI_UNION_CSV_FORMAT_VERSION = '1'
+   integer, parameter :: default_report_buffer_capacity = 1024
+
+   type :: report_buffer_t
+      character(len=:), allocatable :: chars
+      integer :: used = 0
+   end type report_buffer_t
 
 contains
 
@@ -891,26 +897,28 @@ contains
       character(len=:), allocatable, intent(out) :: text
       type(ftimer_metadata_t), intent(in), optional :: metadata(:)
       logical, intent(in), optional :: include_header
+      type(report_buffer_t) :: buffer
       integer :: i
       logical :: emit_header
 
-      text = ''
+      call init_report_buffer(buffer, default_report_buffer_capacity)
       emit_header = .true.
       if (present(include_header)) emit_header = include_header
 
-      if (emit_header) call append_summary_csv_header(text)
-      call append_local_summary_csv_record(text, summary)
+      if (emit_header) call append_summary_csv_header(buffer)
+      call append_local_summary_csv_record(buffer, summary)
 
       if (present(metadata)) then
          do i = 1, size(metadata)
             if (metadata_key_len(metadata(i)) <= 0) cycle
-            call append_metadata_csv_record(text, 'local', metadata(i))
+            call append_metadata_csv_record(buffer, 'local', metadata(i))
          end do
       end if
 
       do i = 1, summary%num_entries
-         call append_local_entry_csv_record(text, summary%entries(i))
+         call append_local_entry_csv_record(buffer, summary%entries(i))
       end do
+      call finish_report_buffer(buffer, text)
    end subroutine format_summary_csv
 
    subroutine format_mpi_summary_csv(summary, text, metadata, include_header)
@@ -918,26 +926,28 @@ contains
       character(len=:), allocatable, intent(out) :: text
       type(ftimer_metadata_t), intent(in), optional :: metadata(:)
       logical, intent(in), optional :: include_header
+      type(report_buffer_t) :: buffer
       integer :: i
       logical :: emit_header
 
-      text = ''
+      call init_report_buffer(buffer, default_report_buffer_capacity)
       emit_header = .true.
       if (present(include_header)) emit_header = include_header
 
-      if (emit_header) call append_summary_csv_header(text)
-      call append_mpi_summary_csv_record(text, summary)
+      if (emit_header) call append_summary_csv_header(buffer)
+      call append_mpi_summary_csv_record(buffer, summary)
 
       if (present(metadata)) then
          do i = 1, size(metadata)
             if (metadata_key_len(metadata(i)) <= 0) cycle
-            call append_metadata_csv_record(text, 'mpi', metadata(i))
+            call append_metadata_csv_record(buffer, 'mpi', metadata(i))
          end do
       end if
 
       do i = 1, summary%num_entries
-         call append_mpi_entry_csv_record(text, summary%entries(i))
+         call append_mpi_entry_csv_record(buffer, summary%entries(i))
       end do
+      call finish_report_buffer(buffer, text)
    end subroutine format_mpi_summary_csv
 
    subroutine format_mpi_union_summary_csv(summary, text, metadata, include_header)
@@ -945,44 +955,46 @@ contains
       character(len=:), allocatable, intent(out) :: text
       type(ftimer_metadata_t), intent(in), optional :: metadata(:)
       logical, intent(in), optional :: include_header
+      type(report_buffer_t) :: buffer
       integer :: i
       logical :: emit_header
 
-      text = ''
+      call init_report_buffer(buffer, default_report_buffer_capacity)
       emit_header = .true.
       if (present(include_header)) emit_header = include_header
 
-      if (emit_header) call append_mpi_union_summary_csv_header(text)
-      call append_mpi_union_summary_csv_record(text, summary)
+      if (emit_header) call append_mpi_union_summary_csv_header(buffer)
+      call append_mpi_union_summary_csv_record(buffer, summary)
 
       if (present(metadata)) then
          do i = 1, size(metadata)
             if (metadata_key_len(metadata(i)) <= 0) cycle
-            call append_mpi_union_metadata_csv_record(text, metadata(i))
+            call append_mpi_union_metadata_csv_record(buffer, metadata(i))
          end do
       end if
 
       do i = 1, summary%num_entries
-         call append_mpi_union_entry_csv_record(text, summary, summary%entries(i))
+         call append_mpi_union_entry_csv_record(buffer, summary, summary%entries(i))
       end do
+      call finish_report_buffer(buffer, text)
    end subroutine format_mpi_union_summary_csv
 
-   subroutine append_summary_csv_header(text)
-      character(len=:), allocatable, intent(inout) :: text
+   subroutine append_summary_csv_header(buffer)
+      type(report_buffer_t), intent(inout) :: buffer
 
-      call append_line(text, csv_header_line())
+      call append_line(buffer, csv_header_line())
    end subroutine append_summary_csv_header
 
-   subroutine append_mpi_union_summary_csv_header(text)
-      character(len=:), allocatable, intent(inout) :: text
+   subroutine append_mpi_union_summary_csv_header(buffer)
+      type(report_buffer_t), intent(inout) :: buffer
 
-      call append_line(text, mpi_union_csv_header_line())
+      call append_line(buffer, mpi_union_csv_header_line())
    end subroutine append_mpi_union_summary_csv_header
 
-   subroutine append_local_summary_csv_record(text, summary)
-      character(len=:), allocatable, intent(inout) :: text
+   subroutine append_local_summary_csv_record(buffer, summary)
+      type(report_buffer_t), intent(inout) :: buffer
       type(ftimer_summary_t), intent(in) :: summary
-      character(len=:), allocatable :: row
+      type(report_buffer_t) :: row
 
       call begin_csv_row(row, 'local', 'summary')
       call append_empty_csv_fields(row, 2)
@@ -992,13 +1004,13 @@ contains
       call append_csv_field(row, integer_csv_text(summary%num_entries))
       call append_csv_field(row, logical_csv_text(summary%has_active_timers))
       call append_empty_csv_fields(row, 33)
-      call append_line(text, row)
+      call append_row(buffer, row)
    end subroutine append_local_summary_csv_record
 
-   subroutine append_mpi_summary_csv_record(text, summary)
-      character(len=:), allocatable, intent(inout) :: text
+   subroutine append_mpi_summary_csv_record(buffer, summary)
+      type(report_buffer_t), intent(inout) :: buffer
       type(ftimer_mpi_summary_t), intent(in) :: summary
-      character(len=:), allocatable :: row
+      type(report_buffer_t) :: row
 
       call begin_csv_row(row, 'mpi', 'summary')
       call append_empty_csv_fields(row, 5)
@@ -1012,13 +1024,13 @@ contains
       call append_csv_field(row, integer_csv_text(summary%max_total_time_rank))
       call append_csv_field(row, real_csv_text(summary%total_time_imbalance))
       call append_empty_csv_fields(row, 26)
-      call append_line(text, row)
+      call append_row(buffer, row)
    end subroutine append_mpi_summary_csv_record
 
-   subroutine append_mpi_union_summary_csv_record(text, summary)
-      character(len=:), allocatable, intent(inout) :: text
+   subroutine append_mpi_union_summary_csv_record(buffer, summary)
+      type(report_buffer_t), intent(inout) :: buffer
       type(ftimer_mpi_union_summary_t), intent(in) :: summary
-      character(len=:), allocatable :: row
+      type(report_buffer_t) :: row
 
       call begin_mpi_union_csv_row(row, 'summary')
       call append_empty_csv_fields(row, 2)
@@ -1031,38 +1043,38 @@ contains
       call append_csv_field(row, integer_csv_text(summary%max_total_time_rank))
       call append_csv_field(row, real_csv_text(summary%total_time_imbalance))
       call append_empty_csv_fields(row, 22)
-      call append_line(text, row)
+      call append_row(buffer, row)
    end subroutine append_mpi_union_summary_csv_record
 
-   subroutine append_metadata_csv_record(text, summary_kind, item)
-      character(len=:), allocatable, intent(inout) :: text
+   subroutine append_metadata_csv_record(buffer, summary_kind, item)
+      type(report_buffer_t), intent(inout) :: buffer
       character(len=*), intent(in) :: summary_kind
       type(ftimer_metadata_t), intent(in) :: item
-      character(len=:), allocatable :: row
+      type(report_buffer_t) :: row
 
       call begin_csv_row(row, summary_kind, 'metadata')
       call append_csv_field(row, metadata_key_text(item))
       call append_csv_field(row, metadata_value_text(item))
       call append_empty_csv_fields(row, 38)
-      call append_line(text, row)
+      call append_row(buffer, row)
    end subroutine append_metadata_csv_record
 
-   subroutine append_mpi_union_metadata_csv_record(text, item)
-      character(len=:), allocatable, intent(inout) :: text
+   subroutine append_mpi_union_metadata_csv_record(buffer, item)
+      type(report_buffer_t), intent(inout) :: buffer
       type(ftimer_metadata_t), intent(in) :: item
-      character(len=:), allocatable :: row
+      type(report_buffer_t) :: row
 
       call begin_mpi_union_csv_row(row, 'metadata')
       call append_csv_field(row, metadata_key_text(item))
       call append_csv_field(row, metadata_value_text(item))
       call append_empty_csv_fields(row, 30)
-      call append_line(text, row)
+      call append_row(buffer, row)
    end subroutine append_mpi_union_metadata_csv_record
 
-   subroutine append_local_entry_csv_record(text, entry)
-      character(len=:), allocatable, intent(inout) :: text
+   subroutine append_local_entry_csv_record(buffer, entry)
+      type(report_buffer_t), intent(inout) :: buffer
       type(ftimer_summary_entry_t), intent(in) :: entry
-      character(len=:), allocatable :: row
+      type(report_buffer_t) :: row
 
       call begin_csv_row(row, 'local', 'entry')
       call append_empty_csv_fields(row, 14)
@@ -1077,13 +1089,13 @@ contains
       call append_csv_field(row, real_csv_text(entry%pct_time))
       call append_csv_field(row, logical_csv_text(entry%is_active))
       call append_empty_csv_fields(row, 16)
-      call append_line(text, row)
+      call append_row(buffer, row)
    end subroutine append_local_entry_csv_record
 
-   subroutine append_mpi_entry_csv_record(text, entry)
-      character(len=:), allocatable, intent(inout) :: text
+   subroutine append_mpi_entry_csv_record(buffer, entry)
+      type(report_buffer_t), intent(inout) :: buffer
       type(ftimer_mpi_summary_entry_t), intent(in) :: entry
-      character(len=:), allocatable :: row
+      type(report_buffer_t) :: row
 
       call begin_csv_row(row, 'mpi', 'entry')
       call append_empty_csv_fields(row, 14)
@@ -1108,14 +1120,14 @@ contains
       call append_csv_field(row, real_csv_text(entry%min_pct_time))
       call append_csv_field(row, real_csv_text(entry%avg_pct_time))
       call append_csv_field(row, real_csv_text(entry%max_pct_time))
-      call append_line(text, row)
+      call append_row(buffer, row)
    end subroutine append_mpi_entry_csv_record
 
-   subroutine append_mpi_union_entry_csv_record(text, summary, entry)
-      character(len=:), allocatable, intent(inout) :: text
+   subroutine append_mpi_union_entry_csv_record(buffer, summary, entry)
+      type(report_buffer_t), intent(inout) :: buffer
       type(ftimer_mpi_union_summary_t), intent(in) :: summary
       type(ftimer_mpi_union_summary_entry_t), intent(in) :: entry
-      character(len=:), allocatable :: row
+      type(report_buffer_t) :: row
       integer :: missing_rank_count
 
       missing_rank_count = summary%num_ranks - entry%participating_rank_count
@@ -1144,32 +1156,32 @@ contains
       call append_csv_field(row, real_csv_text(entry%min_pct_time))
       call append_csv_field(row, real_csv_text(entry%avg_pct_time))
       call append_csv_field(row, real_csv_text(entry%max_pct_time))
-      call append_line(text, row)
+      call append_row(buffer, row)
    end subroutine append_mpi_union_entry_csv_record
 
    subroutine begin_csv_row(row, summary_kind, record_type)
-      character(len=:), allocatable, intent(out) :: row
+      type(report_buffer_t), intent(out) :: row
       character(len=*), intent(in) :: summary_kind
       character(len=*), intent(in) :: record_type
 
-      row = ''
+      call init_report_buffer(row, 512)
       call append_csv_field(row, FTIMER_CSV_FORMAT_VERSION)
       call append_csv_field(row, summary_kind)
       call append_csv_field(row, record_type)
    end subroutine begin_csv_row
 
    subroutine begin_mpi_union_csv_row(row, record_type)
-      character(len=:), allocatable, intent(out) :: row
+      type(report_buffer_t), intent(out) :: row
       character(len=*), intent(in) :: record_type
 
-      row = ''
+      call init_report_buffer(row, 512)
       call append_csv_field(row, FTIMER_MPI_UNION_CSV_FORMAT_VERSION)
       call append_csv_field(row, 'mpi_union')
       call append_csv_field(row, record_type)
    end subroutine begin_mpi_union_csv_row
 
    subroutine append_empty_csv_fields(row, count)
-      character(len=:), allocatable, intent(inout) :: row
+      type(report_buffer_t), intent(inout) :: row
       integer, intent(in) :: count
       integer :: i
 
@@ -1179,28 +1191,21 @@ contains
    end subroutine append_empty_csv_fields
 
    subroutine append_csv_field(row, value)
-      character(len=:), allocatable, intent(inout) :: row
+      type(report_buffer_t), intent(inout) :: row
       character(len=*), intent(in) :: value
-
-      if (len(row) > 0) row = row//','
-      row = row//quoted_csv_field(value)
-   end subroutine append_csv_field
-
-   function quoted_csv_field(value) result(field)
-      character(len=*), intent(in) :: value
-      character(len=:), allocatable :: field
       integer :: i
 
-      field = '"'
+      if (row%used > 0) call append_report_text(row, ',')
+      call append_report_text(row, '"')
       do i = 1, len_trim(value)
          if (value(i:i) == '"') then
-            field = field//'""'
+            call append_report_text(row, '""')
          else
-            field = field//value(i:i)
+            call append_report_text(row, value(i:i))
          end if
       end do
-      field = field//'"'
-   end function quoted_csv_field
+      call append_report_text(row, '"')
+   end subroutine append_csv_field
 
    function integer_csv_text(value) result(text)
       integer, intent(in) :: value
@@ -1240,12 +1245,86 @@ contains
       end if
    end function logical_csv_text
 
-   subroutine append_line(text, line)
-      character(len=:), allocatable, intent(inout) :: text
+   subroutine append_line(buffer, line)
+      type(report_buffer_t), intent(inout) :: buffer
       character(len=*), intent(in) :: line
 
-      text = text//trim(line)//new_line('a')
+      call append_report_text(buffer, trim(line))
+      call append_report_text(buffer, new_line('a'))
    end subroutine append_line
+
+   subroutine append_row(buffer, row)
+      type(report_buffer_t), intent(inout) :: buffer
+      type(report_buffer_t), intent(in) :: row
+
+      if (row%used > 0) call append_report_text(buffer, row%chars(1:row%used))
+      call append_report_text(buffer, new_line('a'))
+   end subroutine append_row
+
+   subroutine init_report_buffer(buffer, initial_capacity)
+      type(report_buffer_t), intent(out) :: buffer
+      integer, intent(in) :: initial_capacity
+      integer :: capacity
+
+      capacity = max(1, initial_capacity)
+      allocate (character(len=capacity) :: buffer%chars)
+      buffer%used = 0
+   end subroutine init_report_buffer
+
+   subroutine append_report_text(buffer, fragment)
+      type(report_buffer_t), intent(inout) :: buffer
+      character(len=*), intent(in) :: fragment
+      integer :: fragment_len
+      integer :: next_used
+
+      fragment_len = len(fragment)
+      if (fragment_len <= 0) return
+
+      next_used = buffer%used + fragment_len
+      call ensure_report_capacity(buffer, next_used)
+      buffer%chars(buffer%used + 1:next_used) = fragment
+      buffer%used = next_used
+   end subroutine append_report_text
+
+   subroutine finish_report_buffer(buffer, text)
+      type(report_buffer_t), intent(in) :: buffer
+      character(len=:), allocatable, intent(out) :: text
+
+      if (buffer%used > 0) then
+         text = buffer%chars(1:buffer%used)
+      else
+         text = ''
+      end if
+   end subroutine finish_report_buffer
+
+   subroutine ensure_report_capacity(buffer, required_capacity)
+      type(report_buffer_t), intent(inout) :: buffer
+      integer, intent(in) :: required_capacity
+      character(len=:), allocatable :: grown
+      integer :: current_capacity
+      integer :: new_capacity
+
+      if (allocated(buffer%chars)) then
+         current_capacity = len(buffer%chars)
+      else
+         current_capacity = 0
+      end if
+      if (current_capacity >= required_capacity) return
+
+      new_capacity = max(default_report_buffer_capacity, current_capacity)
+      if (new_capacity <= 0) new_capacity = default_report_buffer_capacity
+      do while (new_capacity < required_capacity)
+         if (new_capacity > huge(new_capacity)/2) then
+            new_capacity = required_capacity
+         else
+            new_capacity = new_capacity*2
+         end if
+      end do
+
+      allocate (character(len=new_capacity) :: grown)
+      if (buffer%used > 0) grown(1:buffer%used) = buffer%chars(1:buffer%used)
+      call move_alloc(grown, buffer%chars)
+   end subroutine ensure_report_capacity
 
    function summary_entry_name(entry) result(name)
       type(ftimer_summary_entry_t), intent(in) :: entry

--- a/src/ftimer_summary.F90
+++ b/src/ftimer_summary.F90
@@ -13,6 +13,13 @@ module ftimer_summary
    public :: format_mpi_union_summary
    public :: ftimer_summary_status
 
+   integer, parameter :: default_text_buffer_capacity = 1024
+
+   type :: text_buffer_t
+      character(len=:), allocatable :: chars
+      integer :: used = 0
+   end type text_buffer_t
+
 contains
 
    subroutine build_summary(summary, segments, init_wtime, init_date, end_time, end_date)
@@ -43,6 +50,7 @@ contains
       type(ftimer_summary_t), intent(in) :: summary
       character(len=:), allocatable, intent(out) :: text
       type(ftimer_metadata_t), intent(in), optional :: metadata(:)
+      type(text_buffer_t) :: buffer
       character(len=64) :: fmt
       character(len=:), allocatable :: header_suffix
       character(len=:), allocatable :: line
@@ -55,7 +63,7 @@ contains
       integer :: name_width
       logical :: has_active_entries
 
-      text = ''
+      call init_text_buffer(buffer, default_text_buffer_capacity)
       has_active_entries = summary_has_active_entries(summary)
       key_width = metadata_key_width(metadata)
       key_width = max(key_width, len('Active timers'))
@@ -66,13 +74,13 @@ contains
 
       write (line, '(f0.6)') summary%total_time
       call set_padded_text(padded, 'Total time (s)', key_width)
-      call append_line(text, padded(1:key_width)//' : '//trim(line))
+      call append_line(buffer, padded(1:key_width)//' : '//trim(line))
 
       if (has_active_entries) then
          active_value = 'yes'
          call set_padded_text(padded, 'Active timers', key_width)
-         call append_line(text, padded(1:key_width)//' : '//trim(active_value))
-         call append_line(text, 'Snapshot note : active timers are included through the snapshot timestamp.')
+         call append_line(buffer, padded(1:key_width)//' : '//trim(active_value))
+         call append_line(buffer, 'Snapshot note : active timers are included through the snapshot timestamp.')
       end if
 
       if (present(metadata)) then
@@ -80,11 +88,11 @@ contains
             if (metadata_key_len(metadata(i)) <= 0) cycle
             if (has_active_entries .and. metadata_key_is_reserved(metadata_key_text(metadata(i)))) cycle
             call set_padded_text(padded, metadata_key_display_text(metadata(i)), key_width)
-            call append_line(text, padded(1:key_width)//' : '//metadata_value_display_text(metadata(i)))
+            call append_line(buffer, padded(1:key_width)//' : '//metadata_value_display_text(metadata(i)))
          end do
       end if
 
-      call append_line(text, '')
+      call append_line(buffer, '')
       call set_padded_text(padded, 'Timer name', name_width)
       line = repeat(' ', len(line))
       header_suffix = summary_header_suffix(has_active_entries, call_width)
@@ -93,8 +101,8 @@ contains
       else
          line(1:name_width + len(header_suffix)) = padded(1:name_width)//header_suffix
       end if
-      call append_line(text, trim(line))
-      call append_line(text, repeat('-', len_trim(line)))
+      call append_line(buffer, trim(line))
+      call append_line(buffer, repeat('-', len_trim(line)))
 
       if (has_active_entries) then
          write (fmt, '("(a",i0,",2x,f12.6,2x,f12.6,2x,i",i0,",2x,f8.2,2x,a)")') &
@@ -104,7 +112,7 @@ contains
             write (line, fmt) padded(1:name_width), summary%entries(i)%inclusive_time, &
                summary%entries(i)%self_time, summary%entries(i)%call_count, summary%entries(i)%pct_time, &
                active_text(summary%entries(i)%is_active)
-            call append_line(text, trim(line))
+            call append_line(buffer, trim(line))
          end do
       else
          write (fmt, '("(a",i0,",2x,f12.6,2x,f12.6,2x,i",i0,",2x,f8.2)")') &
@@ -113,15 +121,17 @@ contains
             call set_padded_text(padded, display_name(summary%entries(i)), name_width)
             write (line, fmt) padded(1:name_width), summary%entries(i)%inclusive_time, &
                summary%entries(i)%self_time, summary%entries(i)%call_count, summary%entries(i)%pct_time
-            call append_line(text, trim(line))
+            call append_line(buffer, trim(line))
          end do
       end if
+      call finish_text_buffer(buffer, text)
    end subroutine format_summary
 
    subroutine format_mpi_summary(summary, text, metadata)
       type(ftimer_mpi_summary_t), intent(in) :: summary
       character(len=:), allocatable, intent(out) :: text
       type(ftimer_metadata_t), intent(in), optional :: metadata(:)
+      type(text_buffer_t) :: buffer
       character(len=128) :: fmt
       character(len=:), allocatable :: header_suffix
       character(len=64) :: value_line
@@ -133,7 +143,7 @@ contains
       integer :: line_width
       integer :: name_width
 
-      text = ''
+      call init_text_buffer(buffer, default_text_buffer_capacity)
       key_width = metadata_key_width(metadata)
       key_width = max(key_width, len('MPI ranks'))
       key_width = max(key_width, len('Min total time (s)'))
@@ -145,47 +155,47 @@ contains
 
       call set_padded_text(padded, 'MPI ranks', key_width)
       write (value_line, '(i0)') summary%num_ranks
-      call append_line(text, padded(1:key_width)//' : '//trim(value_line))
+      call append_line(buffer, padded(1:key_width)//' : '//trim(value_line))
 
       write (value_line, '(f0.6)') summary%min_total_time
       call set_padded_text(padded, 'Min total time (s)', key_width)
-      call append_line(text, padded(1:key_width)//' : '//trim(value_line))
+      call append_line(buffer, padded(1:key_width)//' : '//trim(value_line))
 
       write (value_line, '(f0.6)') summary%avg_total_time
       call set_padded_text(padded, 'Avg total time (s)', key_width)
-      call append_line(text, padded(1:key_width)//' : '//trim(value_line))
+      call append_line(buffer, padded(1:key_width)//' : '//trim(value_line))
 
       write (value_line, '(f0.6)') summary%max_total_time
       call set_padded_text(padded, 'Max total time (s)', key_width)
-      call append_line(text, padded(1:key_width)//' : '//trim(value_line))
+      call append_line(buffer, padded(1:key_width)//' : '//trim(value_line))
 
       write (value_line, '(i0)') summary%min_total_time_rank
       call set_padded_text(padded, 'Min total rank', key_width)
-      call append_line(text, padded(1:key_width)//' : '//trim(value_line))
+      call append_line(buffer, padded(1:key_width)//' : '//trim(value_line))
 
       write (value_line, '(i0)') summary%max_total_time_rank
       call set_padded_text(padded, 'Max total rank', key_width)
-      call append_line(text, padded(1:key_width)//' : '//trim(value_line))
+      call append_line(buffer, padded(1:key_width)//' : '//trim(value_line))
 
       write (value_line, '(f0.6)') summary%total_time_imbalance
       call set_padded_text(padded, 'Total imbalance', key_width)
-      call append_line(text, padded(1:key_width)//' : '//trim(value_line))
+      call append_line(buffer, padded(1:key_width)//' : '//trim(value_line))
 
       if (present(metadata)) then
          do i = 1, size(metadata)
             if (metadata_key_len(metadata(i)) <= 0) cycle
             call set_padded_text(padded, metadata_key_display_text(metadata(i)), key_width)
-            call append_line(text, padded(1:key_width)//' : '//metadata_value_display_text(metadata(i)))
+            call append_line(buffer, padded(1:key_width)//' : '//metadata_value_display_text(metadata(i)))
          end do
       end if
 
-      call append_line(text, '')
-      call append_line(text, 'Report note: per-entry table is an abbreviated view of ftimer_mpi_summary_t; '// &
+      call append_line(buffer, '')
+      call append_line(buffer, 'Report note: per-entry table is an abbreviated view of ftimer_mpi_summary_t; '// &
                        'use mpi_summary() for all min/max self, call, percent, and tree fields.')
-      call append_line(text, 'Avg % is the arithmetic mean of rank-local % Total values, '// &
+      call append_line(buffer, 'Avg % is the arithmetic mean of rank-local % Total values, '// &
                        'not 100*Avg Incl/Avg total time.')
 
-      call append_line(text, '')
+      call append_line(buffer, '')
       name_width = mpi_summary_name_width(summary)
       avg_call_width = mpi_avg_call_count_width(summary)
       line_width = mpi_summary_line_width(name_width, avg_call_width)
@@ -195,8 +205,8 @@ contains
       line = repeat(' ', len(line))
       header_suffix = mpi_header_suffix(avg_call_width)
       line(1:name_width + len(header_suffix)) = padded(1:name_width)//header_suffix
-      call append_line(text, trim(line))
-      call append_line(text, repeat('-', len_trim(line)))
+      call append_line(buffer, trim(line))
+      call append_line(buffer, repeat('-', len_trim(line)))
 
       write (fmt, '("(a",i0,",2x,f12.6,2x,i8,2x,f12.6,2x,f12.6,2x,i8,2x,f6.3,2x,f12.6,2x,f",i0,".3,2x,f8.2)")') &
          name_width, avg_call_width
@@ -207,14 +217,16 @@ contains
             summary%entries(i)%max_inclusive_time, summary%entries(i)%max_inclusive_time_rank, &
             summary%entries(i)%inclusive_imbalance, summary%entries(i)%avg_self_time, &
             summary%entries(i)%avg_call_count, summary%entries(i)%avg_pct_time
-         call append_line(text, trim(line))
+         call append_line(buffer, trim(line))
       end do
+      call finish_text_buffer(buffer, text)
    end subroutine format_mpi_summary
 
    subroutine format_mpi_union_summary(summary, text, metadata)
       type(ftimer_mpi_union_summary_t), intent(in) :: summary
       character(len=:), allocatable, intent(out) :: text
       type(ftimer_metadata_t), intent(in), optional :: metadata(:)
+      type(text_buffer_t) :: buffer
       character(len=128) :: fmt
       character(len=:), allocatable :: header_suffix
       character(len=64) :: value_line
@@ -227,8 +239,8 @@ contains
       integer :: missing_rank_count
       integer :: name_width
 
-      text = ''
-      call append_line(text, 'Sparse MPI union summary')
+      call init_text_buffer(buffer, default_text_buffer_capacity)
+      call append_line(buffer, 'Sparse MPI union summary')
 
       key_width = metadata_key_width(metadata)
       key_width = max(key_width, len('MPI ranks'))
@@ -241,49 +253,49 @@ contains
 
       call set_padded_text(padded, 'MPI ranks', key_width)
       write (value_line, '(i0)') summary%num_ranks
-      call append_line(text, padded(1:key_width)//' : '//trim(value_line))
+      call append_line(buffer, padded(1:key_width)//' : '//trim(value_line))
 
       write (value_line, '(f0.6)') summary%min_total_time
       call set_padded_text(padded, 'Min total time (s)', key_width)
-      call append_line(text, padded(1:key_width)//' : '//trim(value_line))
+      call append_line(buffer, padded(1:key_width)//' : '//trim(value_line))
 
       write (value_line, '(f0.6)') summary%avg_total_time
       call set_padded_text(padded, 'Avg total time (s)', key_width)
-      call append_line(text, padded(1:key_width)//' : '//trim(value_line))
+      call append_line(buffer, padded(1:key_width)//' : '//trim(value_line))
 
       write (value_line, '(f0.6)') summary%max_total_time
       call set_padded_text(padded, 'Max total time (s)', key_width)
-      call append_line(text, padded(1:key_width)//' : '//trim(value_line))
+      call append_line(buffer, padded(1:key_width)//' : '//trim(value_line))
 
       write (value_line, '(i0)') summary%min_total_time_rank
       call set_padded_text(padded, 'Min total rank', key_width)
-      call append_line(text, padded(1:key_width)//' : '//trim(value_line))
+      call append_line(buffer, padded(1:key_width)//' : '//trim(value_line))
 
       write (value_line, '(i0)') summary%max_total_time_rank
       call set_padded_text(padded, 'Max total rank', key_width)
-      call append_line(text, padded(1:key_width)//' : '//trim(value_line))
+      call append_line(buffer, padded(1:key_width)//' : '//trim(value_line))
 
       write (value_line, '(f0.6)') summary%total_time_imbalance
       call set_padded_text(padded, 'Total imbalance', key_width)
-      call append_line(text, padded(1:key_width)//' : '//trim(value_line))
+      call append_line(buffer, padded(1:key_width)//' : '//trim(value_line))
 
       if (present(metadata)) then
          do i = 1, size(metadata)
             if (metadata_key_len(metadata(i)) <= 0) cycle
             call set_padded_text(padded, metadata_key_display_text(metadata(i)), key_width)
-            call append_line(text, padded(1:key_width)//' : '//metadata_value_display_text(metadata(i)))
+            call append_line(buffer, padded(1:key_width)//' : '//metadata_value_display_text(metadata(i)))
          end do
       end if
 
-      call append_line(text, '')
-      call append_line(text, 'Report note: sparse entry min/avg/max fields are over participating ranks only; '// &
+      call append_line(buffer, '')
+      call append_line(buffer, 'Report note: sparse entry min/avg/max fields are over participating ranks only; '// &
                        'missing ranks are not zero-filled.')
-      call append_line(text, 'Missing ranks = MPI ranks - Participating; absent ranks do not contribute '// &
+      call append_line(buffer, 'Missing ranks = MPI ranks - Participating; absent ranks do not contribute '// &
                        'zero-call or zero-time samples.')
-      call append_line(text, 'Avg % is the arithmetic mean of participating rank-local % Total values, '// &
+      call append_line(buffer, 'Avg % is the arithmetic mean of participating rank-local % Total values, '// &
                        'not 100*Avg Incl/Avg total time.')
 
-      call append_line(text, '')
+      call append_line(buffer, '')
       name_width = mpi_union_summary_name_width(summary)
       avg_call_width = mpi_union_avg_call_count_width(summary)
       line_width = mpi_union_summary_line_width(name_width, avg_call_width)
@@ -293,8 +305,8 @@ contains
       line = repeat(' ', len(line))
       header_suffix = mpi_union_header_suffix(avg_call_width)
       line(1:name_width + len(header_suffix)) = padded(1:name_width)//header_suffix
-      call append_line(text, trim(line))
-      call append_line(text, repeat('-', len_trim(line)))
+      call append_line(buffer, trim(line))
+      call append_line(buffer, repeat('-', len_trim(line)))
 
       write (fmt, '("(a",i0,",2x,i13,2x,i7,2x,f12.6,2x,i8,2x,f12.6,2x,f12.6,2x,i8,2x,f6.3,2x,f12.6,2x,f",i0,".3,2x,f8.2)")') &
          name_width, avg_call_width
@@ -306,8 +318,9 @@ contains
             summary%entries(i)%avg_inclusive_time, summary%entries(i)%max_inclusive_time, &
             summary%entries(i)%max_inclusive_time_rank, summary%entries(i)%inclusive_imbalance, &
             summary%entries(i)%avg_self_time, summary%entries(i)%avg_call_count, summary%entries(i)%avg_pct_time
-         call append_line(text, trim(line))
+         call append_line(buffer, trim(line))
       end do
+      call finish_text_buffer(buffer, text)
    end subroutine format_mpi_union_summary
 
    function ftimer_summary_status(summary) result(status)
@@ -317,12 +330,78 @@ contains
       status = summary%num_entries
    end function ftimer_summary_status
 
-   subroutine append_line(text, line)
-      character(len=:), allocatable, intent(inout) :: text
+   subroutine append_line(buffer, line)
+      type(text_buffer_t), intent(inout) :: buffer
       character(len=*), intent(in) :: line
 
-      text = text//trim(line)//new_line('a')
+      call append_text(buffer, trim(line))
+      call append_text(buffer, new_line('a'))
    end subroutine append_line
+
+   subroutine init_text_buffer(buffer, initial_capacity)
+      type(text_buffer_t), intent(out) :: buffer
+      integer, intent(in) :: initial_capacity
+      integer :: capacity
+
+      capacity = max(1, initial_capacity)
+      allocate (character(len=capacity) :: buffer%chars)
+      buffer%used = 0
+   end subroutine init_text_buffer
+
+   subroutine append_text(buffer, fragment)
+      type(text_buffer_t), intent(inout) :: buffer
+      character(len=*), intent(in) :: fragment
+      integer :: fragment_len
+      integer :: next_used
+
+      fragment_len = len(fragment)
+      if (fragment_len <= 0) return
+
+      next_used = buffer%used + fragment_len
+      call ensure_text_capacity(buffer, next_used)
+      buffer%chars(buffer%used + 1:next_used) = fragment
+      buffer%used = next_used
+   end subroutine append_text
+
+   subroutine finish_text_buffer(buffer, text)
+      type(text_buffer_t), intent(in) :: buffer
+      character(len=:), allocatable, intent(out) :: text
+
+      if (buffer%used > 0) then
+         text = buffer%chars(1:buffer%used)
+      else
+         text = ''
+      end if
+   end subroutine finish_text_buffer
+
+   subroutine ensure_text_capacity(buffer, required_capacity)
+      type(text_buffer_t), intent(inout) :: buffer
+      integer, intent(in) :: required_capacity
+      character(len=:), allocatable :: grown
+      integer :: current_capacity
+      integer :: new_capacity
+
+      if (allocated(buffer%chars)) then
+         current_capacity = len(buffer%chars)
+      else
+         current_capacity = 0
+      end if
+      if (current_capacity >= required_capacity) return
+
+      new_capacity = max(default_text_buffer_capacity, current_capacity)
+      if (new_capacity <= 0) new_capacity = default_text_buffer_capacity
+      do while (new_capacity < required_capacity)
+         if (new_capacity > huge(new_capacity)/2) then
+            new_capacity = required_capacity
+         else
+            new_capacity = new_capacity*2
+         end if
+      end do
+
+      allocate (character(len=new_capacity) :: grown)
+      if (buffer%used > 0) grown(1:buffer%used) = buffer%chars(1:buffer%used)
+      call move_alloc(grown, buffer%chars)
+   end subroutine ensure_text_capacity
 
    subroutine clear_summary(summary)
       type(ftimer_summary_t), intent(out) :: summary
@@ -1078,24 +1157,25 @@ contains
       character(len=*), intent(in) :: raw_text
       character(len=*), intent(in) :: blank_text
       character(len=:), allocatable :: escaped
+      type(text_buffer_t) :: buffer
       integer :: i
       integer :: seq_len
       integer :: visible_len
       logical :: leading_space
 
-      escaped = ''
       visible_len = len_trim(raw_text)
       if (visible_len <= 0) then
          escaped = blank_text
          return
       end if
 
+      call init_text_buffer(buffer, max(default_text_buffer_capacity, visible_len))
       leading_space = .true.
 
       i = 1
       do while (i <= visible_len)
          if (leading_space .and. (raw_text(i:i) == ' ')) then
-            escaped = escaped//'\x20'
+            call append_text(buffer, '\x20')
             i = i + 1
             cycle
          end if
@@ -1104,17 +1184,18 @@ contains
          seq_len = valid_utf8_sequence_len(raw_text, i, visible_len)
          if (seq_len > 0) then
             if (is_utf8_encoded_c1_control(raw_text, i, seq_len)) then
-               call append_escaped_bytes(escaped, raw_text(i:i + seq_len - 1))
+               call append_escaped_bytes(buffer, raw_text(i:i + seq_len - 1))
             else
-               escaped = escaped//raw_text(i:i + seq_len - 1)
+               call append_text(buffer, raw_text(i:i + seq_len - 1))
             end if
             i = i + seq_len
             cycle
          end if
 
-         call append_escaped_char(escaped, raw_text(i:i))
+         call append_escaped_char(buffer, raw_text(i:i))
          i = i + 1
       end do
+      call finish_text_buffer(buffer, escaped)
    end function escaped_report_text
 
    integer function valid_utf8_sequence_len(text, start, visible_len) result(seq_len)
@@ -1200,40 +1281,40 @@ contains
       is_control = (b1 == 194) .and. (b2 >= 128) .and. (b2 <= 159)
    end function is_utf8_encoded_c1_control
 
-   subroutine append_escaped_bytes(text, bytes)
-      character(len=:), allocatable, intent(inout) :: text
+   subroutine append_escaped_bytes(buffer, bytes)
+      type(text_buffer_t), intent(inout) :: buffer
       character(len=*), intent(in) :: bytes
       integer :: i
 
       do i = 1, len(bytes)
-         call append_hex_escape(text, iachar(bytes(i:i)))
+         call append_hex_escape(buffer, iachar(bytes(i:i)))
       end do
    end subroutine append_escaped_bytes
 
-   subroutine append_escaped_char(text, ch)
-      character(len=:), allocatable, intent(inout) :: text
+   subroutine append_escaped_char(buffer, ch)
+      type(text_buffer_t), intent(inout) :: buffer
       character(len=1), intent(in) :: ch
       integer :: code
 
       code = iachar(ch)
       select case (code)
       case (9)
-         text = text//'\t'
+         call append_text(buffer, '\t')
       case (10)
-         text = text//'\n'
+         call append_text(buffer, '\n')
       case (13)
-         text = text//'\r'
+         call append_text(buffer, '\r')
       case (92)
-         text = text//'\\'
+         call append_text(buffer, '\\')
       case (0:8, 11:12, 14:31, 127:159)
-         call append_hex_escape(text, code)
+         call append_hex_escape(buffer, code)
       case default
-         text = text//ch
+         call append_text(buffer, ch)
       end select
    end subroutine append_escaped_char
 
-   subroutine append_hex_escape(text, code)
-      character(len=:), allocatable, intent(inout) :: text
+   subroutine append_hex_escape(buffer, code)
+      type(text_buffer_t), intent(inout) :: buffer
       integer, intent(in) :: code
       character(len=*), parameter :: hex_digits = '0123456789ABCDEF'
       integer :: high_nibble
@@ -1241,7 +1322,8 @@ contains
 
       high_nibble = code/16
       low_nibble = mod(code, 16)
-      text = text//'\x'//hex_digits(high_nibble + 1:high_nibble + 1)//hex_digits(low_nibble + 1:low_nibble + 1)
+      call append_text(buffer, '\x'//hex_digits(high_nibble + 1:high_nibble + 1)// &
+                       hex_digits(low_nibble + 1:low_nibble + 1))
    end subroutine append_hex_escape
 
 end module ftimer_summary

--- a/tests/mpi/test_mpi_summary.pf
+++ b/tests/mpi/test_mpi_summary.pf
@@ -1747,6 +1747,7 @@ contains
       class(mpi_summary_case), intent(inout) :: this
       type(ftimer_t) :: timer
       type(ftimer_metadata_t) :: metadata(1)
+      type(ftimer_mpi_union_summary_t) :: union_summary
       character(len=:), allocatable :: printed
       character(len=:), allocatable :: metadata_value
       character(len=*), parameter :: union_path = 'test_mpi_union_large_sparse_report.txt'
@@ -1754,7 +1755,7 @@ contains
       integer, parameter :: sparse_count = 90
       integer :: expected_entries
       integer :: expected_line_count
-      integer :: flags(18)
+      integer :: flags(20)
       integer :: ierr
       integer :: i
       integer :: max_rank
@@ -1762,8 +1763,10 @@ contains
       integer :: missing
       integer :: participating
       integer :: rank
+      logical :: all_union_rows_match
       logical :: ends_with_newline
       logical :: found
+      logical :: last_row_matches
       real(wp) :: avg_calls
       real(wp) :: avg_incl
       real(wp) :: avg_pct
@@ -1798,6 +1801,9 @@ contains
       metadata(1)%key = 'LongMeta'
       metadata_value = repeat('u', 600)//achar(10)//'tail'
       metadata(1)%value = metadata_value
+
+      call timer%mpi_union_summary(union_summary, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
 
       if (rank == 0) call delete_if_exists(union_path)
       call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
@@ -1843,6 +1849,29 @@ contains
          if (ends_with_newline) flags(17) = 1
          if (len(printed) > 1024) flags(18) = 1
 
+         all_union_rows_match = .true.
+         do i = 1, union_summary%num_entries
+            all_union_rows_match = all_union_rows_match .and. &
+                                   union_report_line_matches(report_text_line_at(printed, 16 + i), &
+                                                             trim(union_summary%entries(i)%name), &
+                                                             union_summary%entries(i)%participating_rank_count, &
+                                                             union_summary%num_ranks - &
+                                                             union_summary%entries(i)%participating_rank_count, &
+                                                             union_summary%entries(i)%min_inclusive_time_rank, &
+                                                             union_summary%entries(i)%max_inclusive_time_rank)
+         end do
+         if (all_union_rows_match) flags(19) = 1
+
+         i = union_summary%num_entries
+         last_row_matches = union_report_line_matches(report_text_line_at(printed, expected_line_count), &
+                                                      trim(union_summary%entries(i)%name), &
+                                                      union_summary%entries(i)%participating_rank_count, &
+                                                      union_summary%num_ranks - &
+                                                      union_summary%entries(i)%participating_rank_count, &
+                                                      union_summary%entries(i)%min_inclusive_time_rank, &
+                                                      union_summary%entries(i)%max_inclusive_time_rank)
+         if (last_row_matches) flags(20) = 1
+
          call delete_if_exists(union_path)
       end if
 
@@ -1867,6 +1896,8 @@ contains
       @assertEqual(1, flags(16))
       @assertEqual(1, flags(17))
       @assertEqual(1, flags(18))
+      @assertEqual(1, flags(19))
+      @assertEqual(1, flags(20))
 
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
@@ -3780,6 +3811,7 @@ contains
       integer :: unit
       integer :: io
       integer :: value_col
+      logical :: all_entry_rows_match
       logical :: all_field_counts_match
       logical :: ends_with_newline
 
@@ -3842,8 +3874,21 @@ contains
          if (csv_field_value(metadata_line, value_col) == long_value) flags(5) = 1
          if (index(metadata_line, '""stress""') > 0) flags(6) = 1
 
-         entry_line = csv_line_at(csv_text, 4)
-         if (csv_text_field_equals(entry_line, name_col, 'mpi_timer_0001')) flags(7) = 1
+         all_entry_rows_match = .true.
+         do i = 1, entry_count
+            write (name, '("mpi_timer_",i4.4)') i
+            entry_line = csv_line_at(csv_text, i + 3)
+            all_entry_rows_match = all_entry_rows_match .and. &
+                                   (csv_text_field_equals(entry_line, record_type_col, 'entry'))
+            all_entry_rows_match = all_entry_rows_match .and. &
+                                   (csv_text_field_equals(entry_line, name_col, trim(name)))
+            all_entry_rows_match = all_entry_rows_match .and. &
+                                   (csv_text_field_equals(entry_line, min_call_count_col, '1'))
+            all_entry_rows_match = all_entry_rows_match .and. &
+                                   (csv_text_field_equals(entry_line, max_call_count_col, '1'))
+         end do
+         if (all_entry_rows_match) flags(7) = 1
+
          entry_line = csv_line_at(csv_text, expected_record_count)
          if (csv_text_field_equals(entry_line, name_col, 'mpi_timer_0120')) flags(8) = 1
          if (csv_text_field_equals(entry_line, min_call_count_col, '1')) flags(9) = 1
@@ -6035,6 +6080,67 @@ contains
          if (text(i:i) == new_line('a')) count = count + 1
       end do
    end function count_text_lines
+
+   function report_text_line_at(text, target_line) result(line)
+      character(len=*), intent(in) :: text
+      integer, intent(in) :: target_line
+      character(len=:), allocatable :: line
+      integer :: current_line
+      integer :: i
+      integer :: line_start
+
+      line = ''
+      if (target_line <= 0) return
+
+      current_line = 1
+      line_start = 1
+      do i = 1, len(text)
+         if (text(i:i) /= new_line('a')) cycle
+         if (current_line == target_line) then
+            if (i > line_start) line = text(line_start:i - 1)
+            return
+         end if
+         current_line = current_line + 1
+         line_start = i + 1
+      end do
+
+      if ((current_line == target_line) .and. (line_start <= len(text))) line = text(line_start:)
+   end function report_text_line_at
+
+   logical function union_report_line_matches(line, timer_name, expected_participating, expected_missing, &
+                                              expected_min_rank, expected_max_rank) result(matches)
+      character(len=*), intent(in) :: line
+      character(len=*), intent(in) :: timer_name
+      integer, intent(in) :: expected_participating
+      integer, intent(in) :: expected_missing
+      integer, intent(in) :: expected_min_rank
+      integer, intent(in) :: expected_max_rank
+      character(len=128) :: row_name
+      integer :: io
+      integer :: max_rank
+      integer :: min_rank
+      integer :: missing
+      integer :: participating
+      real(wp) :: avg_calls
+      real(wp) :: avg_incl
+      real(wp) :: avg_pct
+      real(wp) :: avg_self
+      real(wp) :: imbalance
+      real(wp) :: max_incl
+      real(wp) :: min_incl
+
+      matches = .false.
+      row_name = ''
+      read (line, *, iostat=io) row_name, participating, missing, min_incl, min_rank, avg_incl, &
+         max_incl, max_rank, imbalance, avg_self, avg_calls, avg_pct
+      if (io /= 0) return
+
+      matches = (trim(row_name) == trim(timer_name)) .and. &
+                (participating == expected_participating) .and. &
+                (missing == expected_missing) .and. &
+                (min_rank == expected_min_rank) .and. &
+                (max_rank == expected_max_rank)
+   end function union_report_line_matches
 
    logical function csv_real_field_close(line, column, expected) result(matches)
       character(len=*), intent(in) :: line

--- a/tests/mpi/test_mpi_summary.pf
+++ b/tests/mpi/test_mpi_summary.pf
@@ -1743,6 +1743,136 @@ contains
    end subroutine test_mpi_union_write_summary_reports_sparse_participation
 
    @test
+   subroutine test_mpi_union_write_summary_large_sparse_report_preserves_rows(this)
+      class(mpi_summary_case), intent(inout) :: this
+      type(ftimer_t) :: timer
+      type(ftimer_metadata_t) :: metadata(1)
+      character(len=:), allocatable :: printed
+      character(len=:), allocatable :: metadata_value
+      character(len=*), parameter :: union_path = 'test_mpi_union_large_sparse_report.txt'
+      character(len=24) :: name
+      integer, parameter :: sparse_count = 90
+      integer :: expected_entries
+      integer :: expected_line_count
+      integer :: flags(18)
+      integer :: ierr
+      integer :: i
+      integer :: max_rank
+      integer :: min_rank
+      integer :: missing
+      integer :: participating
+      integer :: rank
+      logical :: ends_with_newline
+      logical :: found
+      real(wp) :: avg_calls
+      real(wp) :: avg_incl
+      real(wp) :: avg_pct
+      real(wp) :: avg_self
+      real(wp) :: imbalance
+      real(wp) :: max_incl
+      real(wp) :: min_incl
+
+      rank = this%getProcessRank()
+      flags = 0
+
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(timer)
+
+      fake_time = 0.0_wp
+      call timer%start('common', ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      fake_time = fake_time + 1.0_wp + real(rank, wp)
+      call timer%stop('common', ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      do i = 1, sparse_count
+         write (name, '("rank_",i1,"_",i4.4)') rank, i
+         call timer%start(trim(name), ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = fake_time + 0.5_wp + 0.125_wp*real(rank, wp)
+         call timer%stop(trim(name), ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+      end do
+
+      metadata(1)%key = 'LongMeta'
+      metadata_value = repeat('u', 600)//achar(10)//'tail'
+      metadata(1)%value = metadata_value
+
+      if (rank == 0) call delete_if_exists(union_path)
+      call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
+
+      call timer%write_mpi_union_summary(union_path, metadata=metadata, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
+
+      if (rank == 0) then
+         printed = read_file_text(union_path)
+         expected_entries = 1 + 2*sparse_count
+         expected_line_count = 16 + expected_entries
+         if (count_text_lines(printed) == expected_line_count) flags(1) = 1
+         if (count_lines_with_prefix(printed, 'rank_0_') == sparse_count) flags(2) = 1
+         if (count_lines_with_prefix(printed, 'rank_1_') == sparse_count) flags(3) = 1
+         if (index(printed, repeat('u', 600)) > 0) flags(4) = 1
+         if (index(printed, '\n') > 0) flags(5) = 1
+
+         found = union_report_row_values(printed, 'common', participating, missing, min_incl, min_rank, &
+                                         avg_incl, max_incl, max_rank, imbalance, avg_self, avg_calls, avg_pct)
+         if (found) flags(6) = 1
+         if (participating == 2) flags(7) = 1
+         if (missing == 0) flags(8) = 1
+
+         found = union_report_row_values(printed, 'rank_0_0090', participating, missing, min_incl, min_rank, &
+                                         avg_incl, max_incl, max_rank, imbalance, avg_self, avg_calls, avg_pct)
+         if (found) flags(9) = 1
+         if (participating == 1) flags(10) = 1
+         if (missing == 1) flags(11) = 1
+         if (min_rank == 0) flags(12) = 1
+         if (max_rank == 0) flags(13) = 1
+
+         found = union_report_row_values(printed, 'rank_1_0090', participating, missing, min_incl, min_rank, &
+                                         avg_incl, max_incl, max_rank, imbalance, avg_self, avg_calls, avg_pct)
+         if (found) flags(14) = 1
+         if (participating == 1) flags(15) = 1
+         if (missing == 1) flags(16) = 1
+
+         ends_with_newline = len(printed) > 0
+         if (ends_with_newline) ends_with_newline = printed(len(printed):len(printed)) == new_line('a')
+         if (ends_with_newline) flags(17) = 1
+         if (len(printed) > 1024) flags(18) = 1
+
+         call delete_if_exists(union_path)
+      end if
+
+      call MPI_F08_Bcast(flags, size(flags), MPI_F08_INTEGER, 0, MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
+
+      @assertEqual(1, flags(1))
+      @assertEqual(1, flags(2))
+      @assertEqual(1, flags(3))
+      @assertEqual(1, flags(4))
+      @assertEqual(1, flags(5))
+      @assertEqual(1, flags(6))
+      @assertEqual(1, flags(7))
+      @assertEqual(1, flags(8))
+      @assertEqual(1, flags(9))
+      @assertEqual(1, flags(10))
+      @assertEqual(1, flags(11))
+      @assertEqual(1, flags(12))
+      @assertEqual(1, flags(13))
+      @assertEqual(1, flags(14))
+      @assertEqual(1, flags(15))
+      @assertEqual(1, flags(16))
+      @assertEqual(1, flags(17))
+      @assertEqual(1, flags(18))
+
+      call timer%finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_mpi_union_write_summary_large_sparse_report_preserves_rows
+
+   @test
    subroutine test_mpi_union_write_summary_replaces_existing_file(this)
       class(mpi_summary_case), intent(inout) :: this
       type(ftimer_t) :: timer
@@ -3621,6 +3751,132 @@ contains
       call timer%finalize(ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)
    end subroutine test_mpi_write_summary_csv_emits_parseable_global_records
+
+   @test
+   subroutine test_mpi_write_summary_csv_large_report_preserves_rows(this)
+      class(mpi_summary_case), intent(inout) :: this
+      type(ftimer_t) :: timer
+      type(ftimer_metadata_t) :: metadata(1)
+      character(len=:), allocatable :: csv_text
+      character(len=:), allocatable :: entry_line
+      character(len=:), allocatable :: header
+      character(len=:), allocatable :: long_value
+      character(len=:), allocatable :: metadata_line
+      character(len=:), allocatable :: record_line
+      character(len=*), parameter :: csv_path = 'test_mpi_summary_large_export.csv'
+      character(len=24) :: name
+      integer, parameter :: entry_count = 120
+      integer :: expected_record_count
+      integer :: flags(12)
+      integer :: header_field_count
+      integer :: ierr
+      integer :: i
+      integer :: max_call_count_col
+      integer :: min_call_count_col
+      integer :: name_col
+      integer :: rank
+      integer :: record_count
+      integer :: record_type_col
+      integer :: unit
+      integer :: io
+      integer :: value_col
+      logical :: all_field_counts_match
+      logical :: ends_with_newline
+
+      rank = this%getProcessRank()
+      flags = 0
+
+      call timer%init(comm=MPI_F08_COMM_WORLD, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(timer)
+
+      fake_time = 0.0_wp
+      do i = 1, entry_count
+         write (name, '("mpi_timer_",i4.4)') i
+         call timer%start(trim(name), ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = fake_time + 1.0_wp + 0.125_wp*real(rank, wp)
+         call timer%stop(trim(name), ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+      end do
+
+      long_value = 'mpi, "stress" '//repeat('m', 600)
+      metadata(1)%key = 'Long'
+      metadata(1)%value = long_value
+
+      if (rank == 0) call delete_if_exists(csv_path)
+      call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
+
+      call timer%write_mpi_summary_csv(csv_path, metadata=metadata, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call MPI_F08_Barrier(MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
+
+      if (rank == 0) then
+         csv_text = read_file_text(csv_path)
+         record_count = csv_record_count(csv_text)
+         expected_record_count = entry_count + 3
+         if (record_count == expected_record_count) flags(1) = 1
+
+         header = csv_line_at(csv_text, 1)
+         header_field_count = csv_field_count_quoted(header)
+         record_type_col = csv_column_index(header, 'record_type')
+         value_col = csv_column_index(header, 'value')
+         name_col = csv_column_index(header, 'name')
+         min_call_count_col = csv_column_index(header, 'min_call_count')
+         max_call_count_col = csv_column_index(header, 'max_call_count')
+
+         if (count_csv_header_records(csv_text, header) == 1) flags(2) = 1
+
+         all_field_counts_match = .true.
+         do i = 1, record_count
+            record_line = csv_line_at(csv_text, i)
+            all_field_counts_match = all_field_counts_match .and. &
+                                     (csv_field_count_quoted(record_line) == header_field_count)
+         end do
+         if (all_field_counts_match) flags(3) = 1
+
+         metadata_line = csv_line_at(csv_text, 3)
+         if (csv_text_field_equals(metadata_line, record_type_col, 'metadata')) flags(4) = 1
+         if (csv_field_value(metadata_line, value_col) == long_value) flags(5) = 1
+         if (index(metadata_line, '""stress""') > 0) flags(6) = 1
+
+         entry_line = csv_line_at(csv_text, 4)
+         if (csv_text_field_equals(entry_line, name_col, 'mpi_timer_0001')) flags(7) = 1
+         entry_line = csv_line_at(csv_text, expected_record_count)
+         if (csv_text_field_equals(entry_line, name_col, 'mpi_timer_0120')) flags(8) = 1
+         if (csv_text_field_equals(entry_line, min_call_count_col, '1')) flags(9) = 1
+         if (csv_text_field_equals(entry_line, max_call_count_col, '1')) flags(10) = 1
+
+         ends_with_newline = len(csv_text) > 0
+         if (ends_with_newline) ends_with_newline = csv_text(len(csv_text):len(csv_text)) == new_line('a')
+         if (ends_with_newline) flags(11) = 1
+         if (len(csv_text) > 1024) flags(12) = 1
+
+         open (newunit=unit, file=csv_path, status='old', iostat=io)
+         if (io == 0) close (unit, status='delete')
+      end if
+
+      call MPI_F08_Bcast(flags, size(flags), MPI_F08_INTEGER, 0, MPI_F08_COMM_WORLD, ierr)
+      @assertEqual(MPI_F08_SUCCESS, ierr)
+
+      @assertEqual(1, flags(1))
+      @assertEqual(1, flags(2))
+      @assertEqual(1, flags(3))
+      @assertEqual(1, flags(4))
+      @assertEqual(1, flags(5))
+      @assertEqual(1, flags(6))
+      @assertEqual(1, flags(7))
+      @assertEqual(1, flags(8))
+      @assertEqual(1, flags(9))
+      @assertEqual(1, flags(10))
+      @assertEqual(1, flags(11))
+      @assertEqual(1, flags(12))
+
+      call timer%finalize(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+   end subroutine test_mpi_write_summary_csv_large_report_preserves_rows
 
    @test
    subroutine test_mpi_write_summary_csv_exports_call_count_extrema(this)
@@ -5745,6 +6001,40 @@ contains
          if (header(i:i) == ',') count = count + 1
       end do
    end function csv_header_column_count
+
+   integer function csv_field_count_quoted(line) result(count)
+      character(len=*), intent(in) :: line
+      integer :: i
+      integer :: text_len
+      logical :: in_quotes
+
+      count = 1
+      in_quotes = .false.
+      text_len = len_trim(line)
+      i = 1
+      do while (i <= text_len)
+         if (line(i:i) == '"') then
+            if (in_quotes .and. (i < text_len) .and. (line(i + 1:i + 1) == '"')) then
+               i = i + 1
+            else
+               in_quotes = .not. in_quotes
+            end if
+         else if ((line(i:i) == ',') .and. (.not. in_quotes)) then
+            count = count + 1
+         end if
+         i = i + 1
+      end do
+   end function csv_field_count_quoted
+
+   integer function count_text_lines(text) result(count)
+      character(len=*), intent(in) :: text
+      integer :: i
+
+      count = 0
+      do i = 1, len(text)
+         if (text(i:i) == new_line('a')) count = count + 1
+      end do
+   end function count_text_lines
 
    logical function csv_real_field_close(line, column, expected) result(matches)
       character(len=*), intent(in) :: line

--- a/tests/test_file_output.pf
+++ b/tests/test_file_output.pf
@@ -267,6 +267,123 @@ contains
    end subroutine test_write_summary_csv_emits_parseable_records
 
    @test
+   subroutine test_write_summary_csv_large_report_preserves_rows()
+      type(ftimer_t) :: timer
+      type(ftimer_metadata_t) :: metadata(2)
+      character(len=*), parameter :: path = 'phase3_summary_large_export.csv'
+      character(len=:), allocatable :: csv_text
+      character(len=:), allocatable :: entry_line
+      character(len=:), allocatable :: header
+      character(len=:), allocatable :: long_value
+      character(len=:), allocatable :: metadata_line
+      character(len=:), allocatable :: multiline_value
+      character(len=:), allocatable :: record_line
+      character(len=24) :: name
+      integer, parameter :: entry_count = 180
+      integer :: call_count_col
+      integer :: expected_record_count
+      integer :: header_count
+      integer :: header_field_count
+      integer :: ierr
+      integer :: is_active_col
+      integer :: logical_record_count
+      integer :: name_col
+      integer :: record_type_col
+      integer :: i
+      integer :: unit
+      integer :: io
+      integer :: value_col
+      logical :: all_entry_rows_match
+      logical :: all_field_counts_match
+      logical :: ends_with_newline
+      logical :: long_metadata_escaped
+      logical :: long_metadata_preserved
+      logical :: multiline_metadata_preserved
+
+      call delete_if_exists(path)
+
+      call timer%init(ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+      call attach_mock_clock(timer)
+
+      fake_time = 0.0_wp
+      do i = 1, entry_count
+         write (name, '("csv_timer_",i4.4)') i
+         call timer%start(trim(name), ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+         fake_time = fake_time + 1.0_wp
+         call timer%stop(trim(name), ierr=ierr)
+         @assertEqual(FTIMER_SUCCESS, ierr)
+      end do
+
+      long_value = 'alpha, "beta" '//repeat('x', 600)
+      multiline_value = 'line one'//new_line('a')//'line, "two"'
+      metadata(1)%key = 'Long'
+      metadata(1)%value = long_value
+      metadata(2)%key = 'Multiline'
+      metadata(2)%value = multiline_value
+
+      call timer%write_summary_csv(path, metadata=metadata, ierr=ierr)
+      @assertEqual(FTIMER_SUCCESS, ierr)
+
+      csv_text = read_file_text(path)
+      logical_record_count = csv_logical_record_count(csv_text)
+      expected_record_count = entry_count + 4
+      @assertEqual(expected_record_count, logical_record_count)
+
+      header = csv_logical_record_at(csv_text, 1)
+      header_count = count_csv_logical_header_records(csv_text, header)
+      header_field_count = csv_field_count_local(header)
+      @assertEqual(1, header_count)
+
+      record_type_col = csv_column_index(header, 'record_type')
+      value_col = csv_column_index(header, 'value')
+      name_col = csv_column_index(header, 'name')
+      call_count_col = csv_column_index(header, 'call_count')
+      is_active_col = csv_column_index(header, 'is_active')
+
+      all_field_counts_match = .true.
+      do i = 1, logical_record_count
+         record_line = csv_logical_record_at(csv_text, i)
+         all_field_counts_match = all_field_counts_match .and. &
+                                  (csv_field_count_local(record_line) == header_field_count)
+      end do
+
+      metadata_line = csv_logical_record_at(csv_text, 3)
+      long_metadata_preserved = csv_field_value(metadata_line, value_col) == long_value
+      long_metadata_escaped = index(metadata_line, '""beta""') > 0
+      metadata_line = csv_logical_record_at(csv_text, 4)
+      multiline_metadata_preserved = csv_field_value(metadata_line, value_col) == multiline_value
+
+      all_entry_rows_match = .true.
+      do i = 1, entry_count
+         write (name, '("csv_timer_",i4.4)') i
+         entry_line = csv_logical_record_at(csv_text, i + 4)
+         all_entry_rows_match = all_entry_rows_match .and. &
+                                (csv_field_value(entry_line, record_type_col) == 'entry')
+         all_entry_rows_match = all_entry_rows_match .and. &
+                                (csv_field_value(entry_line, name_col) == trim(name))
+         all_entry_rows_match = all_entry_rows_match .and. &
+                                (csv_field_value(entry_line, call_count_col) == '1')
+         all_entry_rows_match = all_entry_rows_match .and. &
+                                (csv_field_value(entry_line, is_active_col) == 'false')
+      end do
+
+      ends_with_newline = len(csv_text) > 0
+      if (ends_with_newline) ends_with_newline = csv_text(len(csv_text):len(csv_text)) == new_line('a')
+
+      @assertTrue(all_field_counts_match)
+      @assertTrue(long_metadata_preserved)
+      @assertTrue(long_metadata_escaped)
+      @assertTrue(multiline_metadata_preserved)
+      @assertTrue(all_entry_rows_match)
+      @assertTrue(ends_with_newline)
+
+      open (newunit=unit, file=path, status='old', iostat=io)
+      if (io == 0) close (unit, status='delete')
+   end subroutine test_write_summary_csv_large_report_preserves_rows
+
+   @test
    subroutine test_write_summary_csv_after_set_clock_uses_custom_clock_window()
       type(ftimer_t) :: timer
       character(len=*), parameter :: path = 'phase3_summary_custom_clock_empty.csv'
@@ -1440,6 +1557,19 @@ contains
          if (line == header) count = count + 1
       end do
    end function count_csv_header_records
+
+   integer function count_csv_logical_header_records(text, header) result(count)
+      character(len=*), intent(in) :: text
+      character(len=*), intent(in) :: header
+      character(len=:), allocatable :: record
+      integer :: i
+
+      count = 0
+      do i = 1, csv_logical_record_count(text)
+         record = csv_logical_record_at(text, i)
+         if (record == header) count = count + 1
+      end do
+   end function count_csv_logical_header_records
 
    integer function csv_field_count_local(line) result(count)
       character(len=*), intent(in) :: line

--- a/tests/test_summary.pf
+++ b/tests/test_summary.pf
@@ -562,6 +562,46 @@ contains
    end subroutine test_format_summary_preserves_metadata_above_legacy_len
 
    @test
+   subroutine test_format_summary_large_report_not_truncated()
+      type(ftimer_summary_t) :: summary
+      character(len=:), allocatable :: text
+      character(len=16) :: name
+      integer, parameter :: entry_count = 180
+      integer :: i
+      integer :: line_count
+      logical :: ends_with_newline
+      logical :: first_row_present
+      logical :: last_row_present
+
+      summary%total_time = real(entry_count, wp)
+      summary%num_entries = entry_count
+      allocate (summary%entries(entry_count))
+
+      do i = 1, entry_count
+         write (name, '("timer_",i4.4)') i
+         summary%entries(i)%name = trim(name)
+         summary%entries(i)%inclusive_time = real(i, wp)
+         summary%entries(i)%self_time = real(i, wp)
+         summary%entries(i)%call_count = i
+         summary%entries(i)%avg_time = real(i, wp)
+         summary%entries(i)%pct_time = 100.0_wp*real(i, wp)/real(entry_count, wp)
+      end do
+
+      call format_summary(summary, text)
+
+      line_count = count_lines(text)
+      first_row_present = index(text, 'timer_0001') > 0
+      last_row_present = index(text, 'timer_0180') > 0
+      ends_with_newline = len(text) > 0
+      if (ends_with_newline) ends_with_newline = text(len(text):len(text)) == new_line('a')
+
+      @assertEqual(entry_count + 4, line_count)
+      @assertTrue(first_row_present)
+      @assertTrue(last_row_present)
+      @assertTrue(ends_with_newline)
+   end subroutine test_format_summary_large_report_not_truncated
+
+   @test
    subroutine test_format_summary_handles_unallocated_metadata_fields()
       type(ftimer_metadata_t) :: metadata(3)
       type(ftimer_summary_t) :: summary

--- a/tests/test_summary.pf
+++ b/tests/test_summary.pf
@@ -565,13 +565,16 @@ contains
    subroutine test_format_summary_large_report_not_truncated()
       type(ftimer_summary_t) :: summary
       character(len=:), allocatable :: text
+      character(len=:), allocatable :: actual_line
+      character(len=:), allocatable :: expected_line
       character(len=16) :: name
       integer, parameter :: entry_count = 180
       integer :: i
       integer :: line_count
+      logical :: all_rows_match
       logical :: ends_with_newline
-      logical :: first_row_present
-      logical :: last_row_present
+      logical :: header_matches
+      logical :: separator_matches
 
       summary%total_time = real(entry_count, wp)
       summary%num_entries = entry_count
@@ -590,14 +593,22 @@ contains
       call format_summary(summary, text)
 
       line_count = count_lines(text)
-      first_row_present = index(text, 'timer_0001') > 0
-      last_row_present = index(text, 'timer_0180') > 0
+      header_matches = text_line_at(text, 3) == 'Timer name  Inclusive (s)     Self (s)    Calls   % Total'
+      separator_matches = text_line_at(text, 4) == '---------------------------------------------------------'
       ends_with_newline = len(text) > 0
       if (ends_with_newline) ends_with_newline = text(len(text):len(text)) == new_line('a')
 
+      all_rows_match = .true.
+      do i = 1, entry_count
+         actual_line = text_line_at(text, i + 4)
+         expected_line = expected_large_summary_row(i, entry_count)
+         all_rows_match = all_rows_match .and. (actual_line == expected_line)
+      end do
+
       @assertEqual(entry_count + 4, line_count)
-      @assertTrue(first_row_present)
-      @assertTrue(last_row_present)
+      @assertTrue(header_matches)
+      @assertTrue(separator_matches)
+      @assertTrue(all_rows_match)
       @assertTrue(ends_with_newline)
    end subroutine test_format_summary_large_report_not_truncated
 
@@ -1108,6 +1119,46 @@ contains
          if (text(i:i) == new_line('a')) count = count + 1
       end do
    end function count_lines
+
+   function text_line_at(text, target_line) result(line)
+      character(len=*), intent(in) :: text
+      integer, intent(in) :: target_line
+      character(len=:), allocatable :: line
+      integer :: current_line
+      integer :: i
+      integer :: line_start
+
+      line = ''
+      if (target_line <= 0) return
+
+      current_line = 1
+      line_start = 1
+      do i = 1, len(text)
+         if (text(i:i) /= new_line('a')) cycle
+         if (current_line == target_line) then
+            if (i > line_start) line = text(line_start:i - 1)
+            return
+         end if
+         current_line = current_line + 1
+         line_start = i + 1
+      end do
+
+      if (current_line == target_line) line = text(line_start:)
+   end function text_line_at
+
+   function expected_large_summary_row(entry_index, entry_count) result(row)
+      integer, intent(in) :: entry_index
+      integer, intent(in) :: entry_count
+      character(len=:), allocatable :: row
+      character(len=16) :: name
+      character(len=128) :: scratch
+
+      write (name, '("timer_",i4.4)') entry_index
+      write (scratch, '(a10,2x,f12.6,2x,f12.6,2x,i8,2x,f8.2)') trim(name), &
+         real(entry_index, wp), real(entry_index, wp), entry_index, &
+         100.0_wp*real(entry_index, wp)/real(entry_count, wp)
+      row = trim(scratch)
+   end function expected_large_summary_row
 
    function deep_hierarchy_prefix(level) result(prefix)
       integer, intent(in) :: level


### PR DESCRIPTION
## Summary

Closes #232.
Refs #198.

- Replace repeated full-report string concatenation in local, strict MPI, and sparse MPI-union text formatters with amortized growable character buffers.
- Use the same buffered assembly path for local/strict MPI/sparse union CSV rows and full CSV report strings, while preserving the existing quoting, headers, schemas, and public APIs.
- Add a regression test that formats a report larger than the initial buffer and verifies row boundaries, final newline, and first/last entries are preserved.

## Output / API compatibility

- Public report text format: unchanged.
- CSV schema and quoting behavior: unchanged.
- Public API and summary types: unchanged.
- Start/stop hot paths: untouched.

## Reporting benchmark evidence

Serial `ftimer_bench` reporting rows, before -> after:

| Row | Before per-op ns | After per-op ns |
| --- | ---: | ---: |
| format local text N=100 entries | 208400 | 135640 |
| format local text N=1000 entries | 3538800 | 1380000 |
| write local CSV N=100 entries | 1719800 | 429400 |
| write local CSV N=1000 entries | 22260800 | 3286000 |
| format local text N=100 long L=256 | 2704000 | 460240 |
| format local text metadata M=200 | 1751300 | 446600 |
| write local CSV metadata M=200 | 5299400 | 590000 |
| format sparse union text N=100 | 357920 | 262840 |
| format sparse union text N=1000 | 7092000 | 2465200 |

MPI-enabled benchmark row, before -> after:

| Row | Before per-op ns | After per-op ns |
| --- | ---: | ---: |
| write strict MPI CSV N=100 entries | 4552400 | 1312200 |

Benchmarks are timing evidence only; no hard thresholds were added.

## Validation

- Added regression test first and verified `ctest --test-dir build-tests-232 --output-on-failure -R ftimer_serial_tests` passed before formatter refactor.
- `ctest --test-dir build-tests-232 --output-on-failure -R ftimer_serial_tests`
- `ctest --test-dir build-mpi-tests --output-on-failure -R ftimer_mpi_tests$`
- `ctest --test-dir build-mpi-tests --output-on-failure -R ftimer_mpi_tests_4pe$`
- `ctest --test-dir build-smoke-232 --output-on-failure`
- `ctest --test-dir build-tests-232 --output-on-failure`
- `ctest --test-dir build-bench-232-after --output-on-failure -L bench`
- `ctest --test-dir build-bench-mpi-232-after --output-on-failure -L bench`
- `fprettify --diff src/ftimer_summary.F90 src/ftimer_core_summary_bindings.F90`
- `fprettify --diff tests/test_summary.pf`
- `git diff --check`