### PR TITLE
Document OpenMP timing modes and migration path for #242

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Operational notes:
 - `examples/nested_timers.F90`: nested timers and metadata headers
 - `examples/instrumentation_facade_*.F90`: enabled and disabled application-owned timing facade implementations that demonstrate the supported compile-out/no-op pattern
 - `examples/mpi_example.F90`: pure-MPI timing with a global MPI summary object and first-class MPI report output
-- `examples/openmp_example.F90`: the narrow OpenMP carve-out, where timers bracket the parallel region instead of running inside worker threads
+- `examples/openmp_example.F90`: the narrow OpenMP carve-out, where timers bracket the parallel region instead of running inside worker threads. See [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md) for the current OpenMP/MPI+OpenMP migration guide.
 
 ## CSV Export
 
@@ -404,7 +404,10 @@ Use a separate build directory for each compiler or mode. Reconfiguring the same
 - `FTIMER_USE_OPENMP=ON` enables only limited master-thread-only guards. Worker-thread timer calls inside an OpenMP parallel region are silent no-ops. To time a parallel region as a whole, place `start`/`stop` outside the `!$omp parallel` block.
 - `FTIMER_USE_OPENMP` is the source-level switch for that carve-out; global OpenMP compiler flags alone do not enable the guards when the option is `OFF`.
 - The OpenMP path does not make fTimer thread-safe, does not provide thread-local timer instances, and should not be read as a general hybrid MPI+OpenMP timing model.
-- Future real hybrid MPI+OpenMP timing is tracked separately from the current
+- OpenMP mode selection, accepted instrumentation patterns, and migration
+  guidance are collected in
+  [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md). Future real
+  hybrid MPI+OpenMP timing is tracked separately from the current
   compatibility mode; see
   [`docs/openmp-hybrid-strategy-decision.md`](docs/openmp-hybrid-strategy-decision.md),
   the opt-in API direction in
@@ -444,6 +447,7 @@ The benchmark harness also includes reporting-scale rows for local text reports,
 
 - Runtime semantics: [`docs/semantics.md`](docs/semantics.md)
 - Current architecture reference: [`docs/design.md`](docs/design.md)
+- OpenMP timing modes and migration guide: [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md)
 - Release checklist and artifact policy: [`docs/release.md`](docs/release.md)
 - Contributor guidance: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - Support and security reporting: [`SUPPORT.md`](SUPPORT.md), [`SECURITY.md`](SECURITY.md)

--- a/docs/design.md
+++ b/docs/design.md
@@ -331,6 +331,8 @@ The docs set is intentionally split by purpose:
 - [`README.md`](../README.md): user-facing setup, usage, limitations, and examples
 - [`docs/semantics.md`](semantics.md): current runtime contract and behavior
 - [`docs/design.md`](design.md): current repository architecture, validation reality, and workflow context
+- [`docs/openmp-timing-modes.md`](openmp-timing-modes.md): OpenMP and
+  MPI+OpenMP mode selection, accepted current examples, and migration guidance
 - [`docs/implementation-history.md`](implementation-history.md): historical phase roadmap and landing history
 - [`docs/maintainer.md`](maintainer.md) and [`docs/workflows/`](workflows/): issue/PR/review operating procedures
 
@@ -355,7 +357,9 @@ Future-facing ideas should stay clearly separated from the current architecture 
   [`docs/openmp-hybrid-mpi-reduction-design.md`](openmp-hybrid-mpi-reduction-design.md),
   and the validation plan tracked in
   [`docs/openmp-hybrid-validation-plan.md`](openmp-hybrid-validation-plan.md)
-  before runtime implementation
+  before runtime implementation. User-facing mode selection and migration
+  guidance live in
+  [`docs/openmp-timing-modes.md`](openmp-timing-modes.md).
 - stable semantic callback identity or a stronger external-profiler integration contract
 - explicit reservation/preallocation APIs for known timer sets, if profiling shows the new internal capacity strategy is still not enough for an adopter workload
 

--- a/docs/openmp-hybrid-api-design.md
+++ b/docs/openmp-hybrid-api-design.md
@@ -210,10 +210,10 @@ Existing users do not need to change source code.
   construct a `ftimer_openmp_t`, initialize it with `config=...`, and consume
   the new OpenMP/hybrid summary type.
 
-Documentation under #242 should keep the current `examples/openmp_example.F90`
-as the compatibility example and add a separate true OpenMP example only after
-#239 and #240 define enough runtime and summary behavior for that example to
-compile.
+The #242 migration guide keeps `examples/openmp_example.F90` as the
+compatibility example. Later implementation issues should add a separate true
+OpenMP example only after #239 and #240 define enough runtime and summary
+behavior for that example to compile.
 
 ## Rejected Alternatives
 
@@ -256,8 +256,10 @@ compile.
   implementation issues must add deterministic OpenMP and hybrid tests,
   including compatibility tests that prove current worker no-op behavior still
   holds for existing APIs.
-- #242 must update user-facing docs and examples after the runtime and summary
-  APIs exist, keeping compatibility and true worker timing examples separate.
+- #242 records the user-facing timing modes and migration guide in
+  [`docs/openmp-timing-modes.md`](openmp-timing-modes.md). Later
+  implementation issues must add compile-checked true OpenMP and hybrid
+  examples only after the corresponding public APIs exist.
 
 ## Non-Goals
 

--- a/docs/openmp-hybrid-mpi-reduction-design.md
+++ b/docs/openmp-hybrid-mpi-reduction-design.md
@@ -488,8 +488,10 @@ introduced by #243.
   Later implementation issues must add deterministic MPI+OpenMP validation,
   strict-semantics and participation-aware test matrices, report/CSV golden
   output, and overhead measurements.
-- #242 must update user-facing documentation and examples after the runtime,
-  summary, and reduction APIs exist.
+- #242 records the user-facing timing modes and migration guide in
+  [`docs/openmp-timing-modes.md`](openmp-timing-modes.md). Later
+  implementation issues should add compile-checked hybrid examples after the
+  runtime, summary, and reduction APIs exist.
 
 ## Non-Goals
 

--- a/docs/openmp-hybrid-strategy-decision.md
+++ b/docs/openmp-hybrid-strategy-decision.md
@@ -14,6 +14,8 @@ and the #240 summary/self-time model is recorded in
 [`docs/openmp-hybrid-summary-design.md`](openmp-hybrid-summary-design.md).
 The #241 MPI+OpenMP reduction model is recorded in
 [`docs/openmp-hybrid-mpi-reduction-design.md`](openmp-hybrid-mpi-reduction-design.md).
+The #242 user-facing timing modes and migration guide is recorded in
+[`docs/openmp-timing-modes.md`](openmp-timing-modes.md).
 
 Issue #160 asked whether fTimer should ever support real hybrid MPI+OpenMP
 timing beyond the documented master-thread-only carve-out.
@@ -130,7 +132,8 @@ below is retained as historical context and maps onto #238 through #243:
   [`docs/openmp-hybrid-validation-plan.md`](openmp-hybrid-validation-plan.md),
   alongside current MPI+OpenMP compatibility smoke coverage.
 - Update user-facing docs and examples. Keep the current region-bracketing
-  example, add a clearly separate hybrid example, and explain migration risks.
+  example, explain migration risks, and add clearly separate true OpenMP or
+  hybrid examples only after future public APIs exist.
 
 ## Non-Goals
 

--- a/docs/openmp-hybrid-summary-design.md
+++ b/docs/openmp-hybrid-summary-design.md
@@ -432,8 +432,10 @@ overhead, following the validation plan introduced by #243.
   and starts current MPI+OpenMP compatibility smoke coverage. Later
   implementation issues must add deterministic validation, active-lane tests,
   report/CSV golden output, and overhead measurements.
-- #242 updates user-facing documentation and examples after runtime and summary
-  APIs exist.
+- #242 records the user-facing timing modes and migration guide in
+  [`docs/openmp-timing-modes.md`](openmp-timing-modes.md). Later
+  implementation issues should add compile-checked OpenMP summary examples
+  after runtime and summary APIs exist.
 
 ## Non-Goals
 

--- a/docs/openmp-hybrid-validation-plan.md
+++ b/docs/openmp-hybrid-validation-plan.md
@@ -197,8 +197,9 @@ comparisons are meaningful.
   tests.
 - #241 provides the hybrid reduction contract that MPI+OpenMP pFUnit and CSV
   tests must enforce.
-- #242 provides user-facing examples and documentation that installed-consumer
-  and example smoke tests can compile once the future public API exists.
+- #242 records user-facing timing modes and migration guidance. Later
+  implementation issues add compile-checked future OpenMP/hybrid examples and
+  installed consumers once the future public API exists.
 
 ## Validation For This Plan
 

--- a/docs/openmp-thread-lane-runtime-design.md
+++ b/docs/openmp-thread-lane-runtime-design.md
@@ -385,8 +385,10 @@ validation plan.
   implementation issues supply deterministic mock-clock tests, targeted OpenMP
   worker tests, nested/task rejection tests, active-lane lifecycle and
   region-epoch tests, and overhead measurements.
-- #242 updates examples and user-facing docs after #239 and #240 provide enough
-  runtime and summary behavior for compile-checked examples.
+- #242 records the user-facing timing modes and migration guide in
+  [`docs/openmp-timing-modes.md`](openmp-timing-modes.md). Later
+  implementation issues should add compile-checked worker-timing examples after
+  this runtime model and the summary surface become real public APIs.
 
 ## Non-Goals
 

--- a/docs/openmp-timing-modes.md
+++ b/docs/openmp-timing-modes.md
@@ -1,0 +1,165 @@
+> **When to read this:** When choosing how to instrument OpenMP or
+> MPI+OpenMP code, when migrating from the current master-thread-only
+> compatibility mode, or when reviewing future true OpenMP timing examples.
+
+# OpenMP Timing Modes And Migration Guide
+
+This guide is the user-facing companion to the OpenMP/hybrid strategy under
+umbrella issue #237. It explains what exists on current `main`, what is
+accepted as future opt-in design, and how examples should evolve without making
+today's master-thread-only behavior look accidental.
+
+Current `main` still has no true worker-thread timing API. The design docs name
+future source shapes such as `ftimer_openmp_t`, but those symbols are not
+available until later implementation issues add them.
+
+## Mode Summary
+
+| Mode | Available on current `main` | What it means |
+| --- | --- | --- |
+| Serial timing | Yes | Use `ftimer` or `ftimer_core` normally. No OpenMP behavior is active. |
+| Pure-MPI timing | Yes | Use the current `mpi_f08` `comm=` contract after `MPI_Init` and before `MPI_Finalize`. |
+| `FTIMER_USE_OPENMP=OFF` with external OpenMP flags | Yes | fTimer keeps serial/pure-MPI semantics. Global OpenMP compiler flags do not activate the guard carve-out. |
+| `FTIMER_USE_OPENMP=ON` compatibility mode | Yes | Current APIs run guarded timer operations only on OpenMP thread 0. Worker-thread calls are silent no-ops. |
+| `FTIMER_USE_MPI=ON` plus `FTIMER_USE_OPENMP=ON` | Yes, as compatibility smoke coverage | MPI and OpenMP package dependencies can coexist. This still uses the current master-thread-only OpenMP behavior. |
+| True OpenMP worker timing | No | Future opt-in API behind `ftimer_openmp`, `ftimer_openmp_t`, and explicit configuration. |
+| True MPI+OpenMP rank/lane reductions | No | Future hybrid result family behind the future OpenMP-specific object. |
+
+## Current Accepted Patterns
+
+Use current OpenMP support to time a parallel region as one wall-clock interval.
+Put timing calls in serial context around the `!$omp parallel` region:
+
+```fortran
+call ftimer_start("parallel_region", ierr=ierr)
+!$omp parallel
+! worker work
+!$omp end parallel
+call ftimer_stop("parallel_region", ierr=ierr)
+```
+
+This records one timer call for `parallel_region`. It does not record one call
+per worker and does not sum worker-thread work. If the timed region launches
+asynchronous accelerator work, synchronize that work before `ftimer_stop` when
+the intended measurement is completed device time.
+
+For MPI+OpenMP compatibility builds, keep fTimer inside the MPI lifetime and
+still bracket OpenMP work from serial context:
+
+```fortran
+call MPI_Init(ierr)
+call ftimer_init(comm=MPI_COMM_WORLD, ierr=ierr)
+
+call ftimer_start("rank_parallel_region", ierr=ierr)
+!$omp parallel
+! rank-local threaded work
+!$omp end parallel
+call ftimer_stop("rank_parallel_region", ierr=ierr)
+
+call ftimer_mpi_summary(summary, ierr=ierr)
+call ftimer_finalize(ierr=ierr)
+call MPI_Finalize(ierr)
+```
+
+That pattern preserves the current pure-MPI summary contract. The MPI summary
+reduces rank-local wall-clock intervals; fTimer does not add automatic MPI
+barriers around the measured region.
+
+`examples/openmp_example.F90` is the reference compatibility example. It
+intentionally exercises a worker-thread no-op call and verifies that only the
+outer `parallel_region` timer appears in the summary.
+
+## Patterns To Avoid On Current Main
+
+Do not place current `ftimer_start`/`ftimer_stop` calls inside an OpenMP
+parallel region expecting per-thread data:
+
+```fortran
+! Misleading on current main: worker calls are no-ops.
+!$omp parallel
+call ftimer_start("worker_work")
+! worker work
+call ftimer_stop("worker_work")
+!$omp end parallel
+```
+
+Under `FTIMER_USE_OPENMP=ON`, only thread 0 contributes to current summaries.
+Worker-only timer names do not appear at all, all-thread call counts are
+master-only, and caller-provided `ierr` values on worker paths are left
+unchanged.
+
+Also avoid:
+
+- scoped guards with block-local finalization inside OpenMP parallel regions;
+- summary, report, reset, finalize, clock, or callback operations from inside
+  a parallel region;
+- reading MPI+OpenMP smoke coverage as proof of hybrid rank/lane reductions;
+- using global OpenMP compiler flags as a substitute for `FTIMER_USE_OPENMP=ON`.
+
+## Migration Story
+
+Existing serial and pure-MPI users do not need source changes. The current API,
+summary types, CSV schemas, and MPI result families remain the stable surface.
+
+Existing OpenMP compatibility users should keep the current region-bracketing
+pattern when they want one wall-clock interval for a parallel region. The most
+important migration audit is expectation-setting: if an application currently
+calls fTimer inside a parallel region and expects each worker to contribute,
+that instrumentation is not producing those data today. Move such timing calls
+outside the parallel region for current releases, or plan a future explicit
+worker-timing migration after the OpenMP-specific API lands.
+
+Applications that may need both compatibility mode and future true worker
+timing should put fTimer calls behind an application-owned instrumentation
+facade. That keeps the choice between current `ftimer` calls and future
+`ftimer_openmp` calls in one application module instead of spreading mode
+conditionals across scientific kernels.
+
+When true OpenMP timing is implemented, the intended migration is additive:
+
+- import the future `ftimer_openmp` module explicitly;
+- construct a future `type(ftimer_openmp_t)` object, not the procedural
+  default instance;
+- initialize it with a keyword `config=` object and, for hybrid runs, a keyword
+  `comm=`;
+- register timer names in serial context before hot worker use;
+- pass timer ids into an explicitly opened timed OpenMP region; and
+- consume future OpenMP or MPI+OpenMP summary/result types instead of current
+  `ftimer_summary_t`, `ftimer_mpi_summary_t`, or `ftimer_mpi_union_summary_t`.
+
+The future snippets in the design docs are interface sketches only. They should
+not become compiling examples until the corresponding runtime, summary, and
+validation implementation issues add real public symbols.
+
+## Future Example Policy
+
+Keep current and future examples separate.
+
+- `examples/openmp_example.F90` remains the compatibility example for
+  `FTIMER_USE_OPENMP=ON`.
+- Future true OpenMP worker examples should be added only after the
+  OpenMP-specific runtime and summary APIs exist.
+- Future MPI+OpenMP examples should use the future `ftimer_openmp_t` hybrid
+  summary path, not the current procedural default instance.
+- Future examples should show the id-first worker hot path, explicit timed
+  region begin/end, stopped-run summaries, and participation-aware terminology.
+- Examples must not imply support for nested OpenMP teams, OpenMP task
+  migration, accelerator/device timing, hardware counters, automatic MPI
+  barriers, callback event streams from workers, or full profiler behavior.
+
+When future APIs become available, release notes should say which mode was
+added, which examples compile on that release, which toolchain matrix validates
+the examples, and which non-goals still apply.
+
+## Design References
+
+- API and compatibility direction:
+  [`docs/openmp-hybrid-api-design.md`](openmp-hybrid-api-design.md)
+- Thread-lane runtime model:
+  [`docs/openmp-thread-lane-runtime-design.md`](openmp-thread-lane-runtime-design.md)
+- Local OpenMP summary and report model:
+  [`docs/openmp-hybrid-summary-design.md`](openmp-hybrid-summary-design.md)
+- MPI+OpenMP reduction model:
+  [`docs/openmp-hybrid-mpi-reduction-design.md`](openmp-hybrid-mpi-reduction-design.md)
+- Validation plan:
+  [`docs/openmp-hybrid-validation-plan.md`](openmp-hybrid-validation-plan.md)

--- a/docs/release.md
+++ b/docs/release.md
@@ -33,6 +33,9 @@ Before starting a release candidate:
   smoke/contract checks in the same release-prep PR.
 - Treat release notes as part of the compatibility contract: describe
   user-visible behavior changes, limitations, and migration notes directly.
+- If future OpenMP or MPI+OpenMP APIs become available, update
+  `docs/openmp-timing-modes.md` and name the supported examples, validation
+  matrix, and remaining non-goals in the release notes.
 
 ## Validation Matrix
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -340,6 +340,9 @@ enforcement should pass `ierr` and check it.
 - Suppressed non-master calls are skipped before normal validation, emit no stderr warning, and leave any caller-provided `ierr` unchanged
 - The OpenMP guards do not broaden support for concurrent access to other APIs; summary/report generation and other shared access remain unsupported in threaded regions
 - Thread-local timer instances, fuller concurrent timing support, and any `suppress_in_parallel` control remain deferred
+- For user-facing mode selection, accepted instrumentation patterns, and
+  migration guidance, see
+  [`docs/openmp-timing-modes.md`](openmp-timing-modes.md).
 - Future real hybrid MPI+OpenMP timing is tracked separately from this current
   compatibility mode; see [`docs/openmp-hybrid-strategy-decision.md`](openmp-hybrid-strategy-decision.md)
   and the opt-in API direction in

--- a/examples/openmp_example.F90
+++ b/examples/openmp_example.F90
@@ -37,9 +37,11 @@ program openmp_example
 #endif
    if (ierr /= 0) error stop "ftimer_init failed"
 
-   ! Supported pattern: time the parallel region as a whole by starting and
-   ! stopping outside the !$omp parallel block. For asynchronous accelerator
-   ! work, callers must synchronize device completion before stopping a timer.
+   ! Compatibility example: time the parallel region as a whole by starting and
+   ! stopping outside the !$omp parallel block. docs/openmp-timing-modes.md
+   ! explains how this current pattern differs from future true worker timing.
+   ! For asynchronous accelerator work, callers must synchronize device
+   ! completion before stopping a timer.
    call ftimer_start("parallel_region", ierr=ierr)
    if (ierr /= 0) error stop "ftimer_start failed"
 !$omp parallel num_threads(2) default(none) shared(accumulator, nthreads, thread_seen) &
@@ -87,6 +89,7 @@ program openmp_example
    print '(a)', "fTimer OpenMP support is limited to master-thread-only region bracketing."
    print '(a)', "This example measures one parallel region wall-clock interval,"
    print '(a)', "not per-thread timings."
+   print '(a)', "See docs/openmp-timing-modes.md for the migration guide."
    print '(a,i0)', "OpenMP threads observed: ", nthreads
    print '(a,i0)', "Recorded timers: ", summary%num_entries
    call ftimer_print_summary(ierr=ierr)


### PR DESCRIPTION
Closes #242
Part of #237

## Summary
- Add `docs/openmp-timing-modes.md` as the user-facing OpenMP/MPI+OpenMP mode and migration guide.
- Keep `examples/openmp_example.F90` positioned as the current `FTIMER_USE_OPENMP=ON` compatibility example, not a true worker-timing example.
- Cross-link the new guide from README, semantics, design, release guidance, and the OpenMP/hybrid design documents.

## Design Decision
The current serial, pure-MPI, and `FTIMER_USE_OPENMP=ON` master-thread-only compatibility APIs remain unchanged. True OpenMP worker timing remains a future additive path through the OpenMP-specific `ftimer_openmp` / `ftimer_openmp_t` model already recorded by the #238-#241 design docs. The procedural default instance remains excluded from true worker timing in the documented migration path.

## Rejected Alternatives
- Do not add compiling true OpenMP or MPI+OpenMP examples before those public APIs exist.
- Do not reinterpret MPI+OpenMP smoke coverage as hybrid rank/lane reduction validation.
- Do not document current worker-thread calls inside parallel regions as supported per-thread timing.

## Compatibility Story
Existing serial and pure-MPI users need no source changes. Existing OpenMP compatibility users should continue bracketing parallel regions from serial context when they want one wall-clock interval. Applications that expect worker contribution from current in-parallel fTimer calls need to audit that instrumentation now, because current worker calls are silent no-ops and leave caller-provided `ierr` unchanged.

## Validation
- `find examples -name '*.F90' -exec fprettify --diff {} +` — passed
- `git diff --check` — passed
- `cmake -DREPO_ROOT=/Users/hrh/claude_projects/fTimer -P tests/check_release_docs_contract.cmake` — passed
- `FC=gfortran cmake -S . -B build-codex-242-openmp-smoke -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=OFF` — passed
- `cmake --build build-codex-242-openmp-smoke --target openmp_example` — passed
- `./build-codex-242-openmp-smoke/examples/openmp_example` — passed; output reports master-thread-only region bracketing and points to the migration guide
- `ctest --test-dir build-codex-242-openmp-smoke --output-on-failure --no-tests=error -R '^ftimer_openmp_example_smoke$'` — passed

## Non-Goals
- No threaded runtime implementation.
- No per-thread stacks or true worker timing behavior.
- No MPI+OpenMP rank/lane reductions.
- No new public runtime APIs or placeholder symbols.
- No change to current OpenMP guard semantics.
- Does not close #237.