### PR TITLE
[codex] Ignore Codex local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ benchmark-results/
 # Claude personalization
 .claude/skills/
 .agents/skills/
+.codex/rules/


### PR DESCRIPTION
## Summary

- Add `.codex/rules/` to `.gitignore` with the other local agent/tooling state directories.

## Impact

This prevents local Codex rules from being accidentally tracked while leaving other future repo-owned `.codex` content trackable.

Closes #281

## Validation

- Inspected the staged diff and amended commit; change is limited to `.gitignore`.
- No build/test run: ignore-only metadata change.