### PR TITLE
Add MPI+OpenMP validation coverage for #243

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,30 @@ jobs:
           ctest --test-dir build --output-on-failure --no-tests=error -R '^ftimer_mpi_example_smoke$'
           ctest --test-dir build --output-on-failure --no-tests=error -R '^ftimer_installed_package_consumer_mpi$'
 
+  build-mpi-openmp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gfortran cmake libopenmpi-dev openmpi-bin
+
+      # Hybrid smoke validates that the current MPI and OpenMP compatibility
+      # options can coexist. It does not claim true worker-thread timing.
+      - name: Configure (MPI+OpenMP)
+        run: FC=mpifort cmake -B build -DFTIMER_USE_MPI=ON -DFTIMER_USE_OPENMP=ON
+
+      - name: Build
+        run: cmake --build build -j$(nproc)
+
+      - name: Smoke test
+        run: ctest --test-dir build --output-on-failure
+
+      - name: Verify MPI+OpenMP installed-consumer coverage
+        run: ctest --test-dir build --output-on-failure --no-tests=error -R '^ftimer_installed_package_consumer_mpi_openmp$'
+
   test-serial:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,11 @@ FC=/path/to/mpi-mpifort cmake -B build-mpi -DFTIMER_USE_MPI=ON -DFTIMER_BUILD_TE
 cmake --build build-mpi
 cmake -E chdir build-mpi ctest --output-on-failure -L mpi
 
+# MPI+OpenMP compatibility smoke build (does not enable true worker timing)
+FC=mpifort cmake -B build-mpi-openmp -DFTIMER_USE_MPI=ON -DFTIMER_USE_OPENMP=ON
+cmake --build build-mpi-openmp
+cmake -E chdir build-mpi-openmp ctest --output-on-failure
+
 # OpenMP guard build with pFUnit coverage (GNU Fortran)
 FC=gfortran cmake -B build-openmp -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build-openmp
@@ -70,6 +75,7 @@ Supported toolchain matrix:
 - MPI: GNU Fortran wrapper compiler paths are validated with OpenMPI and MPICH. Smoke/install-consumer coverage runs for both, and MPI pFUnit coverage runs for OpenMPI plus MPICH on hosted Ubuntu 22.04 with a matching MPICH-built pFUnit. `FTIMER_USE_MPI=ON` now runs a configure-time `mpi_f08` probe and fails early if the active compiler cannot consume the discovered MPI module files.
 - OpenMP: GNU Fortran (`gfortran`) with pFUnit guard coverage, plus LLVM Flang smoke/example coverage for the documented master-thread-only carve-out.
   LLVM Flang OpenMP validation requires CMake 3.24 or newer so CMake reports compiler ID `LLVMFlang`.
+- MPI+OpenMP: OpenMPI wrapper builds with OpenMP are smoke-tested for current compatibility mode only, including an MPI-initialized OpenMP installed consumer; this does not validate true worker-thread timing or hybrid rank/lane reductions.
 
 Other serial compilers may still work, but they are not part of the current release-validated matrix unless the repo adds direct automation for them.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,11 @@ FC=/path/to/mpi-mpifort cmake -B build-mpi -DFTIMER_USE_MPI=ON -DFTIMER_BUILD_TE
 cmake --build build-mpi
 cmake -E chdir build-mpi ctest --output-on-failure -L mpi
 
+# MPI+OpenMP compatibility smoke build (does not enable true worker timing)
+FC=mpifort cmake -B build-mpi-openmp -DFTIMER_USE_MPI=ON -DFTIMER_USE_OPENMP=ON
+cmake --build build-mpi-openmp
+cmake -E chdir build-mpi-openmp ctest --output-on-failure
+
 # OpenMP guard build with pFUnit coverage (GNU Fortran)
 FC=gfortran cmake -B build-openmp -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build-openmp
@@ -70,6 +75,7 @@ Supported toolchain matrix:
 - MPI: GNU Fortran wrapper compiler paths are validated with OpenMPI and MPICH. Smoke/install-consumer coverage runs for both, and MPI pFUnit coverage runs for OpenMPI plus MPICH on hosted Ubuntu 22.04 with a matching MPICH-built pFUnit. `FTIMER_USE_MPI=ON` now runs a configure-time `mpi_f08` probe and fails early if the active compiler cannot consume the discovered MPI module files.
 - OpenMP: GNU Fortran (`gfortran`) with pFUnit guard coverage, plus LLVM Flang smoke/example coverage for the documented master-thread-only carve-out.
   LLVM Flang OpenMP validation requires CMake 3.24 or newer so CMake reports compiler ID `LLVMFlang`.
+- MPI+OpenMP: OpenMPI wrapper builds with OpenMP are smoke-tested for current compatibility mode only, including an MPI-initialized OpenMP installed consumer; this does not validate true worker-thread timing or hybrid rank/lane reductions.
 
 Other serial compilers may still work, but they are not part of the current release-validated matrix unless the repo adds direct automation for them.
 

--- a/README.md
+++ b/README.md
@@ -343,6 +343,11 @@ FC=/path/to/mpi-mpifort cmake -B build-mpi -DFTIMER_USE_MPI=ON -DFTIMER_BUILD_TE
 cmake --build build-mpi
 cmake -E chdir build-mpi ctest --output-on-failure -L mpi
 
+# MPI+OpenMP compatibility smoke build (does not enable true worker timing)
+FC=mpifort cmake -B build-mpi-openmp -DFTIMER_USE_MPI=ON -DFTIMER_USE_OPENMP=ON
+cmake --build build-mpi-openmp
+cmake -E chdir build-mpi-openmp ctest --output-on-failure
+
 # OpenMP build with pFUnit tests (GNU Fortran)
 FC=gfortran cmake -B build-openmp -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 cmake --build build-openmp
@@ -375,6 +380,7 @@ Supported toolchain matrix:
 - Serial plus pFUnit tests: GNU Fortran with a matching pFUnit installation
 - MPI: GNU Fortran wrapper compiler paths are validated with OpenMPI and MPICH; smoke/install-consumer coverage runs for both, and MPI pFUnit coverage runs for OpenMPI plus MPICH on hosted Ubuntu 22.04 with a matching MPICH-built pFUnit
 - OpenMP: GNU Fortran with pFUnit guard coverage, plus LLVM Flang smoke/example coverage for the documented master-thread-only carve-out
+- MPI+OpenMP: OpenMPI wrapper builds with OpenMP are smoke-tested for current compatibility mode only, including an MPI-initialized OpenMP installed consumer; this does not validate true worker-thread timing or hybrid rank/lane reductions
 
 Other serial compilers may still work, but they are not part of the current release-validated matrix unless the repo adds direct automation for them.
 
@@ -398,7 +404,19 @@ Use a separate build directory for each compiler or mode. Reconfiguring the same
 - `FTIMER_USE_OPENMP=ON` enables only limited master-thread-only guards. Worker-thread timer calls inside an OpenMP parallel region are silent no-ops. To time a parallel region as a whole, place `start`/`stop` outside the `!$omp parallel` block.
 - `FTIMER_USE_OPENMP` is the source-level switch for that carve-out; global OpenMP compiler flags alone do not enable the guards when the option is `OFF`.
 - The OpenMP path does not make fTimer thread-safe, does not provide thread-local timer instances, and should not be read as a general hybrid MPI+OpenMP timing model.
-- Future real hybrid MPI+OpenMP timing is tracked separately from the current compatibility mode; see [`docs/openmp-hybrid-strategy-decision.md`](docs/openmp-hybrid-strategy-decision.md), the opt-in API direction in [`docs/openmp-hybrid-api-design.md`](docs/openmp-hybrid-api-design.md), the thread-lane runtime model in [`docs/openmp-thread-lane-runtime-design.md`](docs/openmp-thread-lane-runtime-design.md), the summary/self-time model in [`docs/openmp-hybrid-summary-design.md`](docs/openmp-hybrid-summary-design.md), and the MPI+OpenMP reduction model in [`docs/openmp-hybrid-mpi-reduction-design.md`](docs/openmp-hybrid-mpi-reduction-design.md).
+- Future real hybrid MPI+OpenMP timing is tracked separately from the current
+  compatibility mode; see
+  [`docs/openmp-hybrid-strategy-decision.md`](docs/openmp-hybrid-strategy-decision.md),
+  the opt-in API direction in
+  [`docs/openmp-hybrid-api-design.md`](docs/openmp-hybrid-api-design.md),
+  the thread-lane runtime model in
+  [`docs/openmp-thread-lane-runtime-design.md`](docs/openmp-thread-lane-runtime-design.md),
+  the summary/self-time model in
+  [`docs/openmp-hybrid-summary-design.md`](docs/openmp-hybrid-summary-design.md),
+  the MPI+OpenMP reduction model in
+  [`docs/openmp-hybrid-mpi-reduction-design.md`](docs/openmp-hybrid-mpi-reduction-design.md),
+  and the validation plan in
+  [`docs/openmp-hybrid-validation-plan.md`](docs/openmp-hybrid-validation-plan.md).
 - `on_event` remains a lightweight intra-run hook, not a serious profiler-backend integration contract with stable semantic timer identity.
 - If `FTIMER_USE_MPI=OFF`, `mpi_summary()` and `mpi_union_summary()` return `FTIMER_ERR_NOT_IMPLEMENTED` and leave their MPI result objects empty. MPI report APIs, including the sparse union report and CSV APIs, return `FTIMER_ERR_NOT_IMPLEMENTED` without emitting report output or creating/replacing report files.
 - Formatted local and MPI report output are separate paths: `print_summary()`/`write_summary()` are local, `print_mpi_summary()`/`write_mpi_summary()` are strict MPI reports, and `print_mpi_union_summary()`/`write_mpi_union_summary()` are opt-in sparse MPI union reports. MPI reports are deliberately abbreviated; `ftimer_mpi_summary_t` and `ftimer_mpi_union_summary_t` remain the complete structured data models.

--- a/docs/design.md
+++ b/docs/design.md
@@ -225,6 +225,7 @@ Supported local build paths today are:
 - serial pFUnit tests with `gfortran` plus a matching pFUnit install
 - MPI builds through GNU Fortran MPI wrapper compilers, with CI smoke/install-consumer coverage for OpenMPI and MPICH and MPI pFUnit coverage for OpenMPI plus MPICH on hosted Ubuntu 22.04
 - OpenMP builds with GNU Fortran and LLVM Flang for the master-thread-only carve-out; pFUnit OpenMP guard coverage remains on `gfortran`
+- MPI+OpenMP build-only smoke coverage for the current compatibility mode, proving the existing MPI and OpenMP feature flags can coexist without claiming true worker-thread timing
 - benchmark harness builds with `FTIMER_BUILD_BENCH=ON`
 
 The top-level CMake options that shape those paths are:
@@ -250,6 +251,7 @@ The current test inventory is:
 - serial pFUnit tests for core behavior, summaries, callbacks, reset behavior, call-stack behavior, and procedural parity
 - MPI pFUnit tests under `tests/mpi/`, validated in CI with GNU Fortran against OpenMPI and MPICH
 - OpenMP guard tests enabled when `FTIMER_USE_OPENMP=ON`, covering the master-thread-only carve-out rather than general threaded timing support
+- MPI+OpenMP installed-consumer smoke coverage for the current exported-package dependency story, including an MPI-initialized OpenMP region that preserves worker no-op behavior
 
 The default repository baseline is still the smoke/build-contract path. The full behavioral suite is enabled explicitly with `FTIMER_BUILD_TESTS=ON`.
 
@@ -261,6 +263,7 @@ The default repository baseline is still the smoke/build-contract path. The full
 - `build-serial-flang`
 - `build-mpi`
 - `build-mpi-mpich`
+- `build-mpi-openmp`
 - `test-serial`
 - `test-mpi`
 - `test-mpi-mpich`
@@ -271,7 +274,35 @@ The default repository baseline is still the smoke/build-contract path. The full
 - `build-bench`
 - `lint`
 
-That means pFUnit-backed serial, OpenMPI MPI, MPICH MPI, GNU OpenMP guard, and LLVM Flang OpenMP smoke jobs are part of current CI now; they are not deferred future work. The issue #255 hosted-runner investigation found that Ubuntu 24.04's apt MPICH 4.2.0/Hydra launcher can start `/usr/bin/mpiexec.mpich -n 2` Fortran MPI programs as two singleton `MPI_COMM_WORLD` ranks on hosted runners, which made pFUnit report `Insufficient processes to run this test. (PE=0)` for `[npes=2]` cases. The MPICH CI jobs now run on hosted Ubuntu 22.04 and guard the launcher with a raw two-rank MPI probe before claiming coverage. The MPICH pFUnit job builds pFUnit v4.16.0 with `/usr/bin/mpifort.mpich`, verifies the installed package reports `PFUNIT_MPI_FOUND "TRUE"`, and runs both `ftimer_mpi_tests` and `ftimer_mpi_tests_4pe` through `/usr/bin/mpiexec.mpich`. The separate `build-mpi-mpich` job covers MPICH smoke/install-consumer behavior on the same runner family after the launcher probe. Local Homebrew MPICH 5.0.1 was not a valid reproduction path because it does not install `mpi_f08.mod`, so it fails fTimer's configure-time MPI contract probe. A GitHub-hosted NVHPC 26.3 serial smoke/install-consumer trial installed and built successfully, but the generated executables aborted at runtime with `DEALLOCATE: memory at (nil) not allocated`, so NVHPC validation remains deferred rather than claimed. The contract-regression job also verifies the configure-time MPI/OpenMP gates and the documented Makefile wrapper behavior.
+That means pFUnit-backed serial, OpenMPI MPI, MPICH MPI, GNU OpenMP
+guard, LLVM Flang OpenMP smoke, and build-only OpenMPI+OpenMP compatibility
+jobs are part of current CI now; they are not deferred future work.
+
+The issue #255 hosted-runner investigation found that Ubuntu 24.04's apt
+MPICH 4.2.0/Hydra launcher can start `/usr/bin/mpiexec.mpich -n 2`
+Fortran MPI programs as two singleton `MPI_COMM_WORLD` ranks on hosted
+runners, which made pFUnit report `Insufficient processes to run this test.
+(PE=0)` for `[npes=2]` cases. The MPICH CI jobs now run on hosted Ubuntu
+22.04 and guard the launcher with a raw two-rank MPI probe before claiming
+coverage. The MPICH pFUnit job builds pFUnit v4.16.0 with
+`/usr/bin/mpifort.mpich`, verifies the installed package reports
+`PFUNIT_MPI_FOUND "TRUE"`, and runs both `ftimer_mpi_tests` and
+`ftimer_mpi_tests_4pe` through `/usr/bin/mpiexec.mpich`. The separate
+`build-mpi-mpich` job covers MPICH smoke/install-consumer behavior on the
+same runner family after the launcher probe.
+
+The hybrid `build-mpi-openmp` job configures both `FTIMER_USE_MPI=ON` and
+`FTIMER_USE_OPENMP=ON`, builds, and runs smoke/install-consumer checks for
+today's compatibility mode only. Local Homebrew MPICH 5.0.1 was not a valid
+reproduction path because it does not install `mpi_f08.mod`, so it fails
+fTimer's configure-time MPI contract probe. A GitHub-hosted NVHPC 26.3 serial
+smoke/install-consumer trial installed and built successfully, but the
+generated executables aborted at runtime with `DEALLOCATE: memory at (nil) not
+allocated`, so NVHPC validation remains deferred rather than claimed. The
+contract-regression job also verifies the configure-time MPI/OpenMP gates and
+the documented Makefile wrapper behavior. Future true OpenMP/hybrid test
+expectations are tracked in
+[`docs/openmp-hybrid-validation-plan.md`](openmp-hybrid-validation-plan.md).
 
 ## Maintainer Workflow
 
@@ -311,7 +342,20 @@ Future-facing ideas should stay clearly separated from the current architecture 
 
 - built-in hardware counter or power-measurement backends
 - richer export formats beyond summary CSV, such as JSON or trace/event formats
-- broader OpenMP support beyond the documented master-thread-only guard model, with the historical #160 deferral recorded in [`docs/openmp-hybrid-strategy-decision.md`](openmp-hybrid-strategy-decision.md), the reopened opt-in API direction tracked in [`docs/openmp-hybrid-api-design.md`](openmp-hybrid-api-design.md), the thread-lane runtime model tracked in [`docs/openmp-thread-lane-runtime-design.md`](openmp-thread-lane-runtime-design.md), the summary/self-time model tracked in [`docs/openmp-hybrid-summary-design.md`](openmp-hybrid-summary-design.md), and the MPI+OpenMP reduction model tracked in [`docs/openmp-hybrid-mpi-reduction-design.md`](openmp-hybrid-mpi-reduction-design.md) before runtime implementation
+- broader OpenMP support beyond the documented master-thread-only guard model,
+  with the historical #160 deferral recorded in
+  [`docs/openmp-hybrid-strategy-decision.md`](openmp-hybrid-strategy-decision.md),
+  the reopened opt-in API direction tracked in
+  [`docs/openmp-hybrid-api-design.md`](openmp-hybrid-api-design.md),
+  the thread-lane runtime model tracked in
+  [`docs/openmp-thread-lane-runtime-design.md`](openmp-thread-lane-runtime-design.md),
+  the summary/self-time model tracked in
+  [`docs/openmp-hybrid-summary-design.md`](openmp-hybrid-summary-design.md),
+  the MPI+OpenMP reduction model tracked in
+  [`docs/openmp-hybrid-mpi-reduction-design.md`](openmp-hybrid-mpi-reduction-design.md),
+  and the validation plan tracked in
+  [`docs/openmp-hybrid-validation-plan.md`](openmp-hybrid-validation-plan.md)
+  before runtime implementation
 - stable semantic callback identity or a stronger external-profiler integration contract
 - explicit reservation/preallocation APIs for known timer sets, if profiling shows the new internal capacity strategy is still not enough for an adopter workload
 

--- a/docs/openmp-hybrid-api-design.md
+++ b/docs/openmp-hybrid-api-design.md
@@ -250,9 +250,12 @@ compile.
   [`docs/openmp-hybrid-mpi-reduction-design.md`](openmp-hybrid-mpi-reduction-design.md)
   without changing current `mpi_summary()` or `mpi_union_summary()` semantics
   by accident.
-- #243 must add deterministic OpenMP and hybrid validation, including
-  compatibility tests that prove current worker no-op behavior still holds for
-  existing APIs.
+- #243 records the OpenMP/hybrid validation plan in
+  [`docs/openmp-hybrid-validation-plan.md`](openmp-hybrid-validation-plan.md)
+  and adds current MPI+OpenMP compatibility smoke coverage. Later
+  implementation issues must add deterministic OpenMP and hybrid tests,
+  including compatibility tests that prove current worker no-op behavior still
+  holds for existing APIs.
 - #242 must update user-facing docs and examples after the runtime and summary
   APIs exist, keeping compatibility and true worker timing examples separate.
 

--- a/docs/openmp-hybrid-mpi-reduction-design.md
+++ b/docs/openmp-hybrid-mpi-reduction-design.md
@@ -78,7 +78,8 @@ call timer%finalize(ierr=ierr)
 ```
 
 The first implementation should expose the participation-aware path only unless
-#243 measurements or a concrete adopter need justifies a public strict policy.
+future implementation measurements or a concrete adopter need justifies a
+public strict policy.
 If strict validation is later exposed, that control must be keyword-only and
 must not add positional mode arguments to current `ftimer_t%init`,
 `ftimer_init`, `mpi_summary()`, or `mpi_union_summary()` signatures.
@@ -235,8 +236,8 @@ Strict validation remains useful when users expect identical instrumentation
 and identical worker participation on every rank. This issue defines the
 semantics for tests, internal invariants, and possible future adopter-driven
 use, but strict validation should not become a required first public policy
-until #243 validation or a concrete adopter demonstrates that the added API,
-CSV, and test surface is worth carrying.
+until future implementation validation or a concrete adopter demonstrates that
+the added API, CSV, and test surface is worth carrying.
 
 If implemented, strict validation should require:
 
@@ -275,9 +276,9 @@ Recommended retained levels:
 This staging preserves enough rank information to interpret hybrid imbalance
 without making every routine result allocate `O(num_ranks * lane_count *
 descriptor_count)` detail rows. Full rank/lane rows remain important for tests,
-debugging, and adoption diagnostics, but they should be opt-in until #243
-demonstrates that always materializing them is worth the memory and report
-burden.
+debugging, and adoption diagnostics, but they should be opt-in until future
+measurement work demonstrates that always materializing them is worth the
+memory and report burden.
 
 ## Result Type Expectations
 
@@ -327,8 +328,8 @@ like `sum_participating_lane_inclusive_time` and
 
 Secondary fields such as imbalance values, communicator-local rank/lane extrema
 attribution, and extra self-time extrema should initially be derived by report
-writers or helper routines unless #243 validation or concrete consumers justify
-making them stable stored fields.
+writers or helper routines unless future implementation validation or concrete
+consumers justify making them stable stored fields.
 
 ## Text Reports
 
@@ -407,8 +408,9 @@ principles:
 - Do not repair active or mismatched lane stacks during summary construction.
 
 The exact diagnostic payload and overflow policy depend on #239's bounded
-diagnostic storage and #243's validation work, but the implementation must not
-solve hybrid error noise by silently treating worker or rank errors as success.
+diagnostic storage and the validation plan introduced by #243, but the
+implementation must not solve hybrid error noise by silently treating worker or
+rank errors as success.
 
 ## Validation Expectations For Implementation
 
@@ -438,9 +440,11 @@ The implementation issue that adds hybrid reductions should include tests for:
   and `FTIMER_USE_OPENMP=ON` master-thread-only behavior are unchanged.
 
 Tests should use the injectable clock or an OpenMP-aware deterministic clock
-model wherever possible. #243 should also measure descriptor-union cost,
-rank-level materialization cost, optional rank/lane detail cost, and warmed
-worker `start_id`/`stop_id` overhead separately.
+model wherever possible. The implementation issue that first adds hybrid
+reductions should also measure descriptor-union cost, rank-level
+materialization cost, optional rank/lane detail cost, and warmed worker
+`start_id`/`stop_id` overhead separately, following the validation plan
+introduced by #243.
 
 ## Rejected Alternatives
 
@@ -478,9 +482,12 @@ worker `start_id`/`stop_id` overhead separately.
   all-lane active scan, and bounded diagnostics consumed by hybrid preflight.
 - #240 provides the local OpenMP summary shape, self-time semantics, envelope
   fields, participation model, and optional lane detail input.
-- #243 must add deterministic MPI+OpenMP validation, strict-semantics and
-  participation-aware test matrices, report/CSV golden output, installed
-  consumer checks for `mpi_f08` plus OpenMP, and overhead measurements.
+- #243 records the validation plan in
+  [`docs/openmp-hybrid-validation-plan.md`](openmp-hybrid-validation-plan.md)
+  and starts current installed-consumer checks for `mpi_f08` plus OpenMP.
+  Later implementation issues must add deterministic MPI+OpenMP validation,
+  strict-semantics and participation-aware test matrices, report/CSV golden
+  output, and overhead measurements.
 - #242 must update user-facing documentation and examples after the runtime,
   summary, and reduction APIs exist.
 

--- a/docs/openmp-hybrid-strategy-decision.md
+++ b/docs/openmp-hybrid-strategy-decision.md
@@ -125,7 +125,10 @@ below is retained as historical context and maps onto #238 through #243:
   [`docs/openmp-thread-lane-runtime-design.md`](openmp-thread-lane-runtime-design.md).
 - Add deterministic OpenMP tests. Preserve the existing worker no-op tests for
   the default mode, then add opt-in tests for worker-only timers, all-thread
-  timers, nested per-thread stacks, callbacks, and summary generation.
+  timers, nested per-thread stacks, callbacks, and summary generation. The
+  #243 validation plan is now recorded in
+  [`docs/openmp-hybrid-validation-plan.md`](openmp-hybrid-validation-plan.md),
+  alongside current MPI+OpenMP compatibility smoke coverage.
 - Update user-facing docs and examples. Keep the current region-bracketing
   example, add a clearly separate hybrid example, and explain migration risks.
 

--- a/docs/openmp-hybrid-summary-design.md
+++ b/docs/openmp-hybrid-summary-design.md
@@ -301,9 +301,9 @@ Because hybrid OpenMP has no existing callers, #241 chooses one
 participation-aware result that can represent rank and lane absence explicitly.
 Strict identical-participant behavior is documented for tests and future
 adopter-driven use, but should not become required first public policy unless
-#243 validation or a concrete adopter justifies the added API, CSV, and test
-burden. Whatever implementation follows that design must not weaken current
-`mpi_summary()` or `mpi_union_summary()` by accident.
+future implementation validation or a concrete adopter justifies the added API,
+CSV, and test burden. Whatever implementation follows that design must not
+weaken current `mpi_summary()` or `mpi_union_summary()` by accident.
 
 ## Text Reports
 
@@ -389,9 +389,10 @@ tests for:
   are unchanged.
 
 Tests should use the injectable clock or an OpenMP-aware deterministic clock
-model wherever possible. Performance validation under #243 should measure the
-merge-time cost of descriptor unioning and lane-detail materialization
-separately from hot-path `start_id`/`stop_id` overhead.
+model wherever possible. The implementation issue that first adds this summary
+surface should measure the merge-time cost of descriptor unioning and
+lane-detail materialization separately from hot-path `start_id`/`stop_id`
+overhead, following the validation plan introduced by #243.
 
 ## Rejected Alternatives
 
@@ -426,8 +427,11 @@ separately from hot-path `start_id`/`stop_id` overhead.
   over the OpenMP summary shape, including participation-aware union behavior,
   strict validation, descriptor identity, active-lane preflight, and
   report/CSV expectations.
-- #243 adds deterministic validation, active-lane tests, report/CSV golden
-  output, and overhead measurements.
+- #243 records the validation plan in
+  [`docs/openmp-hybrid-validation-plan.md`](openmp-hybrid-validation-plan.md)
+  and starts current MPI+OpenMP compatibility smoke coverage. Later
+  implementation issues must add deterministic validation, active-lane tests,
+  report/CSV golden output, and overhead measurements.
 - #242 updates user-facing documentation and examples after runtime and summary
   APIs exist.
 

--- a/docs/openmp-hybrid-validation-plan.md
+++ b/docs/openmp-hybrid-validation-plan.md
@@ -1,0 +1,208 @@
+> **When to read this:** When adding, reviewing, or extending OpenMP and
+> MPI+OpenMP validation under umbrella issue #237.
+
+# OpenMP And Hybrid Validation Plan
+
+Issue #243 defines the validation strategy for the OpenMP/hybrid direction
+recorded in #238, #239, #240, and #241. This document is a validation contract
+only. It does not implement true OpenMP worker timing, add `ftimer_openmp`
+public APIs, add hybrid reductions, or change the current
+`FTIMER_USE_OPENMP=ON` master-thread-only compatibility mode.
+
+## Decision
+
+Validation should advance in two layers:
+
+- current compatibility coverage for configurations that exist on `main`; and
+- future true OpenMP/hybrid behavioral coverage that lands only with the
+  corresponding runtime, summary, reduction, documentation, and benchmark work.
+
+The initial #243 change adds current build-only hybrid coverage:
+
+- a `build-mpi-openmp` CI job that configures, builds, and smoke-tests fTimer
+  with both `FTIMER_USE_MPI=ON` and `FTIMER_USE_OPENMP=ON`; and
+- an installed-package consumer check that builds the producer with both MPI
+  and OpenMP enabled, then verifies the exported package through the MPI
+  installed-consumer path, including an MPI-initialized OpenMP region that
+  preserves current worker no-op behavior.
+
+That coverage proves the current MPI and OpenMP compatibility options can
+coexist. It must not be read as evidence that true worker-thread timing or
+hybrid rank/lane reductions are implemented.
+
+## Current Compatibility Coverage
+
+Current `main` should keep these validation gates:
+
+- serial smoke and pFUnit jobs;
+- pure-MPI OpenMPI and MPICH smoke, pFUnit, example, and installed-consumer
+  coverage;
+- GNU OpenMP master-thread-only smoke and pFUnit guard coverage;
+- LLVM Flang OpenMP smoke and installed-consumer coverage when a discoverable
+  `libomp` runtime is available;
+- option-off/global-OpenMP regression coverage for #199;
+- build-contract regression coverage for configure gates and Makefile wrapper
+  behavior; and
+- MPI+OpenMP build-only smoke coverage for the current compatibility mode.
+
+The compatibility matrix is intentionally about today's APIs:
+
+- `type(ftimer_t)`, procedural wrappers, `get_summary()`, `mpi_summary()`, and
+  `mpi_union_summary()` keep their existing contracts.
+- `FTIMER_USE_OPENMP=ON` continues to mean master-thread-only guards for
+  current APIs, not true worker timing.
+- The procedural default instance remains excluded from true worker timing.
+- `FTIMER_USE_MPI=ON` plus `FTIMER_USE_OPENMP=ON` must build and install
+  cleanly without changing pure-MPI result shapes.
+- The MPI+OpenMP installed-consumer test should be registered only in top-level
+  hybrid builds. The dedicated hybrid CI job should assert that the test is
+  present and executed so non-hybrid smoke jobs do not accidentally claim
+  unsupported hybrid toolchain coverage.
+
+## Future True OpenMP Test Matrix
+
+When #239 introduces the first true OpenMP runtime, deterministic tests should
+cover:
+
+- explicit opt-in construction through the future `ftimer_openmp` module and
+  `ftimer_openmp_t` object;
+- one strict stack per OpenMP lane, initially one lane per level-1 team thread;
+- serial-context timer registration before worker use;
+- id-based `start_id`/`stop_id` inside a timed parallel-region epoch;
+- worker-only timers, all-lane timers, and mixed serial/worker timers;
+- nested timers with independent lane-local stacks;
+- cross-thread stop attempts that fail lane-locally without mutating another
+  lane's stack;
+- active-lane lifecycle errors for reset, summary, reduction, and finalize;
+- bounded diagnostic storage and deterministic aggregate diagnostics;
+- thread-private `ierr` behavior on worker paths; and
+- compatibility tests proving current `FTIMER_USE_OPENMP=ON` worker no-op
+  behavior remains unchanged for existing APIs.
+
+Tests should use the injectable mock clock or a deterministic OpenMP-aware clock
+model. They should not sleep or depend on wall-clock timing jitter.
+
+## Future Summary And Report Matrix
+
+When #240 adds local OpenMP summaries and reports, tests should cover:
+
+- stopped-run-only summary construction and active-lane refusal;
+- wall-clock `timed_region_envelope_time` distinct from summed lane work;
+- lane participation, missing-lane counts, and `*_known` fields for ambiguous
+  mixed-epoch aggregates;
+- self time computed from lane-local direct children before cross-lane
+  aggregation;
+- aggregate-first summary rows and opt-in lane detail rows;
+- local OpenMP text report output that labels envelope time and summed work
+  separately;
+- local OpenMP CSV schema versioning and append-header rejection; and
+- compatibility with current local, strict MPI, and sparse MPI CSV/report
+  schemas.
+
+## Future MPI+OpenMP Reduction Matrix
+
+When #241's reduction contract is implemented, tests should cover at least two
+MPI ranks and at least two OpenMP lanes per rank for:
+
+- participation-aware hybrid summaries with all-rank/all-lane participation;
+- rank-conditional descriptors;
+- lane-conditional descriptors inside participating ranks;
+- different OpenMP team sizes across ranks under participation-aware policy;
+- strict-semantics validation failures for descriptor, eligible-lane, missing
+  rank, and missing-lane mismatches, even if strict remains internal or
+  adopter-driven rather than first public API;
+- all-rank active-lane preflight returning `FTIMER_ERR_ACTIVE` before descriptor
+  or timing-data reductions;
+- invalid worker-thread reduction calls failing locally without MPI calls;
+- all-rank structured result validity after successful hybrid reductions;
+- deterministic canonical descriptor ordering and `node_id`/`parent_id`
+  assignment when local creation order differs across ranks; and
+- hybrid report and CSV golden output, including append rejection against local,
+  strict MPI, sparse MPI, and incompatible hybrid schemas.
+
+MPI+OpenMP validation must not add automatic barriers around timed user
+regions. Callers own synchronization when they want phase-aligned measurements.
+
+## Installed-Consumer Coverage
+
+Installed-package checks should verify the public package story at each stage:
+
+- current serial installed consumers;
+- current MPI installed consumers using `mpi_f08` and an MPI wrapper compiler;
+- current OpenMP installed consumers using the master-thread-only package
+  contract;
+- current MPI+OpenMP installed consumers proving that exported MPI and OpenMP
+  dependencies can coexist; and
+- future true OpenMP/hybrid installed consumers only after the public
+  `ftimer_openmp` module, config object, and result types exist.
+
+Future installed consumers should compile the documented source shapes, run the
+supported examples, and assert the exported CMake package resolves only the
+dependencies required by the selected feature mode.
+
+## Toolchain And Skip Policy
+
+Unsupported toolchains should skip or fail explicitly, never silently pretend
+to provide coverage.
+
+- GNU Fortran remains the primary OpenMP pFUnit path.
+- OpenMPI remains the primary hosted hybrid smoke path until MPICH+OpenMP
+  coverage is separately proven.
+- MPICH hybrid coverage may be added after the existing MPICH launcher probes
+  demonstrate a real multi-rank `MPI_COMM_WORLD` for the selected runner.
+- LLVM Flang OpenMP smoke coverage remains useful for the master-thread-only
+  carve-out, but it is not a substitute for GNU pFUnit behavioral coverage.
+- Cross-compiling or execution-restricted package builds may use
+  `FTIMER_OPENMP_ASSUME_MASTER_PROBE_OK=ON` only after independent validation of
+  equivalent OpenMP master-thread runtime semantics.
+
+Any skipped optional path should emit a clear CMake or CI message naming the
+missing compiler, MPI wrapper, launcher, OpenMP runtime, or pFUnit dependency.
+
+## Performance Validation
+
+Performance validation belongs with implementation issues, not with this
+build-only compatibility PR. When true worker timing lands, measurements should
+track:
+
+- serial hot-path overhead relative to current `ftimer_t`;
+- MPI-only hot-path and summary overhead relative to current pure-MPI paths;
+- master-thread-only OpenMP overhead for current compatibility mode;
+- warmed worker `start_id`/`stop_id` overhead in the future opt-in runtime;
+- timed-region open/close overhead;
+- lane merge cost for local summaries;
+- descriptor-union and rank-level materialization cost for hybrid summaries;
+- optional rank/lane detail materialization cost; and
+- memory growth for lane-local stacks, diagnostics, and summary artifacts.
+
+Benchmarks should report configuration, compiler, MPI implementation, OpenMP
+runtime, rank count, lane count, timer count, and nesting shape so later
+comparisons are meaningful.
+
+## Non-Goals
+
+- Implementing true OpenMP worker timing in #243.
+- Adding pFUnit tests for future APIs that do not exist yet.
+- Treating MPI+OpenMP build success as proof of hybrid rank/lane reductions.
+- Requiring every CI runner to support every MPI/OpenMP/compiler combination.
+- Weakening current worker no-op compatibility tests.
+- Adding automatic MPI barriers, OpenMP task timing, accelerator/device timing,
+  hardware counters, traces, or profiler callback identity.
+
+## Dependencies On Later Child Issues
+
+- #239 provides runtime lane state, timed-region epochs, active-lane scans, and
+  diagnostics for true worker timing tests.
+- #240 provides local OpenMP summary/report/CSV behavior for summary golden
+  tests.
+- #241 provides the hybrid reduction contract that MPI+OpenMP pFUnit and CSV
+  tests must enforce.
+- #242 provides user-facing examples and documentation that installed-consumer
+  and example smoke tests can compile once the future public API exists.
+
+## Validation For This Plan
+
+Issue #243 adds CI/package validation wiring for current feature flags and a
+durable test plan for future APIs. Focused validation should include CMake
+configure/build checks for the added hybrid smoke surface, docs contract checks,
+and `git diff --check`.

--- a/docs/openmp-thread-lane-runtime-design.md
+++ b/docs/openmp-thread-lane-runtime-design.md
@@ -43,7 +43,8 @@ Object-level state:
   open and the current epoch id;
 - configuration for maximum lanes and bounded worker diagnostics;
 - private reserve and warm-up policy for lane-local timers, contexts, and stack
-  depth, unless #243 demonstrates that public tuning knobs are needed;
+  depth, unless future measurement work demonstrates that public tuning knobs
+  are needed;
 - bounded aggregate diagnostic counters for worker calls without `ierr`.
 
 Lane-level state:
@@ -162,9 +163,9 @@ recommended hot path. The first implementation should make catalog mutation
 serial-only: inside a parallel region, name-based calls may perform read-only
 lookup of already-registered names or may be rejected outright. Unknown names
 inside a parallel region should return an error and leave state unchanged.
-Dynamic worker registration can be reconsidered later only if #243 or a later
-measurement issue shows that the extra catalog-locking path is worth the API,
-allocation, and test burden.
+Dynamic worker registration can be reconsidered later only if a future
+implementation issue shows that the extra catalog-locking path is worth the
+API, allocation, and test burden.
 
 Unknown-id `start_id` and `stop_id` calls should return an error. They must not
 create unnamed catalog entries.
@@ -340,8 +341,8 @@ growth path and must be documented separately from steady-state timing cost.
 The first public config surface should stay lean: `max_lanes` plus bounded
 diagnostic policy are enough for correctness. Expected timer counts, context
 counts, and stack-depth reserves should remain private implementation details,
-or become public only after #243 measurements show that users need direct
-control.
+or become public only after future measurement work shows that users need
+direct control.
 
 Name-based calls inside parallel regions are explicitly slower unless the
 implementation can prove a lock-free read-only catalog lookup with no concurrent
@@ -363,8 +364,10 @@ Implementation guidance:
 - preserve catalog ids so merge-time descriptor construction does not need to
   compare timer names from every lane in the hot path.
 
-#243 should measure both cold first-touch overhead and warmed steady-state
-`start_id`/`stop_id` overhead after pre-registration and lane/context warm-up.
+The implementation issue that first enables true worker timing should measure
+both cold first-touch overhead and warmed steady-state `start_id`/`stop_id`
+overhead after pre-registration and lane/context warm-up, following the #243
+validation plan.
 
 ## Interaction With Later Child Issues
 
@@ -376,9 +379,12 @@ Implementation guidance:
   [`docs/openmp-hybrid-mpi-reduction-design.md`](openmp-hybrid-mpi-reduction-design.md)
   over the #240 result shape without changing current strict or sparse MPI
   APIs by accident.
-- #243 supplies deterministic mock-clock tests, targeted OpenMP worker tests,
-  nested/task rejection tests, active-lane lifecycle and region-epoch tests,
-  and overhead measurements.
+- #243 records the validation plan in
+  [`docs/openmp-hybrid-validation-plan.md`](openmp-hybrid-validation-plan.md)
+  and starts current MPI+OpenMP compatibility smoke coverage. Later
+  implementation issues supply deterministic mock-clock tests, targeted OpenMP
+  worker tests, nested/task rejection tests, active-lane lifecycle and
+  region-epoch tests, and overhead measurements.
 - #242 updates examples and user-facing docs after #239 and #240 provide enough
   runtime and summary behavior for compile-checked examples.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -44,6 +44,7 @@ then require GitHub CI to pass before tagging.
 | Smoke/install path | Yes |
 | Serial pFUnit path | Yes when pFUnit is available |
 | MPI path | Yes when MPI and matching pFUnit are available |
+| MPI+OpenMP compatibility path | Yes when validating the hybrid compatibility matrix; this proves current feature-flag and package coexistence, not true worker timing |
 | OpenMP carve-out | Yes: GNU pFUnit guard coverage when OpenMP and matching pFUnit are available; LLVM Flang smoke/example coverage when validating the OpenMP compiler matrix |
 | Bench harness | Yes for hot-path or summary-performance changes |
 | Formatting | Yes for source/test/example changes |
@@ -76,6 +77,14 @@ FC=/path/to/mpi-mpifort cmake -B build-mpi \
   -DMPIEXEC_EXECUTABLE=/path/to/mpi-mpiexec
 cmake --build build-mpi
 cmake -E chdir build-mpi ctest --output-on-failure -L mpi
+
+FC=mpifort cmake -B build-mpi-openmp \
+  -DFTIMER_USE_MPI=ON \
+  -DFTIMER_USE_OPENMP=ON
+cmake --build build-mpi-openmp
+cmake -E chdir build-mpi-openmp ctest --output-on-failure
+cmake -E chdir build-mpi-openmp ctest --output-on-failure \
+  --no-tests=error -R '^ftimer_installed_package_consumer_mpi_openmp$'
 
 FC=gfortran cmake -B build-openmp \
   -DFTIMER_USE_OPENMP=ON \

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -348,6 +348,8 @@ enforcement should pass `ierr` and check it.
   [`docs/openmp-hybrid-summary-design.md`](openmp-hybrid-summary-design.md)
   and the MPI+OpenMP reduction model in
   [`docs/openmp-hybrid-mpi-reduction-design.md`](openmp-hybrid-mpi-reduction-design.md)
+  plus the validation plan in
+  [`docs/openmp-hybrid-validation-plan.md`](openmp-hybrid-validation-plan.md)
 
 ### Consequences for timing data
 

--- a/examples/openmp_example.F90
+++ b/examples/openmp_example.F90
@@ -3,9 +3,13 @@ program openmp_example
                      ftimer_print_summary, ftimer_start, ftimer_stop
    use ftimer_types, only: ftimer_summary_t
    use omp_lib, only: omp_get_num_threads, omp_get_thread_num, omp_set_dynamic
+#ifdef FTIMER_USE_MPI
+   use mpi_f08, only: MPI_COMM_WORLD, MPI_Finalize, MPI_Init, MPI_SUCCESS
+#endif
    implicit none
    integer, parameter :: NOOP_IERR_SENTINEL = -100
    integer :: i
+   integer :: ierr
    integer :: local_ierr
    integer :: nthreads
    integer :: thread_num
@@ -23,12 +27,21 @@ program openmp_example
    worker_calls = 0
    worker_ierr_failures = 0
 
-   call ftimer_init()
+#ifdef FTIMER_USE_MPI
+   call MPI_Init(ierr)
+   if (ierr /= MPI_SUCCESS) error stop "MPI_Init failed"
+
+   call ftimer_init(comm=MPI_COMM_WORLD, ierr=ierr)
+#else
+   call ftimer_init(ierr=ierr)
+#endif
+   if (ierr /= 0) error stop "ftimer_init failed"
 
    ! Supported pattern: time the parallel region as a whole by starting and
    ! stopping outside the !$omp parallel block. For asynchronous accelerator
    ! work, callers must synchronize device completion before stopping a timer.
-   call ftimer_start("parallel_region")
+   call ftimer_start("parallel_region", ierr=ierr)
+   if (ierr /= 0) error stop "ftimer_start failed"
 !$omp parallel num_threads(2) default(none) shared(accumulator, nthreads, thread_seen) &
 !$omp& private(i, local_ierr, thread_num) reduction(+:worker_calls, worker_ierr_failures)
    thread_num = omp_get_thread_num()
@@ -57,9 +70,11 @@ program openmp_example
       worker_calls = worker_calls + 1
    end if
 !$omp end parallel
-   call ftimer_stop("parallel_region")
+   call ftimer_stop("parallel_region", ierr=ierr)
+   if (ierr /= 0) error stop "ftimer_stop failed"
 
-   call ftimer_get_summary(summary)
+   call ftimer_get_summary(summary, ierr=ierr)
+   if (ierr /= 0) error stop "ftimer_get_summary failed"
    if (.not. thread_seen(1)) error stop "OpenMP master thread was not observed"
    if (.not. thread_seen(2)) error stop "OpenMP worker thread was not observed"
    if (nthreads < 2) error stop "OpenMP example did not run with at least two threads"
@@ -74,7 +89,13 @@ program openmp_example
    print '(a)', "not per-thread timings."
    print '(a,i0)', "OpenMP threads observed: ", nthreads
    print '(a,i0)', "Recorded timers: ", summary%num_entries
-   call ftimer_print_summary()
-   call ftimer_finalize()
+   call ftimer_print_summary(ierr=ierr)
+   if (ierr /= 0) error stop "ftimer_print_summary failed"
+   call ftimer_finalize(ierr=ierr)
+   if (ierr /= 0) error stop "ftimer_finalize failed"
+#ifdef FTIMER_USE_MPI
+   call MPI_Finalize(ierr)
+   if (ierr /= MPI_SUCCESS) error stop "MPI_Finalize failed"
+#endif
    if (accumulator < 0.0) print *, accumulator
 end program openmp_example

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -126,6 +126,15 @@ if(FTIMER_BUILD_SMOKE_TESTS)
     ENABLE_MPI
   )
 
+  if(FTIMER_USE_MPI AND FTIMER_USE_OPENMP)
+    ftimer_add_installed_consumer_test(
+      ftimer_installed_package_consumer_mpi_openmp
+      ${CMAKE_CURRENT_BINARY_DIR}/installed_package_consumer_mpi_openmp
+      ENABLE_MPI
+      ENABLE_OPENMP
+    )
+  endif()
+
   ftimer_add_installed_consumer_test(
     ftimer_installed_package_consumer_openmp
     ${CMAKE_CURRENT_BINARY_DIR}/installed_package_consumer_openmp

--- a/tests/check_installed_package_consumer.cmake
+++ b/tests/check_installed_package_consumer.cmake
@@ -586,6 +586,7 @@ set(consumer_configure_args
   -G "${CMAKE_GENERATOR}"
   -DCMAKE_PREFIX_PATH=${install_prefix}
   -DFTIMER_CONSUMER_ENABLE_MPI=${TEST_ENABLE_MPI}
+  -DFTIMER_CONSUMER_ENABLE_OPENMP=${TEST_ENABLE_OPENMP}
 )
 
 if(DEFINED TEST_OPENMP_ROOT AND NOT TEST_OPENMP_ROOT STREQUAL "")
@@ -699,19 +700,27 @@ if(TEST_ENABLE_MPI)
     find_program(ftimer_mpiexec NAMES mpiexec mpirun)
   endif()
   if(NOT ftimer_mpiexec)
-    message(STATUS "Skipping ${test_name} MPI run: no mpiexec/mpirun found on PATH.")
-    return()
+    if(TEST_ENABLE_OPENMP)
+      message(FATAL_ERROR
+        "${test_name} requires mpiexec/mpirun so the MPI+OpenMP installed consumer is executed."
+      )
+    else()
+      message(STATUS "Skipping ${test_name} MPI run: no mpiexec/mpirun found on PATH.")
+      return()
+    endif()
   endif()
 
-  set(ftimer_mpi_launch_command "${ftimer_mpiexec}")
+  set(ftimer_mpi_launch_prefix "${ftimer_mpiexec}")
   if(DEFINED TEST_MPIEXEC_NUMPROC_FLAG AND NOT TEST_MPIEXEC_NUMPROC_FLAG STREQUAL "")
-    list(APPEND ftimer_mpi_launch_command "${TEST_MPIEXEC_NUMPROC_FLAG}" 2)
+    list(APPEND ftimer_mpi_launch_prefix "${TEST_MPIEXEC_NUMPROC_FLAG}" 2)
   else()
-    list(APPEND ftimer_mpi_launch_command -n 2)
+    list(APPEND ftimer_mpi_launch_prefix -n 2)
   endif()
   if(DEFINED TEST_MPIEXEC_PREFLAGS AND NOT TEST_MPIEXEC_PREFLAGS STREQUAL "")
-    list(APPEND ftimer_mpi_launch_command ${TEST_MPIEXEC_PREFLAGS})
+    list(APPEND ftimer_mpi_launch_prefix ${TEST_MPIEXEC_PREFLAGS})
   endif()
+
+  set(ftimer_mpi_launch_command "${ftimer_mpi_launch_prefix}")
   list(APPEND ftimer_mpi_launch_command "${mpi_consumer_executable}")
   if(DEFINED TEST_MPIEXEC_POSTFLAGS AND NOT TEST_MPIEXEC_POSTFLAGS STREQUAL "")
     list(APPEND ftimer_mpi_launch_command ${TEST_MPIEXEC_POSTFLAGS})
@@ -744,5 +753,36 @@ if(TEST_ENABLE_MPI)
   endif()
   if(NOT ftimer_consumer_union_csv_text MATCHES "consumer_mpi_work")
     message(FATAL_ERROR "Installed-package MPI union CSV does not contain the expected consumer_mpi_work entry.")
+  endif()
+
+  if(TEST_ENABLE_OPENMP)
+    set(mpi_openmp_consumer_executable
+      "${consumer_build_dir}/ftimer_installed_mpi_openmp_consumer${TEST_EXECUTABLE_SUFFIX}"
+    )
+    if(DEFINED TEST_CONFIG AND NOT TEST_CONFIG STREQUAL "")
+      set(configured_mpi_openmp_consumer_executable
+        "${consumer_build_dir}/${TEST_CONFIG}/ftimer_installed_mpi_openmp_consumer${TEST_EXECUTABLE_SUFFIX}"
+      )
+      if(EXISTS "${configured_mpi_openmp_consumer_executable}")
+        set(mpi_openmp_consumer_executable "${configured_mpi_openmp_consumer_executable}")
+      endif()
+    endif()
+
+    set(ftimer_mpi_openmp_launch_command "${ftimer_mpi_launch_prefix}")
+    list(APPEND ftimer_mpi_openmp_launch_command "${mpi_openmp_consumer_executable}")
+    if(DEFINED TEST_MPIEXEC_POSTFLAGS AND NOT TEST_MPIEXEC_POSTFLAGS STREQUAL "")
+      list(APPEND ftimer_mpi_openmp_launch_command ${TEST_MPIEXEC_POSTFLAGS})
+    endif()
+
+    execute_process(
+      COMMAND ${ftimer_mpi_openmp_launch_command}
+      WORKING_DIRECTORY "${consumer_build_dir}"
+      RESULT_VARIABLE mpi_openmp_consumer_run_result
+    )
+    if(NOT mpi_openmp_consumer_run_result EQUAL 0)
+      message(FATAL_ERROR
+        "Installed-package MPI+OpenMP consumer executable exited with a nonzero status."
+      )
+    endif()
   endif()
 endif()

--- a/tests/install-consumer/CMakeLists.txt
+++ b/tests/install-consumer/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 project(ftimer_installed_consumer LANGUAGES Fortran)
 
 option(FTIMER_CONSUMER_ENABLE_MPI "Build the MPI installed-package consumer" OFF)
+option(FTIMER_CONSUMER_ENABLE_OPENMP "Build the OpenMP installed-package consumer" OFF)
 
 find_package(fTimer CONFIG REQUIRED)
 
@@ -18,4 +19,9 @@ target_link_libraries(ftimer_installed_mixed_consumer PRIVATE fTimer::ftimer)
 if(FTIMER_CONSUMER_ENABLE_MPI)
   add_executable(ftimer_installed_mpi_consumer mpi_main.F90)
   target_link_libraries(ftimer_installed_mpi_consumer PRIVATE fTimer::ftimer)
+endif()
+
+if(FTIMER_CONSUMER_ENABLE_MPI AND FTIMER_CONSUMER_ENABLE_OPENMP)
+  add_executable(ftimer_installed_mpi_openmp_consumer mpi_openmp_main.F90)
+  target_link_libraries(ftimer_installed_mpi_openmp_consumer PRIVATE fTimer::ftimer)
 endif()

--- a/tests/install-consumer/mpi_openmp_main.F90
+++ b/tests/install-consumer/mpi_openmp_main.F90
@@ -1,0 +1,107 @@
+program ftimer_installed_mpi_openmp_consumer
+   use, intrinsic :: iso_fortran_env, only: int64
+   use ftimer, only: ftimer_finalize, ftimer_init, ftimer_mpi_summary, ftimer_mpi_union_summary, &
+                     ftimer_start, ftimer_stop
+   use ftimer_types, only: ftimer_mpi_summary_t, ftimer_mpi_union_summary_t, wp
+   use mpi_f08
+   use omp_lib, only: omp_get_num_threads, omp_get_thread_num, omp_set_dynamic
+   implicit none
+   integer, parameter :: NOOP_IERR_SENTINEL = -100
+   integer :: i
+   integer :: ierr
+   integer :: local_ierr
+   integer :: nthreads
+   integer :: rank
+   integer :: thread_num
+   integer :: worker_calls
+   integer :: worker_ierr_failures
+   real :: accumulator
+   logical :: thread_seen(2)
+   type(ftimer_mpi_summary_t) :: summary
+   type(ftimer_mpi_union_summary_t) :: union_summary
+
+   call MPI_Init(ierr)
+   if (ierr /= MPI_SUCCESS) error stop 1
+
+   call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierr)
+   if (ierr /= MPI_SUCCESS) error stop 2
+
+   call omp_set_dynamic(.false.)
+
+   nthreads = 1
+   accumulator = 0.0
+   thread_seen = .false.
+   worker_calls = 0
+   worker_ierr_failures = 0
+
+   call ftimer_init(comm=MPI_COMM_WORLD, ierr=ierr)
+   if (ierr /= 0) error stop 3
+
+   call ftimer_start("consumer_mpi_openmp_region", ierr=ierr)
+   if (ierr /= 0) error stop 4
+
+!$omp parallel num_threads(2) default(none) &
+!$omp& shared(accumulator, nthreads, rank, thread_seen) &
+!$omp& private(i, local_ierr, thread_num) &
+!$omp& reduction(+:worker_calls, worker_ierr_failures)
+   thread_num = omp_get_thread_num()
+   if (thread_num + 1 <= size(thread_seen)) thread_seen(thread_num + 1) = .true.
+
+   do i = 1, (rank + 1)*50000
+!$omp atomic update
+      accumulator = accumulator + real(i)
+   end do
+
+!$omp master
+   nthreads = omp_get_num_threads()
+!$omp end master
+
+   if (thread_num /= 0) then
+      local_ierr = NOOP_IERR_SENTINEL
+      call ftimer_start("consumer_worker_only", ierr=local_ierr)
+      if (local_ierr /= NOOP_IERR_SENTINEL) worker_ierr_failures = worker_ierr_failures + 1
+
+      local_ierr = NOOP_IERR_SENTINEL
+      call ftimer_stop("consumer_worker_only", ierr=local_ierr)
+      if (local_ierr /= NOOP_IERR_SENTINEL) worker_ierr_failures = worker_ierr_failures + 1
+
+      worker_calls = worker_calls + 1
+   end if
+!$omp end parallel
+
+   call ftimer_stop("consumer_mpi_openmp_region", ierr=ierr)
+   if (ierr /= 0) error stop 5
+
+   if (.not. thread_seen(1)) error stop 6
+   if (.not. thread_seen(2)) error stop 7
+   if (nthreads < 2) error stop 8
+   if (worker_calls < 1) error stop 9
+   if (worker_ierr_failures /= 0) error stop 10
+
+   call ftimer_mpi_summary(summary, ierr=ierr)
+   if (ierr /= 0) error stop 11
+   if (summary%num_ranks /= 2) error stop 12
+   if (summary%num_entries /= 1) error stop 13
+   if (trim(summary%entries(1)%name) /= "consumer_mpi_openmp_region") error stop 14
+   if (summary%entries(1)%min_inclusive_time < 0.0_wp) error stop 15
+   if (summary%entries(1)%max_inclusive_time < summary%entries(1)%min_inclusive_time) error stop 16
+   if (summary%entries(1)%avg_call_count < 1.0_wp) error stop 17
+   if (kind(summary%entries(1)%min_call_count) /= int64) error stop 18
+   if (kind(summary%entries(1)%max_call_count) /= int64) error stop 19
+
+   call ftimer_mpi_union_summary(union_summary, ierr=ierr)
+   if (ierr /= 0) error stop 20
+   if (union_summary%num_ranks /= 2) error stop 21
+   if (union_summary%num_entries /= 1) error stop 22
+   if (trim(union_summary%entries(1)%name) /= "consumer_mpi_openmp_region") error stop 23
+   if (union_summary%entries(1)%participating_rank_count /= 2) error stop 24
+   if (union_summary%entries(1)%avg_call_count < 1.0_wp) error stop 25
+
+   call ftimer_finalize(ierr=ierr)
+   if (ierr /= 0) error stop 26
+
+   call MPI_Finalize(ierr)
+   if (ierr /= MPI_SUCCESS) error stop 27
+
+   if (accumulator < 0.0) print *, accumulator
+end program ftimer_installed_mpi_openmp_consumer


### PR DESCRIPTION
Closes #243
Part of #237

## Summary

- Add `docs/openmp-hybrid-validation-plan.md` as the durable #243 validation contract for current compatibility coverage and future true OpenMP/hybrid tests.
- Add a `build-mpi-openmp` CI smoke job that configures, builds, and smoke-tests with both `FTIMER_USE_MPI=ON` and `FTIMER_USE_OPENMP=ON`.
- Add an installed-package consumer smoke test for the current MPI+OpenMP exported-package dependency story.
- Cross-link the validation plan from README and the existing OpenMP/hybrid design docs.

## Design Decision

The validation model is layered: current `main` should prove that existing MPI and OpenMP compatibility flags can coexist, while deterministic worker-thread, summary, hybrid reduction, report/CSV, and benchmark validation waits for the implementation issues that add those surfaces.

## Rejected Alternatives

- Do not add future pFUnit tests for APIs that do not exist yet.
- Do not treat a successful MPI+OpenMP build as proof of true worker-thread timing or hybrid rank/lane reductions.
- Do not broaden current OpenMP guard semantics or weaken worker no-op compatibility tests under this issue.
- Do not require every CI runner to support every MPI/OpenMP/compiler combination before adding the primary OpenMPI hybrid smoke path.

## Compatibility Story

Existing serial, pure-MPI, and master-thread-only OpenMP APIs remain unchanged. `FTIMER_USE_MPI=ON` plus `FTIMER_USE_OPENMP=ON` is validated only as a current compatibility/package mode: `ftimer_t`, procedural wrappers, local summaries, `mpi_summary()`, and `mpi_union_summary()` keep their current contracts, and true worker timing remains explicitly future opt-in work.

## Validation

- `git diff --check`
- `FC=mpifort cmake --fresh -S . -B build-codex-243-hybrid-smoke -DFTIMER_USE_MPI=ON -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=OFF`
- `cmake --build build-codex-243-hybrid-smoke`
- `ctest --test-dir build-codex-243-hybrid-smoke --output-on-failure --no-tests=error --timeout 30 -R '^ftimer_release_docs_contract$'`
- `ctest --test-dir build-codex-243-hybrid-smoke --output-on-failure --no-tests=error --timeout 180 -R '^(ftimer_phase0_smoke|ftimer_mpi_example_smoke|ftimer_openmp_example_smoke|ftimer_installed_package_consumer_mpi_openmp)$'`
- `git diff --cached --check`

## Non-Goals

- Implementing true OpenMP worker timing.
- Adding per-lane stacks or timed-region runtime behavior.
- Adding OpenMP summary public types, reports, or CSV schemas.
- Adding hybrid MPI+OpenMP reductions.
- Adding benchmark runs for future worker timing before that runtime exists.
- Closing #237.