### PR TITLE
[codex] Validate OpenMP compiler gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,7 +491,7 @@ jobs:
           fi
 
       - name: Configure (Flang OpenMP)
-        run: FC=${{ env.FTIMER_FLANG_COMPILER }} cmake -B build -DFTIMER_USE_OPENMP=ON -DOpenMP_ROOT=/usr/lib/llvm-19
+        run: FC=${{ env.FTIMER_FLANG_COMPILER }} cmake -B build -DFTIMER_USE_OPENMP=ON -DFTIMER_REQUIRE_FLANG_OPENMP_CONTRACT=ON -DOpenMP_ROOT=/usr/lib/llvm-19
 
       - name: Build
         run: cmake --build build -j$(nproc)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,6 +467,38 @@ jobs:
       - name: Smoke test
         run: ctest --test-dir build --output-on-failure
 
+  build-openmp-flang:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flang-19 libomp-19-dev cmake
+
+      - name: Resolve Flang
+        run: |
+          if command -v flang-19 >/dev/null 2>&1; then
+            echo "FTIMER_FLANG_COMPILER=flang-19" >> "$GITHUB_ENV"
+          elif command -v flang-new-19 >/dev/null 2>&1; then
+            echo "FTIMER_FLANG_COMPILER=flang-new-19" >> "$GITHUB_ENV"
+          elif command -v flang >/dev/null 2>&1; then
+            echo "FTIMER_FLANG_COMPILER=flang" >> "$GITHUB_ENV"
+          else
+            echo "No supported Flang executable found on PATH." >&2
+            exit 1
+          fi
+
+      - name: Configure (Flang OpenMP)
+        run: FC=${{ env.FTIMER_FLANG_COMPILER }} cmake -B build -DFTIMER_USE_OPENMP=ON -DOpenMP_ROOT=/usr/lib/llvm-19
+
+      - name: Build
+        run: cmake --build build -j$(nproc)
+
+      - name: OpenMP example smoke test
+        run: ctest --test-dir build --output-on-failure --no-tests=error -R '^ftimer_openmp_example_smoke$'
+
   build-contract-regressions:
     runs-on: ubuntu-latest
     steps:
@@ -475,7 +507,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y gfortran cmake make libopenmpi-dev openmpi-bin flang-19
+          sudo apt-get install -y gfortran cmake make libopenmpi-dev openmpi-bin flang-19 libomp-19-dev
 
       # These checks cover the configure-time negative gates and the Makefile
       # wrapper defaults that Issue #51 tracks as automated regressions.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,7 +497,7 @@ jobs:
         run: cmake --build build -j$(nproc)
 
       - name: OpenMP example smoke test
-        run: ctest --test-dir build --output-on-failure --no-tests=error -R '^ftimer_openmp_example_smoke$'
+        run: ctest --test-dir build --output-on-failure --no-tests=error -R '^(ftimer_openmp_example_smoke|ftimer_installed_package_consumer_openmp_flang)$'
 
   build-contract-regressions:
     runs-on: ubuntu-latest
@@ -512,7 +512,7 @@ jobs:
       # These checks cover the configure-time negative gates and the Makefile
       # wrapper defaults that Issue #51 tracks as automated regressions.
       - name: Configure contract checks
-        run: cmake -B build-contract -DFTIMER_BUILD_EXAMPLES=OFF
+        run: cmake -B build-contract -DFTIMER_BUILD_EXAMPLES=OFF -DFTIMER_REQUIRE_FLANG_OPENMP_CONTRACT=ON
 
       - name: Run contract regression tests
         run: ctest --test-dir build-contract --output-on-failure -R "ftimer_(configure|make)_.*contracts"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Supported toolchain matrix:
 - Serial + pFUnit tests: GNU Fortran (`gfortran`) with a pFUnit installation built for the same compiler/toolchain.
 - MPI: GNU Fortran wrapper compiler paths are validated with OpenMPI and MPICH. Smoke/install-consumer coverage runs for both, and MPI pFUnit coverage runs for OpenMPI plus MPICH on hosted Ubuntu 22.04 with a matching MPICH-built pFUnit. `FTIMER_USE_MPI=ON` now runs a configure-time `mpi_f08` probe and fails early if the active compiler cannot consume the discovered MPI module files.
 - OpenMP: GNU Fortran (`gfortran`) with pFUnit guard coverage, plus LLVM Flang smoke/example coverage for the documented master-thread-only carve-out.
+  LLVM Flang OpenMP validation requires CMake 3.24 or newer so CMake reports compiler ID `LLVMFlang`.
 
 Other serial compilers may still work, but they are not part of the current release-validated matrix unless the repo adds direct automation for them.
 
@@ -258,6 +259,7 @@ The native Codex trigger comments are intentionally posted as single-line `@code
 
 - **`FTIMER_USE_MPI`** (CMake option, default OFF): Enables MPI support. When ON, `MPI_Wtime()` is used as the clock source and `mpi_summary()` / `mpi_union_summary()` can populate cross-rank fields. Use MPI-enabled fTimer only after `MPI_Init` and before `MPI_Finalize`. The supported path is an MPI wrapper compiler such as `mpifort`; configure now fails early if the active compiler cannot compile a minimal `mpi_f08` probe against the discovered MPI toolchain. When OFF, `mpi_summary()` and `mpi_union_summary()` return `FTIMER_ERR_NOT_IMPLEMENTED` with empty MPI result objects; they do not fall back to local summaries.
 - **`FTIMER_USE_OPENMP`** (CMake option, default OFF): Enables limited `!$omp master` guards around the guarded `ftimer_core` entry points. This is master-thread-only protection, not full thread safety. The documented/supported build paths are GNU Fortran (`gfortran`) and LLVM Flang after CMake resolves `OpenMP::OpenMP_Fortran` and fTimer's configure-time OpenMP master-thread probe passes.
+- **`FTIMER_OPENMP_ASSUME_MASTER_PROBE_OK`** (CMake option, default OFF): Advanced escape hatch for cross-compiling or execution-restricted package builds. It may be set only after independently validating equivalent OpenMP master-thread runtime semantics for the selected compiler/runtime pair.
 - **`FTIMER_BUILD_SMOKE_TESTS`** (CMake option, default ON): Enables the smoke-test baseline, including install/export consumer verification and the script-driven build-contract regression checks when their toolchain prerequisites are available.
 - **`FTIMER_BUILD_TESTS`** (CMake option, default OFF): Enables the pFUnit-backed behavioral and MPI test suites.
 - **`CMAKE_INSTALL_PREFIX`**: Where `make install` places the library and module files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,15 @@ FC=/path/to/mpi-mpifort cmake -B build-mpi -DFTIMER_USE_MPI=ON -DFTIMER_BUILD_TE
 cmake --build build-mpi
 cmake -E chdir build-mpi ctest --output-on-failure -L mpi
 
-# OpenMP guard build (currently supported with GNU Fortran)
+# OpenMP guard build with pFUnit coverage (GNU Fortran)
 FC=gfortran cmake -B build-openmp -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build-openmp
 cmake -E chdir build-openmp ctest --output-on-failure
+
+# OpenMP smoke/example build (LLVM Flang with discoverable libomp)
+FC=flang-19 cmake -B build-openmp-flang -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=OFF
+cmake --build build-openmp-flang
+./build-openmp-flang/examples/openmp_example
 
 # Lint / format check
 find src -name '*.F90' -exec fprettify --diff {} +
@@ -63,7 +68,7 @@ Supported toolchain matrix:
 - Serial smoke/library build: GNU Fortran and LLVM Flang are the validated automation paths.
 - Serial + pFUnit tests: GNU Fortran (`gfortran`) with a pFUnit installation built for the same compiler/toolchain.
 - MPI: GNU Fortran wrapper compiler paths are validated with OpenMPI and MPICH. Smoke/install-consumer coverage runs for both, and MPI pFUnit coverage runs for OpenMPI plus MPICH on hosted Ubuntu 22.04 with a matching MPICH-built pFUnit. `FTIMER_USE_MPI=ON` now runs a configure-time `mpi_f08` probe and fails early if the active compiler cannot consume the discovered MPI module files.
-- OpenMP: GNU Fortran (`gfortran`) only for the documented/supported path.
+- OpenMP: GNU Fortran (`gfortran`) with pFUnit guard coverage, plus LLVM Flang smoke/example coverage for the documented master-thread-only carve-out.
 
 Other serial compilers may still work, but they are not part of the current release-validated matrix unless the repo adds direct automation for them.
 
@@ -252,7 +257,7 @@ The native Codex trigger comments are intentionally posted as single-line `@code
 ## Configuration
 
 - **`FTIMER_USE_MPI`** (CMake option, default OFF): Enables MPI support. When ON, `MPI_Wtime()` is used as the clock source and `mpi_summary()` / `mpi_union_summary()` can populate cross-rank fields. Use MPI-enabled fTimer only after `MPI_Init` and before `MPI_Finalize`. The supported path is an MPI wrapper compiler such as `mpifort`; configure now fails early if the active compiler cannot compile a minimal `mpi_f08` probe against the discovered MPI toolchain. When OFF, `mpi_summary()` and `mpi_union_summary()` return `FTIMER_ERR_NOT_IMPLEMENTED` with empty MPI result objects; they do not fall back to local summaries.
-- **`FTIMER_USE_OPENMP`** (CMake option, default OFF): Enables limited `!$omp master` guards around the guarded `ftimer_core` entry points. This is master-thread-only protection, not full thread safety. The documented/supported build path is GNU Fortran (`gfortran`).
+- **`FTIMER_USE_OPENMP`** (CMake option, default OFF): Enables limited `!$omp master` guards around the guarded `ftimer_core` entry points. This is master-thread-only protection, not full thread safety. The documented/supported build paths are GNU Fortran (`gfortran`) and LLVM Flang after CMake resolves `OpenMP::OpenMP_Fortran` and fTimer's configure-time OpenMP master-thread probe passes.
 - **`FTIMER_BUILD_SMOKE_TESTS`** (CMake option, default ON): Enables the smoke-test baseline, including install/export consumer verification and the script-driven build-contract regression checks when their toolchain prerequisites are available.
 - **`FTIMER_BUILD_TESTS`** (CMake option, default OFF): Enables the pFUnit-backed behavioral and MPI test suites.
 - **`CMAKE_INSTALL_PREFIX`**: Where `make install` places the library and module files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,10 +34,15 @@ FC=/path/to/mpi-mpifort cmake -B build-mpi -DFTIMER_USE_MPI=ON -DFTIMER_BUILD_TE
 cmake --build build-mpi
 cmake -E chdir build-mpi ctest --output-on-failure -L mpi
 
-# OpenMP guard build (currently supported with GNU Fortran)
+# OpenMP guard build with pFUnit coverage (GNU Fortran)
 FC=gfortran cmake -B build-openmp -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build-openmp
 cmake -E chdir build-openmp ctest --output-on-failure
+
+# OpenMP smoke/example build (LLVM Flang with discoverable libomp)
+FC=flang-19 cmake -B build-openmp-flang -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=OFF
+cmake --build build-openmp-flang
+./build-openmp-flang/examples/openmp_example
 
 # Lint / format check
 find src -name '*.F90' -exec fprettify --diff {} +
@@ -63,7 +68,8 @@ Supported toolchain matrix:
 - Serial smoke/library build: GNU Fortran and LLVM Flang are the validated automation paths.
 - Serial + pFUnit tests: GNU Fortran (`gfortran`) with a pFUnit installation built for the same compiler/toolchain.
 - MPI: GNU Fortran wrapper compiler paths are validated with OpenMPI and MPICH. Smoke/install-consumer coverage runs for both, and MPI pFUnit coverage runs for OpenMPI plus MPICH on hosted Ubuntu 22.04 with a matching MPICH-built pFUnit. `FTIMER_USE_MPI=ON` now runs a configure-time `mpi_f08` probe and fails early if the active compiler cannot consume the discovered MPI module files.
-- OpenMP: GNU Fortran (`gfortran`) only for the documented/supported path.
+- OpenMP: GNU Fortran (`gfortran`) with pFUnit guard coverage, plus LLVM Flang smoke/example coverage for the documented master-thread-only carve-out.
+  LLVM Flang OpenMP validation requires CMake 3.24 or newer so CMake reports compiler ID `LLVMFlang`.
 
 Other serial compilers may still work, but they are not part of the current release-validated matrix unless the repo adds direct automation for them.
 
@@ -252,7 +258,8 @@ The native Codex trigger comments are intentionally posted as single-line `@code
 ## Configuration
 
 - **`FTIMER_USE_MPI`** (CMake option, default OFF): Enables MPI support. When ON, `MPI_Wtime()` is used as the clock source and `mpi_summary()` / `mpi_union_summary()` can populate cross-rank fields. Use MPI-enabled fTimer only after `MPI_Init` and before `MPI_Finalize`. The supported path is an MPI wrapper compiler such as `mpifort`; configure now fails early if the active compiler cannot compile a minimal `mpi_f08` probe against the discovered MPI toolchain. When OFF, `mpi_summary()` and `mpi_union_summary()` return `FTIMER_ERR_NOT_IMPLEMENTED` with empty MPI result objects; they do not fall back to local summaries.
-- **`FTIMER_USE_OPENMP`** (CMake option, default OFF): Enables limited `!$omp master` guards around the guarded `ftimer_core` entry points. This is master-thread-only protection, not full thread safety. The documented/supported build path is GNU Fortran (`gfortran`).
+- **`FTIMER_USE_OPENMP`** (CMake option, default OFF): Enables limited `!$omp master` guards around the guarded `ftimer_core` entry points. This is master-thread-only protection, not full thread safety. The documented/supported build paths are GNU Fortran (`gfortran`) and LLVM Flang after CMake resolves `OpenMP::OpenMP_Fortran` and fTimer's configure-time OpenMP master-thread probe passes.
+- **`FTIMER_OPENMP_ASSUME_MASTER_PROBE_OK`** (CMake option, default OFF): Advanced escape hatch for cross-compiling or execution-restricted package builds. It may be set only after independently validating equivalent OpenMP master-thread runtime semantics for the selected compiler/runtime pair.
 - **`FTIMER_BUILD_SMOKE_TESTS`** (CMake option, default ON): Enables the smoke-test baseline, including install/export consumer verification and the script-driven build-contract regression checks when their toolchain prerequisites are available.
 - **`FTIMER_BUILD_TESTS`** (CMake option, default OFF): Enables the pFUnit-backed behavioral and MPI test suites.
 - **`CMAKE_INSTALL_PREFIX`**: Where `make install` places the library and module files.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,71 @@ end program ftimer_mpi_datatype_probe
   set(${out_var} "${_ftimer_mpi_datatype_probe_ok}" PARENT_SCOPE)
 endfunction()
 
+function(ftimer_try_run_openmp_master_probe out_var details_var)
+  set(_ftimer_openmp_probe_src "${CMAKE_BINARY_DIR}/CMakeFiles/ftimer_openmp_master_probe.F90")
+  file(WRITE "${_ftimer_openmp_probe_src}" [=[
+program ftimer_openmp_master_probe
+  use omp_lib, only: omp_get_num_threads, omp_get_thread_num, omp_set_dynamic
+  implicit none
+
+  integer :: master_hits
+  integer :: worker_hits
+  integer :: threads
+  integer :: thread_num
+  logical :: master_thread_was_zero
+
+  call omp_set_dynamic(.false.)
+
+  master_hits = 0
+  worker_hits = 0
+  threads = 0
+  master_thread_was_zero = .false.
+
+!$omp parallel num_threads(2) default(shared) private(thread_num)
+  thread_num = omp_get_thread_num()
+  if (thread_num /= 0) then
+!$omp atomic update
+    worker_hits = worker_hits + 1
+  end if
+
+!$omp master
+  master_hits = master_hits + 1
+  threads = omp_get_num_threads()
+  master_thread_was_zero = (omp_get_thread_num() == 0)
+!$omp end master
+!$omp end parallel
+
+  if (master_hits /= 1) error stop "OpenMP master region did not execute exactly once"
+  if (.not. master_thread_was_zero) error stop "OpenMP master region did not run on thread zero"
+  if (worker_hits < 1) error stop "OpenMP parallel region did not create a worker thread"
+  if (threads < 2) error stop "OpenMP parallel region did not report two threads"
+end program ftimer_openmp_master_probe
+]=])
+
+  try_run(_ftimer_openmp_run_result _ftimer_openmp_compile_ok
+    "${CMAKE_BINARY_DIR}/CMakeFiles/ftimer_openmp_master_probe_build"
+    "${_ftimer_openmp_probe_src}"
+    LINK_LIBRARIES OpenMP::OpenMP_Fortran
+    COMPILE_OUTPUT_VARIABLE _ftimer_openmp_compile_output
+    RUN_OUTPUT_VARIABLE _ftimer_openmp_run_output
+  )
+
+  string(CONCAT _ftimer_openmp_details
+    "compile_result='${_ftimer_openmp_compile_ok}'\n"
+    "run_result='${_ftimer_openmp_run_result}'\n"
+    "compile_output:\n${_ftimer_openmp_compile_output}\n"
+    "run_output:\n${_ftimer_openmp_run_output}"
+  )
+
+  if(_ftimer_openmp_compile_ok AND _ftimer_openmp_run_result EQUAL 0)
+    set(${out_var} TRUE PARENT_SCOPE)
+  else()
+    set(${out_var} FALSE PARENT_SCOPE)
+  endif()
+
+  set(${details_var} "${_ftimer_openmp_details}" PARENT_SCOPE)
+endfunction()
+
 # Options
 option(FTIMER_USE_MPI "Enable MPI support" OFF)
 option(FTIMER_USE_OPENMP "Enable OpenMP master-thread guards" OFF)
@@ -112,20 +177,33 @@ if(FTIMER_USE_MPI)
 endif()
 
 if(FTIMER_USE_OPENMP)
-  if(NOT CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+  set(FTIMER_VALIDATED_OPENMP_COMPILER_IDS GNU LLVMFlang)
+  if(NOT CMAKE_Fortran_COMPILER_ID IN_LIST FTIMER_VALIDATED_OPENMP_COMPILER_IDS)
     message(FATAL_ERROR
-      "FTIMER_USE_OPENMP=ON is currently supported only with GNU Fortran ('gfortran').\n"
+      "FTIMER_USE_OPENMP=ON is not currently validated for compiler ID '${CMAKE_Fortran_COMPILER_ID}'.\n"
       "The active compiler is '${CMAKE_Fortran_COMPILER_ID}' at '${CMAKE_Fortran_COMPILER}'.\n"
-      "Supported path: configure with 'FC=gfortran cmake -B build-openmp -DFTIMER_USE_OPENMP=ON ...'."
+      "Validated OpenMP compiler IDs: GNU and LLVMFlang.\n"
+      "Supported paths: configure with GNU Fortran ('FC=gfortran ...') or LLVM Flang ('FC=flang-19 ...') and a discoverable OpenMP runtime.\n"
+      "Other compilers must be added only after fTimer's master-thread-only OpenMP probe and smoke coverage validate them."
     )
   endif()
 
   find_package(OpenMP COMPONENTS Fortran)
-  if(NOT OpenMP_Fortran_FOUND)
+  if(NOT OpenMP_Fortran_FOUND OR NOT TARGET OpenMP::OpenMP_Fortran)
     message(FATAL_ERROR
-      "FTIMER_USE_OPENMP=ON requires a GNU Fortran toolchain where CMake can find OpenMP::OpenMP_Fortran.\n"
-      "CMake could not find the Fortran OpenMP runtime for '${CMAKE_Fortran_COMPILER}'.\n"
-      "Supported path: configure with 'FC=gfortran cmake -B build-openmp -DFTIMER_USE_OPENMP=ON ...'."
+      "FTIMER_USE_OPENMP=ON requires CMake to resolve OpenMP::OpenMP_Fortran for the active validated compiler.\n"
+      "CMake could not find the Fortran OpenMP runtime for compiler ID '${CMAKE_Fortran_COMPILER_ID}' at '${CMAKE_Fortran_COMPILER}'.\n"
+      "Supported paths: configure with GNU Fortran or LLVM Flang plus a discoverable OpenMP runtime. On platforms where LLVM Flang's libomp is not auto-discovered, pass '-DOpenMP_ROOT=/path/to/libomp'."
+    )
+  endif()
+
+  ftimer_try_run_openmp_master_probe(FTIMER_OPENMP_MASTER_PROBE_OK FTIMER_OPENMP_MASTER_PROBE_DETAILS)
+  if(NOT FTIMER_OPENMP_MASTER_PROBE_OK)
+    message(FATAL_ERROR
+      "FTIMER_USE_OPENMP=ON requires a validated compiler/runtime pair that passes fTimer's master-thread-only OpenMP capability probe.\n"
+      "The probe compiles, links, and runs a Fortran program using omp_lib, a two-thread parallel region, and !$omp master semantics.\n"
+      "Active compiler ID: '${CMAKE_Fortran_COMPILER_ID}' at '${CMAKE_Fortran_COMPILER}'.\n"
+      "${FTIMER_OPENMP_MASTER_PROBE_DETAILS}"
     )
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,18 +115,57 @@ program ftimer_openmp_master_probe
 end program ftimer_openmp_master_probe
 ]=])
 
+  try_compile(_ftimer_openmp_compile_ok
+    "${CMAKE_BINARY_DIR}/CMakeFiles/ftimer_openmp_master_probe_compile"
+    SOURCES "${_ftimer_openmp_probe_src}"
+    LINK_LIBRARIES OpenMP::OpenMP_Fortran
+    OUTPUT_VARIABLE _ftimer_openmp_compile_output
+  )
+
+  if(NOT _ftimer_openmp_compile_ok)
+    string(CONCAT _ftimer_openmp_details
+      "compile_result='${_ftimer_openmp_compile_ok}'\n"
+      "compile_output:\n${_ftimer_openmp_compile_output}"
+    )
+    set(${out_var} FALSE PARENT_SCOPE)
+    set(${details_var} "${_ftimer_openmp_details}" PARENT_SCOPE)
+    return()
+  endif()
+
+  if(FTIMER_OPENMP_ASSUME_MASTER_PROBE_OK)
+    string(CONCAT _ftimer_openmp_details
+      "compile_result='${_ftimer_openmp_compile_ok}'\n"
+      "run_result='assumed by FTIMER_OPENMP_ASSUME_MASTER_PROBE_OK'\n"
+      "compile_output:\n${_ftimer_openmp_compile_output}"
+    )
+    set(${out_var} TRUE PARENT_SCOPE)
+    set(${details_var} "${_ftimer_openmp_details}" PARENT_SCOPE)
+    return()
+  endif()
+
+  if(CMAKE_CROSSCOMPILING AND NOT CMAKE_CROSSCOMPILING_EMULATOR)
+    string(CONCAT _ftimer_openmp_details
+      "compile_result='${_ftimer_openmp_compile_ok}'\n"
+      "run_result='not run because CMake is cross-compiling without CMAKE_CROSSCOMPILING_EMULATOR'\n"
+      "compile_output:\n${_ftimer_openmp_compile_output}"
+    )
+    set(${out_var} FALSE PARENT_SCOPE)
+    set(${details_var} "${_ftimer_openmp_details}" PARENT_SCOPE)
+    return()
+  endif()
+
   try_run(_ftimer_openmp_run_result _ftimer_openmp_compile_ok
-    "${CMAKE_BINARY_DIR}/CMakeFiles/ftimer_openmp_master_probe_build"
+    "${CMAKE_BINARY_DIR}/CMakeFiles/ftimer_openmp_master_probe_run"
     "${_ftimer_openmp_probe_src}"
     LINK_LIBRARIES OpenMP::OpenMP_Fortran
-    COMPILE_OUTPUT_VARIABLE _ftimer_openmp_compile_output
+    COMPILE_OUTPUT_VARIABLE _ftimer_openmp_run_compile_output
     RUN_OUTPUT_VARIABLE _ftimer_openmp_run_output
   )
 
   string(CONCAT _ftimer_openmp_details
     "compile_result='${_ftimer_openmp_compile_ok}'\n"
     "run_result='${_ftimer_openmp_run_result}'\n"
-    "compile_output:\n${_ftimer_openmp_compile_output}\n"
+    "compile_output:\n${_ftimer_openmp_compile_output}\n${_ftimer_openmp_run_compile_output}\n"
     "run_output:\n${_ftimer_openmp_run_output}"
   )
 
@@ -142,10 +181,16 @@ endfunction()
 # Options
 option(FTIMER_USE_MPI "Enable MPI support" OFF)
 option(FTIMER_USE_OPENMP "Enable OpenMP master-thread guards" OFF)
+option(
+  FTIMER_OPENMP_ASSUME_MASTER_PROBE_OK
+  "Assume the OpenMP master-thread runtime probe passes after compile/link succeeds; intended only for cross-compiling or execution-restricted packaging environments"
+  OFF
+)
 option(FTIMER_BUILD_TESTS "Build pFUnit tests (requires pFUnit)" OFF)
 option(FTIMER_BUILD_SMOKE_TESTS "Build Phase 0 smoke tests" ON)
 option(FTIMER_BUILD_EXAMPLES "Build example programs" ON)
 option(FTIMER_BUILD_BENCH "Build performance measurement harness" OFF)
+mark_as_advanced(FTIMER_OPENMP_ASSUME_MASTER_PROBE_OK)
 
 set(FTIMER_PACKAGE_VERSION_COMPATIBILITY SameMinorVersion)
 
@@ -178,6 +223,14 @@ endif()
 
 if(FTIMER_USE_OPENMP)
   set(FTIMER_VALIDATED_OPENMP_COMPILER_IDS GNU LLVMFlang)
+  if(CMAKE_VERSION VERSION_LESS 3.24 AND NOT CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    message(FATAL_ERROR
+      "FTIMER_USE_OPENMP=ON with LLVM Flang requires CMake 3.24 or newer so CMake reports compiler ID 'LLVMFlang'.\n"
+      "The active CMake version is ${CMAKE_VERSION}, and the active compiler ID is '${CMAKE_Fortran_COMPILER_ID}' at '${CMAKE_Fortran_COMPILER}'.\n"
+      "Supported paths: use GNU Fortran with this CMake version, or upgrade CMake for LLVM Flang OpenMP validation."
+    )
+  endif()
+
   if(NOT CMAKE_Fortran_COMPILER_ID IN_LIST FTIMER_VALIDATED_OPENMP_COMPILER_IDS)
     message(FATAL_ERROR
       "FTIMER_USE_OPENMP=ON is not currently validated for compiler ID '${CMAKE_Fortran_COMPILER_ID}'.\n"
@@ -202,6 +255,7 @@ if(FTIMER_USE_OPENMP)
     message(FATAL_ERROR
       "FTIMER_USE_OPENMP=ON requires a validated compiler/runtime pair that passes fTimer's master-thread-only OpenMP capability probe.\n"
       "The probe compiles, links, and runs a Fortran program using omp_lib, a two-thread parallel region, and !$omp master semantics.\n"
+      "For cross-compiling or execution-restricted package builds, maintainers may set FTIMER_OPENMP_ASSUME_MASTER_PROBE_OK=ON after independently validating equivalent runtime semantics for the selected compiler/runtime pair.\n"
       "Active compiler ID: '${CMAKE_Fortran_COMPILER_ID}' at '${CMAKE_Fortran_COMPILER}'.\n"
       "${FTIMER_OPENMP_MASTER_PROBE_DETAILS}"
     )

--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Minimum requirements:
 - pFUnit only when `FTIMER_BUILD_TESTS=ON`
 - An MPI wrapper/compiler pair only when `FTIMER_USE_MPI=ON`
 - GNU Fortran or LLVM Flang with a discoverable OpenMP runtime when `FTIMER_USE_OPENMP=ON`
+- CMake 3.24 or newer for the LLVM Flang OpenMP path
 
 ```bash
 # Smoke-test path (includes install/export consumer verification)
@@ -361,6 +362,10 @@ make test
 
 If CMake cannot discover LLVM Flang's OpenMP runtime automatically, pass
 `-DOpenMP_ROOT=/path/to/libomp` for that toolchain.
+Cross-compiling or execution-restricted package builds may set
+`-DFTIMER_OPENMP_ASSUME_MASTER_PROBE_OK=ON` only after independently validating
+equivalent OpenMP master-thread runtime semantics for the selected
+compiler/runtime pair.
 
 The smoke-test path also runs the enabled and disabled instrumentation facade examples so the documented compile-out strategy stays buildable.
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Minimum requirements:
 - A Fortran compiler with preprocess support
 - pFUnit only when `FTIMER_BUILD_TESTS=ON`
 - An MPI wrapper/compiler pair only when `FTIMER_USE_MPI=ON`
-- GNU Fortran only when `FTIMER_USE_OPENMP=ON`
+- GNU Fortran or LLVM Flang with a discoverable OpenMP runtime when `FTIMER_USE_OPENMP=ON`
 
 ```bash
 # Smoke-test path (includes install/export consumer verification)
@@ -342,10 +342,15 @@ FC=/path/to/mpi-mpifort cmake -B build-mpi -DFTIMER_USE_MPI=ON -DFTIMER_BUILD_TE
 cmake --build build-mpi
 cmake -E chdir build-mpi ctest --output-on-failure -L mpi
 
-# OpenMP build with pFUnit tests
+# OpenMP build with pFUnit tests (GNU Fortran)
 FC=gfortran cmake -B build-openmp -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build-openmp
 cmake -E chdir build-openmp ctest --output-on-failure
+
+# OpenMP smoke build (LLVM Flang)
+FC=flang-19 cmake -B build-openmp-flang -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=OFF
+cmake --build build-openmp-flang
+./build-openmp-flang/examples/openmp_example
 
 # Convenience Makefile wrapper
 make
@@ -354,6 +359,9 @@ make openmp
 make test
 ```
 
+If CMake cannot discover LLVM Flang's OpenMP runtime automatically, pass
+`-DOpenMP_ROOT=/path/to/libomp` for that toolchain.
+
 The smoke-test path also runs the enabled and disabled instrumentation facade examples so the documented compile-out strategy stays buildable.
 
 Supported toolchain matrix:
@@ -361,7 +369,7 @@ Supported toolchain matrix:
 - Serial smoke/library build: GNU Fortran and LLVM Flang are validated in automation
 - Serial plus pFUnit tests: GNU Fortran with a matching pFUnit installation
 - MPI: GNU Fortran wrapper compiler paths are validated with OpenMPI and MPICH; smoke/install-consumer coverage runs for both, and MPI pFUnit coverage runs for OpenMPI plus MPICH on hosted Ubuntu 22.04 with a matching MPICH-built pFUnit
-- OpenMP: GNU Fortran only for the documented master-thread-only carve-out
+- OpenMP: GNU Fortran with pFUnit guard coverage, plus LLVM Flang smoke/example coverage for the documented master-thread-only carve-out
 
 Other serial compilers may still work, but they are not part of the current release-validated matrix unless the repo adds direct automation for them.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -224,7 +224,7 @@ Supported local build paths today are:
 - serial smoke/library build validated with GNU Fortran and LLVM Flang
 - serial pFUnit tests with `gfortran` plus a matching pFUnit install
 - MPI builds through GNU Fortran MPI wrapper compilers, with CI smoke/install-consumer coverage for OpenMPI and MPICH and MPI pFUnit coverage for OpenMPI plus MPICH on hosted Ubuntu 22.04
-- OpenMP builds with `gfortran`
+- OpenMP builds with GNU Fortran and LLVM Flang for the master-thread-only carve-out; pFUnit OpenMP guard coverage remains on `gfortran`
 - benchmark harness builds with `FTIMER_BUILD_BENCH=ON`
 
 The top-level CMake options that shape those paths are:
@@ -240,7 +240,7 @@ The MPI and OpenMP enablement paths are guarded at configure time:
 
 - `FTIMER_USE_MPI=ON` requires a compiler/toolchain pair that can compile a minimal `mpi_f08` probe against the discovered MPI installation.
 - MPI builds also require the same `mpi_f08` path to compile the `MPI_Type_match_size`/`MPI_ERRORS_RETURN` validation calls used to select reduction datatypes for `real(wp)` and `integer(int64)`.
-- `FTIMER_USE_OPENMP=ON` is currently supported only with GNU Fortran and requires `OpenMP::OpenMP_Fortran` to resolve successfully.
+- `FTIMER_USE_OPENMP=ON` is admitted only for validated compiler IDs (`GNU` and `LLVMFlang` today), requires `OpenMP::OpenMP_Fortran` to resolve successfully, and runs a configure-time probe that compiles, links, and executes `omp_lib`, a two-thread parallel region, and `!$omp master` semantics.
 
 ### Test Categories
 
@@ -265,12 +265,13 @@ The default repository baseline is still the smoke/build-contract path. The full
 - `test-mpi`
 - `test-mpi-mpich`
 - `build-openmp`
+- `build-openmp-flang`
 - `test-openmp`
 - `build-contract-regressions`
 - `build-bench`
 - `lint`
 
-That means pFUnit-backed serial, OpenMPI MPI, MPICH MPI, and OpenMP test jobs are part of current CI now; they are not deferred future work. The issue #255 hosted-runner investigation found that Ubuntu 24.04's apt MPICH 4.2.0/Hydra launcher can start `/usr/bin/mpiexec.mpich -n 2` Fortran MPI programs as two singleton `MPI_COMM_WORLD` ranks on hosted runners, which made pFUnit report `Insufficient processes to run this test. (PE=0)` for `[npes=2]` cases. The MPICH CI jobs now run on hosted Ubuntu 22.04 and guard the launcher with a raw two-rank MPI probe before claiming coverage. The MPICH pFUnit job builds pFUnit v4.16.0 with `/usr/bin/mpifort.mpich`, verifies the installed package reports `PFUNIT_MPI_FOUND "TRUE"`, and runs both `ftimer_mpi_tests` and `ftimer_mpi_tests_4pe` through `/usr/bin/mpiexec.mpich`. The separate `build-mpi-mpich` job covers MPICH smoke/install-consumer behavior on the same runner family after the launcher probe. Local Homebrew MPICH 5.0.1 was not a valid reproduction path because it does not install `mpi_f08.mod`, so it fails fTimer's configure-time MPI contract probe. A GitHub-hosted NVHPC 26.3 serial smoke/install-consumer trial installed and built successfully, but the generated executables aborted at runtime with `DEALLOCATE: memory at (nil) not allocated`, so NVHPC validation remains deferred rather than claimed. The contract-regression job also verifies the configure-time MPI/OpenMP gates and the documented Makefile wrapper behavior.
+That means pFUnit-backed serial, OpenMPI MPI, MPICH MPI, GNU OpenMP guard, and LLVM Flang OpenMP smoke jobs are part of current CI now; they are not deferred future work. The issue #255 hosted-runner investigation found that Ubuntu 24.04's apt MPICH 4.2.0/Hydra launcher can start `/usr/bin/mpiexec.mpich -n 2` Fortran MPI programs as two singleton `MPI_COMM_WORLD` ranks on hosted runners, which made pFUnit report `Insufficient processes to run this test. (PE=0)` for `[npes=2]` cases. The MPICH CI jobs now run on hosted Ubuntu 22.04 and guard the launcher with a raw two-rank MPI probe before claiming coverage. The MPICH pFUnit job builds pFUnit v4.16.0 with `/usr/bin/mpifort.mpich`, verifies the installed package reports `PFUNIT_MPI_FOUND "TRUE"`, and runs both `ftimer_mpi_tests` and `ftimer_mpi_tests_4pe` through `/usr/bin/mpiexec.mpich`. The separate `build-mpi-mpich` job covers MPICH smoke/install-consumer behavior on the same runner family after the launcher probe. Local Homebrew MPICH 5.0.1 was not a valid reproduction path because it does not install `mpi_f08.mod`, so it fails fTimer's configure-time MPI contract probe. A GitHub-hosted NVHPC 26.3 serial smoke/install-consumer trial installed and built successfully, but the generated executables aborted at runtime with `DEALLOCATE: memory at (nil) not allocated`, so NVHPC validation remains deferred rather than claimed. The contract-regression job also verifies the configure-time MPI/OpenMP gates and the documented Makefile wrapper behavior.
 
 ## Maintainer Workflow
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -240,13 +240,13 @@ The MPI and OpenMP enablement paths are guarded at configure time:
 
 - `FTIMER_USE_MPI=ON` requires a compiler/toolchain pair that can compile a minimal `mpi_f08` probe against the discovered MPI installation.
 - MPI builds also require the same `mpi_f08` path to compile the `MPI_Type_match_size`/`MPI_ERRORS_RETURN` validation calls used to select reduction datatypes for `real(wp)` and `integer(int64)`.
-- `FTIMER_USE_OPENMP=ON` is admitted only for validated compiler IDs (`GNU` and `LLVMFlang` today), requires `OpenMP::OpenMP_Fortran` to resolve successfully, and runs a configure-time probe that compiles, links, and executes `omp_lib`, a two-thread parallel region, and `!$omp master` semantics.
+- `FTIMER_USE_OPENMP=ON` is admitted only for validated compiler IDs (`GNU` and `LLVMFlang` today), requires `OpenMP::OpenMP_Fortran` to resolve successfully, and runs a configure-time probe that compiles, links, and executes `omp_lib`, a two-thread parallel region, and `!$omp master` semantics. LLVM Flang OpenMP validation requires CMake 3.24 or newer so CMake reports compiler ID `LLVMFlang`; cross-compiling or execution-restricted package builds may use the advanced `FTIMER_OPENMP_ASSUME_MASTER_PROBE_OK` option only after independently validating equivalent runtime semantics for the selected compiler/runtime pair.
 
 ### Test Categories
 
 The current test inventory is:
 
-- smoke tests in `tests/test_phase0_smoke.F90`, runtime execution of `basic_usage`, MPI example execution when `FTIMER_USE_MPI=ON`, installed-package consumer build-and-run checks, and build-contract regression checks under `tests/check_*_contracts.cmake`
+- smoke tests in `tests/test_phase0_smoke.F90`, runtime execution of `basic_usage`, OpenMP example execution when `FTIMER_USE_OPENMP=ON`, MPI example execution when `FTIMER_USE_MPI=ON`, installed-package consumer build-and-run checks, and build-contract regression checks under `tests/check_*_contracts.cmake`
 - serial pFUnit tests for core behavior, summaries, callbacks, reset behavior, call-stack behavior, and procedural parity
 - MPI pFUnit tests under `tests/mpi/`, validated in CI with GNU Fortran against OpenMPI and MPICH
 - OpenMP guard tests enabled when `FTIMER_USE_OPENMP=ON`, covering the master-thread-only carve-out rather than general threaded timing support

--- a/docs/release.md
+++ b/docs/release.md
@@ -44,7 +44,7 @@ then require GitHub CI to pass before tagging.
 | Smoke/install path | Yes |
 | Serial pFUnit path | Yes when pFUnit is available |
 | MPI path | Yes when MPI and matching pFUnit are available |
-| OpenMP carve-out | Yes when OpenMP and matching pFUnit are available |
+| OpenMP carve-out | Yes: GNU pFUnit guard coverage when OpenMP and matching pFUnit are available; LLVM Flang smoke/example coverage when validating the OpenMP compiler matrix |
 | Bench harness | Yes for hot-path or summary-performance changes |
 | Formatting | Yes for source/test/example changes |
 | Diff hygiene | Yes |
@@ -83,6 +83,16 @@ FC=gfortran cmake -B build-openmp \
   -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build-openmp
 cmake -E chdir build-openmp ctest --output-on-failure
+
+FC=flang-19 cmake -B build-openmp-flang \
+  -DFTIMER_USE_OPENMP=ON \
+  -DFTIMER_BUILD_TESTS=OFF
+cmake --build build-openmp-flang
+cmake -E chdir build-openmp-flang ctest --output-on-failure \
+  -R '^(ftimer_openmp_example_smoke|ftimer_installed_package_consumer_openmp_flang)$'
+
+Add `-DOpenMP_ROOT=/path/to/libomp` on LLVM Flang platforms where CMake does
+not discover the OpenMP runtime automatically.
 
 cmake -S . -B build-bench \
   -DFTIMER_BUILD_BENCH=ON \

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -58,4 +58,8 @@ endif()
 if(FTIMER_USE_OPENMP)
   add_executable(openmp_example openmp_example.F90)
   target_link_libraries(openmp_example PRIVATE ftimer)
+
+  if(FTIMER_BUILD_SMOKE_TESTS)
+    add_test(NAME ftimer_openmp_example_smoke COMMAND openmp_example)
+  endif()
 endif()

--- a/examples/openmp_example.F90
+++ b/examples/openmp_example.F90
@@ -2,15 +2,26 @@ program openmp_example
    use ftimer, only: ftimer_finalize, ftimer_get_summary, ftimer_init, &
                      ftimer_print_summary, ftimer_start, ftimer_stop
    use ftimer_types, only: ftimer_summary_t
-   use omp_lib, only: omp_get_num_threads
+   use omp_lib, only: omp_get_num_threads, omp_get_thread_num, omp_set_dynamic
    implicit none
+   integer, parameter :: NOOP_IERR_SENTINEL = -100
    integer :: i
+   integer :: local_ierr
    integer :: nthreads
+   integer :: thread_num
+   integer :: worker_calls
+   integer :: worker_ierr_failures
    real :: accumulator
+   logical :: thread_seen(2)
    type(ftimer_summary_t) :: summary
+
+   call omp_set_dynamic(.false.)
 
    nthreads = 1
    accumulator = 0.0
+   thread_seen = .false.
+   worker_calls = 0
+   worker_ierr_failures = 0
 
    call ftimer_init()
 
@@ -18,22 +29,46 @@ program openmp_example
    ! stopping outside the !$omp parallel block. For asynchronous accelerator
    ! work, callers must synchronize device completion before stopping a timer.
    call ftimer_start("parallel_region")
-!$omp parallel default(none) shared(accumulator, nthreads) private(i)
+!$omp parallel num_threads(2) default(none) shared(accumulator, nthreads, thread_seen) &
+!$omp& private(i, local_ierr, thread_num) reduction(+:worker_calls, worker_ierr_failures)
+   thread_num = omp_get_thread_num()
+   if (thread_num + 1 <= size(thread_seen)) thread_seen(thread_num + 1) = .true.
+
    do i = 1, 150000
 !$omp atomic update
       accumulator = accumulator + real(i)
    end do
-!$omp single
+!$omp master
    nthreads = omp_get_num_threads()
-!$omp end single
+!$omp end master
 
    ! Misleading anti-pattern: placing ftimer_start/ftimer_stop inside this
    ! parallel region does not collect per-thread timings. Worker-thread calls
    ! are silent no-ops under the supported FTIMER_USE_OPENMP contract.
+   if (thread_num /= 0) then
+      local_ierr = NOOP_IERR_SENTINEL
+      call ftimer_start("worker_only", ierr=local_ierr)
+      if (local_ierr /= NOOP_IERR_SENTINEL) worker_ierr_failures = worker_ierr_failures + 1
+
+      local_ierr = NOOP_IERR_SENTINEL
+      call ftimer_stop("worker_only", ierr=local_ierr)
+      if (local_ierr /= NOOP_IERR_SENTINEL) worker_ierr_failures = worker_ierr_failures + 1
+
+      worker_calls = worker_calls + 1
+   end if
 !$omp end parallel
    call ftimer_stop("parallel_region")
 
    call ftimer_get_summary(summary)
+   if (.not. thread_seen(1)) error stop "OpenMP master thread was not observed"
+   if (.not. thread_seen(2)) error stop "OpenMP worker thread was not observed"
+   if (nthreads < 2) error stop "OpenMP example did not run with at least two threads"
+   if (worker_calls < 1) error stop "OpenMP worker no-op path was not exercised"
+   if (worker_ierr_failures /= 0) error stop "OpenMP worker no-op path changed ierr"
+   if (summary%num_entries /= 1) error stop "OpenMP example expected exactly one recorded timer"
+   if (trim(summary%entries(1)%name) /= "parallel_region") error stop "OpenMP example recorded the wrong timer"
+   if (summary%entries(1)%call_count /= 1) error stop "OpenMP example expected one timer call"
+
    print '(a)', "fTimer OpenMP support is limited to master-thread-only region bracketing."
    print '(a)', "This example measures one parallel region wall-clock interval,"
    print '(a)', "not per-thread timings."

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ function(ftimer_add_installed_consumer_test test_name test_binary_dir)
     INSTALL_ONLY
     USE_DESTDIR
   )
-  set(oneValueArgs INSTALL_INCLUDEDIR REQUIRED_COMPILER_NAMES)
+  set(oneValueArgs INSTALL_INCLUDEDIR OPENMP_ROOT REQUIRED_COMPILER_NAMES)
   cmake_parse_arguments(FTIMER_CONSUMER "${options}" "${oneValueArgs}" "" ${ARGN})
 
   add_test(NAME ${test_name}
@@ -34,6 +34,7 @@ function(ftimer_add_installed_consumer_test test_name test_binary_dir)
       -DTEST_USE_DESTDIR=${FTIMER_CONSUMER_USE_DESTDIR}
       -DTEST_ENABLE_MPI=${FTIMER_CONSUMER_ENABLE_MPI}
       -DTEST_ENABLE_OPENMP=${FTIMER_CONSUMER_ENABLE_OPENMP}
+      -DTEST_OPENMP_ROOT=${FTIMER_CONSUMER_OPENMP_ROOT}
       -DTEST_EXECUTABLE_SUFFIX=${CMAKE_EXECUTABLE_SUFFIX}
       -DTEST_PACKAGE_VERSION=${PROJECT_VERSION}
       -DTEST_PACKAGE_VERSION_MAJOR=${PROJECT_VERSION_MAJOR}
@@ -130,12 +131,29 @@ if(FTIMER_BUILD_SMOKE_TESTS)
     ENABLE_OPENMP
   )
 
+  if(FTIMER_USE_OPENMP)
+    set(ftimer_openmp_flang_consumer_args
+      REQUIRED_COMPILER_NAMES flang-19,flang-new-19,flang-new,flang
+      ENABLE_OPENMP
+    )
+    if(DEFINED OpenMP_ROOT AND NOT OpenMP_ROOT STREQUAL "")
+      list(APPEND ftimer_openmp_flang_consumer_args OPENMP_ROOT ${OpenMP_ROOT})
+    endif()
+
+    ftimer_add_installed_consumer_test(
+      ftimer_installed_package_consumer_openmp_flang
+      ${CMAKE_CURRENT_BINARY_DIR}/installed_package_consumer_openmp_flang
+      ${ftimer_openmp_flang_consumer_args}
+    )
+  endif()
+
   add_test(NAME ftimer_configure_contracts
     COMMAND ${CMAKE_COMMAND}
       -DREPO_ROOT=${CMAKE_SOURCE_DIR}
       -DTEST_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}/configure_contracts
       -DCMAKE_GENERATOR=${CMAKE_GENERATOR}
       -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
+      -DFTIMER_REQUIRE_FLANG_OPENMP_CONTRACT=${FTIMER_REQUIRE_FLANG_OPENMP_CONTRACT}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/check_configure_contracts.cmake
   )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 function(ftimer_add_installed_consumer_test test_name test_binary_dir)
   set(options
+    ALLOW_CONFIGURE_SKIP
     CLEAN_INSTALL_INCLUDEDIR
     ENABLE_MPI
     ENABLE_OPENMP
@@ -35,6 +36,7 @@ function(ftimer_add_installed_consumer_test test_name test_binary_dir)
       -DTEST_ENABLE_MPI=${FTIMER_CONSUMER_ENABLE_MPI}
       -DTEST_ENABLE_OPENMP=${FTIMER_CONSUMER_ENABLE_OPENMP}
       -DTEST_OPENMP_ROOT=${FTIMER_CONSUMER_OPENMP_ROOT}
+      -DTEST_ALLOW_CONFIGURE_SKIP=${FTIMER_CONSUMER_ALLOW_CONFIGURE_SKIP}
       -DTEST_EXECUTABLE_SUFFIX=${CMAKE_EXECUTABLE_SUFFIX}
       -DTEST_PACKAGE_VERSION=${PROJECT_VERSION}
       -DTEST_PACKAGE_VERSION_MAJOR=${PROJECT_VERSION_MAJOR}
@@ -138,6 +140,9 @@ if(FTIMER_BUILD_SMOKE_TESTS)
     )
     if(DEFINED OpenMP_ROOT AND NOT OpenMP_ROOT STREQUAL "")
       list(APPEND ftimer_openmp_flang_consumer_args OPENMP_ROOT ${OpenMP_ROOT})
+    endif()
+    if(NOT FTIMER_REQUIRE_FLANG_OPENMP_CONTRACT)
+      list(APPEND ftimer_openmp_flang_consumer_args ALLOW_CONFIGURE_SKIP)
     endif()
 
     ftimer_add_installed_consumer_test(

--- a/tests/check_configure_contracts.cmake
+++ b/tests/check_configure_contracts.cmake
@@ -236,6 +236,11 @@ if(ftimer_openmp_compiler_gate_pos GREATER ftimer_openmp_find_package_pos)
     "FTIMER_USE_OPENMP=ON must reject unvalidated compiler IDs before OpenMP runtime discovery."
   )
 endif()
+if(NOT ftimer_root_cmake MATCHES "FTIMER_USE_OPENMP=ON is not currently validated for compiler ID")
+  message(FATAL_ERROR
+    "FTIMER_USE_OPENMP=ON configure coverage must keep a clear diagnostic for unvalidated compiler IDs."
+  )
+endif()
 if(NOT ftimer_root_cmake MATCHES "ftimer_try_run_openmp_master_probe")
   message(FATAL_ERROR
     "FTIMER_USE_OPENMP=ON configure coverage must run fTimer's OpenMP master-thread capability probe."

--- a/tests/check_configure_contracts.cmake
+++ b/tests/check_configure_contracts.cmake
@@ -84,6 +84,33 @@ function(ftimer_expect_configure_success label compiler)
   endif()
 endfunction()
 
+function(ftimer_try_configure_success out_var label compiler)
+  set(extra_args ${ARGN})
+  set(build_dir "${TEST_BINARY_DIR}/${label}")
+
+  file(REMOVE_RECURSE "${build_dir}")
+
+  ftimer_append_common_configure_args(configure_args)
+  list(APPEND configure_args
+    -B "${build_dir}"
+    -DCMAKE_Fortran_COMPILER=${compiler}
+  )
+  list(APPEND configure_args ${extra_args})
+
+  execute_process(
+    COMMAND "${CMAKE_COMMAND}" ${configure_args}
+    RESULT_VARIABLE configure_result
+    OUTPUT_VARIABLE configure_stdout
+    ERROR_VARIABLE configure_stderr
+  )
+
+  if(configure_result EQUAL 0)
+    set(${out_var} TRUE PARENT_SCOPE)
+  else()
+    set(${out_var} FALSE PARENT_SCOPE)
+  endif()
+endfunction()
+
 function(ftimer_try_configure_failure out_var label compiler required_text)
   set(extra_args ${ARGN})
   set(build_dir "${TEST_BINARY_DIR}/${label}")
@@ -184,6 +211,31 @@ if(NOT ftimer_root_cmake MATCHES "FTIMER_VALIDATED_OPENMP_COMPILER_IDS[^\n]*GNU[
     "FTIMER_USE_OPENMP=ON configure coverage must keep the validated compiler-ID policy explicit for GNU and LLVMFlang."
   )
 endif()
+string(FIND
+  "${ftimer_root_cmake}"
+  "if(NOT CMAKE_Fortran_COMPILER_ID IN_LIST FTIMER_VALIDATED_OPENMP_COMPILER_IDS)"
+  ftimer_openmp_compiler_gate_pos
+)
+string(FIND
+  "${ftimer_root_cmake}"
+  "find_package(OpenMP COMPONENTS Fortran)"
+  ftimer_openmp_find_package_pos
+)
+if(ftimer_openmp_compiler_gate_pos EQUAL -1)
+  message(FATAL_ERROR
+    "FTIMER_USE_OPENMP=ON configure coverage must enforce the validated compiler-ID gate."
+  )
+endif()
+if(ftimer_openmp_find_package_pos EQUAL -1)
+  message(FATAL_ERROR
+    "FTIMER_USE_OPENMP=ON configure coverage must still discover OpenMP::OpenMP_Fortran."
+  )
+endif()
+if(ftimer_openmp_compiler_gate_pos GREATER ftimer_openmp_find_package_pos)
+  message(FATAL_ERROR
+    "FTIMER_USE_OPENMP=ON must reject unvalidated compiler IDs before OpenMP runtime discovery."
+  )
+endif()
 if(NOT ftimer_root_cmake MATCHES "ftimer_try_run_openmp_master_probe")
   message(FATAL_ERROR
     "FTIMER_USE_OPENMP=ON configure coverage must run fTimer's OpenMP master-thread capability probe."
@@ -227,11 +279,22 @@ if(ftimer_flang_compiler)
     list(APPEND ftimer_flang_openmp_args -DOpenMP_ROOT=/usr/lib/llvm-19)
   endif()
 
-  ftimer_expect_configure_success(
+  ftimer_try_configure_success(
+    flang_openmp_configure_ok
     openmp_allows_validated_flang
     "${ftimer_flang_compiler}"
     ${ftimer_flang_openmp_args}
   )
+
+  if(NOT flang_openmp_configure_ok AND FTIMER_REQUIRE_FLANG_OPENMP_CONTRACT)
+    message(FATAL_ERROR
+      "Required LLVM Flang OpenMP configure success regression failed. Ensure the CI contract job installs libomp and passes a usable OpenMP_ROOT when needed."
+    )
+  elseif(NOT flang_openmp_configure_ok)
+    message(STATUS
+      "Skipping LLVM Flang OpenMP configure success regression: Flang is present, but CMake could not configure fTimer with the locally discoverable OpenMP runtime."
+    )
+  endif()
 else()
   message(STATUS
     "Skipping LLVM Flang OpenMP configure success regression: flang-19/flang-new/flang is not available on PATH."

--- a/tests/check_configure_contracts.cmake
+++ b/tests/check_configure_contracts.cmake
@@ -55,6 +55,35 @@ function(ftimer_expect_configure_failure label compiler required_text)
   endif()
 endfunction()
 
+function(ftimer_expect_configure_success label compiler)
+  set(extra_args ${ARGN})
+  set(build_dir "${TEST_BINARY_DIR}/${label}")
+
+  file(REMOVE_RECURSE "${build_dir}")
+
+  ftimer_append_common_configure_args(configure_args)
+  list(APPEND configure_args
+    -B "${build_dir}"
+    -DCMAKE_Fortran_COMPILER=${compiler}
+  )
+  list(APPEND configure_args ${extra_args})
+
+  execute_process(
+    COMMAND "${CMAKE_COMMAND}" ${configure_args}
+    RESULT_VARIABLE configure_result
+    OUTPUT_VARIABLE configure_stdout
+    ERROR_VARIABLE configure_stderr
+  )
+
+  string(CONCAT configure_output "${configure_stdout}" "\n" "${configure_stderr}")
+
+  if(NOT configure_result EQUAL 0)
+    message(FATAL_ERROR
+      "Expected '${label}' configure to succeed, but it failed.\n${configure_output}"
+    )
+  endif()
+endfunction()
+
 function(ftimer_try_configure_failure out_var label compiler required_text)
   set(extra_args ${ARGN})
   set(build_dir "${TEST_BINARY_DIR}/${label}")
@@ -119,12 +148,14 @@ endif()
 
 find_program(ftimer_mpifort_compiler NAMES mpifort mpif90 mpif77)
 find_program(ftimer_gfortran_compiler NAMES gfortran)
-find_program(ftimer_unsupported_compiler NAMES flang-new-19 flang-19 flang-new-18 flang-18 flang-new flang)
+find_program(ftimer_plain_nonmpi_compiler NAMES flang-new-19 flang-19 flang-new-18 flang-18 flang-new flang)
+find_program(ftimer_flang_compiler NAMES flang-19 flang-new-19 flang-new flang)
+find_program(ftimer_unvalidated_openmp_compiler NAMES nvfortran ifx ifort nagfor lfortran)
 
-if(ftimer_unsupported_compiler AND ftimer_mpifort_compiler)
+if(ftimer_plain_nonmpi_compiler AND ftimer_mpifort_compiler)
   ftimer_expect_configure_failure(
     mpi_requires_wrapper_compiler
-    "${ftimer_unsupported_compiler}"
+    "${ftimer_plain_nonmpi_compiler}"
     "failed a configure-time MPI probe"
     -DFTIMER_USE_MPI=ON
   )
@@ -148,15 +179,74 @@ else()
   )
 endif()
 
-if(ftimer_unsupported_compiler)
-  ftimer_expect_configure_failure(
-    openmp_requires_gnu
-    "${ftimer_unsupported_compiler}"
-    "FTIMER_USE_OPENMP=ON is currently supported only with GNU Fortran"
+if(NOT ftimer_root_cmake MATCHES "FTIMER_VALIDATED_OPENMP_COMPILER_IDS[^\n]*GNU[^\n]*LLVMFlang")
+  message(FATAL_ERROR
+    "FTIMER_USE_OPENMP=ON configure coverage must keep the validated compiler-ID policy explicit for GNU and LLVMFlang."
+  )
+endif()
+if(NOT ftimer_root_cmake MATCHES "ftimer_try_run_openmp_master_probe")
+  message(FATAL_ERROR
+    "FTIMER_USE_OPENMP=ON configure coverage must run fTimer's OpenMP master-thread capability probe."
+  )
+endif()
+if(NOT ftimer_root_cmake MATCHES "use omp_lib")
+  message(FATAL_ERROR
+    "FTIMER_USE_OPENMP=ON configure coverage must probe omp_lib availability."
+  )
+endif()
+if(NOT ftimer_root_cmake MATCHES "!\\$omp parallel")
+  message(FATAL_ERROR
+    "FTIMER_USE_OPENMP=ON configure coverage must probe an OpenMP parallel region."
+  )
+endif()
+if(NOT ftimer_root_cmake MATCHES "!\\$omp master")
+  message(FATAL_ERROR
+    "FTIMER_USE_OPENMP=ON configure coverage must probe OpenMP master semantics."
+  )
+endif()
+
+if(ftimer_gfortran_compiler)
+  ftimer_expect_configure_success(
+    openmp_allows_validated_gnu
+    "${ftimer_gfortran_compiler}"
     -DFTIMER_USE_OPENMP=ON
   )
 else()
   message(STATUS
-    "Skipping OpenMP configure gate regression: no unsupported non-GNU Fortran compiler found on PATH."
+    "Skipping GNU OpenMP configure success regression: gfortran is not available on PATH."
+  )
+endif()
+
+if(ftimer_flang_compiler)
+  set(ftimer_flang_openmp_args -DFTIMER_USE_OPENMP=ON)
+  if(EXISTS "/opt/homebrew/opt/libomp")
+    list(APPEND ftimer_flang_openmp_args -DOpenMP_ROOT=/opt/homebrew/opt/libomp)
+  elseif(EXISTS "/usr/local/opt/libomp")
+    list(APPEND ftimer_flang_openmp_args -DOpenMP_ROOT=/usr/local/opt/libomp)
+  elseif(EXISTS "/usr/lib/llvm-19")
+    list(APPEND ftimer_flang_openmp_args -DOpenMP_ROOT=/usr/lib/llvm-19)
+  endif()
+
+  ftimer_expect_configure_success(
+    openmp_allows_validated_flang
+    "${ftimer_flang_compiler}"
+    ${ftimer_flang_openmp_args}
+  )
+else()
+  message(STATUS
+    "Skipping LLVM Flang OpenMP configure success regression: flang-19/flang-new/flang is not available on PATH."
+  )
+endif()
+
+if(ftimer_unvalidated_openmp_compiler)
+  ftimer_expect_configure_failure(
+    openmp_rejects_unvalidated_compiler
+    "${ftimer_unvalidated_openmp_compiler}"
+    "not currently validated for compiler ID"
+    -DFTIMER_USE_OPENMP=ON
+  )
+else()
+  message(STATUS
+    "Skipping unvalidated OpenMP compiler rejection regression: no nvfortran/ifx/ifort/nagfor/lfortran compiler found on PATH."
   )
 endif()

--- a/tests/check_installed_package_consumer.cmake
+++ b/tests/check_installed_package_consumer.cmake
@@ -118,6 +118,12 @@ execute_process(
   RESULT_VARIABLE producer_configure_result
 )
 if(NOT producer_configure_result EQUAL 0)
+  if(TEST_ALLOW_CONFIGURE_SKIP)
+    message(STATUS
+      "Skipping ${test_name}: producer configure failed for the optional compiler/runtime path."
+    )
+    return()
+  endif()
   message(FATAL_ERROR "Failed to configure the producer install tree.")
 endif()
 

--- a/tests/check_installed_package_consumer.cmake
+++ b/tests/check_installed_package_consumer.cmake
@@ -97,6 +97,10 @@ if(TEST_ENABLE_OPENMP)
   list(APPEND configure_args -DFTIMER_USE_OPENMP=ON)
 endif()
 
+if(DEFINED TEST_OPENMP_ROOT AND NOT TEST_OPENMP_ROOT STREQUAL "")
+  list(APPEND configure_args -DOpenMP_ROOT=${TEST_OPENMP_ROOT})
+endif()
+
 if(DEFINED CMAKE_MAKE_PROGRAM AND NOT CMAKE_MAKE_PROGRAM STREQUAL "")
   list(APPEND configure_args -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM})
 endif()
@@ -251,6 +255,9 @@ target_link_libraries(ftimer_integer_mpi_comm_rejection PRIVATE fTimer::ftimer)
     -G "${CMAKE_GENERATOR}"
     -DCMAKE_PREFIX_PATH=${install_prefix}
   )
+  if(DEFINED TEST_OPENMP_ROOT AND NOT TEST_OPENMP_ROOT STREQUAL "")
+    list(APPEND probe_configure_args -DOpenMP_ROOT=${TEST_OPENMP_ROOT})
+  endif()
   if(DEFINED CMAKE_MAKE_PROGRAM AND NOT CMAKE_MAKE_PROGRAM STREQUAL "")
     list(APPEND probe_configure_args -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM})
   endif()
@@ -437,6 +444,9 @@ find_package(fTimer @requested_version@ CONFIG REQUIRED
     -G "${CMAKE_GENERATOR}"
     -DCMAKE_PREFIX_PATH=${prefix_path}
   )
+  if(DEFINED TEST_OPENMP_ROOT AND NOT TEST_OPENMP_ROOT STREQUAL "")
+    list(APPEND version_probe_configure_args -DOpenMP_ROOT=${TEST_OPENMP_ROOT})
+  endif()
   if(DEFINED CMAKE_MAKE_PROGRAM AND NOT CMAKE_MAKE_PROGRAM STREQUAL "")
     list(APPEND version_probe_configure_args -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM})
   endif()
@@ -571,6 +581,10 @@ set(consumer_configure_args
   -DCMAKE_PREFIX_PATH=${install_prefix}
   -DFTIMER_CONSUMER_ENABLE_MPI=${TEST_ENABLE_MPI}
 )
+
+if(DEFINED TEST_OPENMP_ROOT AND NOT TEST_OPENMP_ROOT STREQUAL "")
+  list(APPEND consumer_configure_args -DOpenMP_ROOT=${TEST_OPENMP_ROOT})
+endif()
 
 if(DEFINED CMAKE_MAKE_PROGRAM AND NOT CMAKE_MAKE_PROGRAM STREQUAL "")
   list(APPEND consumer_configure_args -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM})


### PR DESCRIPTION
## Summary

Closes #246.

This PR replaces the GNU-only `FTIMER_USE_OPENMP=ON` compiler-ID gate with a validated-toolchain policy plus a configure-time capability probe for the existing master-thread-only OpenMP carve-out.

Changes:
- admit only validated OpenMP compiler IDs: `GNU` and `LLVMFlang`
- require `OpenMP::OpenMP_Fortran` for admitted compilers
- run a configure-time Fortran OpenMP probe covering `omp_lib`, a two-thread parallel region, and `!$omp master` semantics
- keep unvalidated compiler IDs rejected with an explicit diagnostic
- add an OpenMP example smoke test and a CI Flang OpenMP smoke job
- update configure-contract tests and supported-toolchain documentation

## Compiler Policy

`FTIMER_USE_OPENMP=ON` is now supported for:
- GNU Fortran, with existing pFUnit OpenMP guard coverage
- LLVM Flang, with smoke/example coverage and the configure-time master-thread probe

Other compilers remain unvalidated and fail at configure time until they are explicitly proven by the same probe plus smoke coverage. NVHPC/nvfortran remains deferred and non-blocking.

## Validation

Local validation run on macOS/Homebrew:

- `ctest --test-dir build-issue246-contract --output-on-failure -R '^ftimer_configure_contracts$'` — passed
- `FC=gfortran cmake -B build-issue246-openmp-gnu -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/opt/homebrew/PFUNIT-4.16` — passed
- `cmake --build build-issue246-openmp-gnu -j4` — passed
- `ctest --test-dir build-issue246-openmp-gnu --output-on-failure -R '^ftimer_serial_tests$'` — passed
- `ctest --test-dir build-issue246-openmp-gnu --output-on-failure --no-tests=error -R '^ftimer_openmp_example_smoke$'` — passed
- `./build-issue246-openmp-gnu/examples/openmp_example` — passed, recorded one `parallel_region` timer
- `FC=flang-new cmake -B build-issue246-openmp-flang -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=OFF -DOpenMP_ROOT=/opt/homebrew/opt/libomp` — passed
- `cmake --build build-issue246-openmp-flang -j4` — passed
- `ctest --test-dir build-issue246-openmp-flang --output-on-failure --no-tests=error -R '^ftimer_openmp_example_smoke$'` — passed
- `./build-issue246-openmp-flang/examples/openmp_example` — passed, recorded one `parallel_region` timer
- `ctest --test-dir build-issue246-contract --output-on-failure -R '^ftimer_openmp_option_off_ignores_global_flags$'` — passed
- `FC=flang-new cmake -B build-issue246-openmp-flang-no-root -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=OFF` — failed as expected with the new clear OpenMP runtime diagnostic
- `git diff --check` — passed