### PR TITLE
Add true OpenMP and hybrid examples, docs, and release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,8 +188,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gfortran cmake libopenmpi-dev openmpi-bin
 
-      # Hybrid smoke validates MPI/OpenMP coexistence plus the installed
-      # ftimer_openmp worker API. It does not claim hybrid rank/lane reductions.
+      # Hybrid smoke validates MPI/OpenMP coexistence, the installed
+      # ftimer_openmp worker API, and strict/sparse hybrid rank/lane reductions.
       - name: Configure (MPI+OpenMP)
         run: FC=mpifort cmake -B build -DFTIMER_USE_MPI=ON -DFTIMER_USE_OPENMP=ON
 
@@ -521,7 +521,7 @@ jobs:
         run: cmake --build build -j$(nproc)
 
       - name: OpenMP example smoke test
-        run: ctest --test-dir build --output-on-failure --no-tests=error -R '^(ftimer_openmp_example_smoke|ftimer_installed_package_consumer_openmp_flang)$'
+        run: ctest --test-dir build --output-on-failure --no-tests=error -R '^(ftimer_openmp_example_smoke|ftimer_openmp_worker_example_smoke|ftimer_installed_package_consumer_openmp_flang)$'
 
   build-contract-regressions:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ fTimer currently supports these usage paths:
 - Downstream consumption through `find_package(fTimer CONFIG REQUIRED)`
 - Application-owned instrumentation facades that can select either the real fTimer implementation or a dependency-free no-op implementation at build time
 
+Choose the smallest mode that matches the measurement you need. Use serial
+timing for one process, pure MPI for rank-local intervals reduced across a
+communicator, OpenMP compatibility mode when one wall-clock timer should bracket
+an entire parallel region, true OpenMP worker timing when per-lane participation
+matters inside one level-1 team, strict MPI+OpenMP when all ranks and lanes must
+share the same descriptor tree, and sparse union MPI+OpenMP when rank- or
+lane-conditional work should be represented with explicit participation metadata.
+
 Important limitations are documented later in this README. The short version is that serial and pure-MPI are the core supported stories on current `main`; OpenMP has a legacy master-thread-only compatibility path plus the explicit `ftimer_openmp_t` worker-timing object, local stopped-run summaries, strict MPI+OpenMP rank/lane reductions, and separate sparse union MPI+OpenMP rank/lane reductions.
 
 ## Quick Start
@@ -287,7 +295,11 @@ Operational notes:
 - `examples/nested_timers.F90`: nested timers and metadata headers
 - `examples/instrumentation_facade_*.F90`: enabled and disabled application-owned timing facade implementations that demonstrate the supported compile-out/no-op pattern
 - `examples/mpi_example.F90`: pure-MPI timing with a global MPI summary object and first-class MPI report output
-- `examples/openmp_example.F90`: the OpenMP compatibility carve-out, where existing API timers bracket the parallel region instead of running inside worker threads. See [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md) for the current OpenMP/MPI+OpenMP migration guide and the explicit `ftimer_openmp_t` worker-timing path.
+- `examples/openmp_example.F90`: the OpenMP compatibility carve-out, where existing API timers bracket the parallel region instead of running inside worker threads
+- `examples/openmp_worker_example.F90`: true OpenMP worker timing with `ftimer_openmp_t`, pre-registered ids, an explicit timed region, local OpenMP summary output, and local OpenMP CSV output
+- `examples/mpi_openmp_example.F90`: strict MPI+OpenMP worker timing followed by sparse union MPI+OpenMP participation reporting through `ftimer_openmp_t`
+
+See [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md) for the current OpenMP/MPI+OpenMP migration guide. Existing serial, pure-MPI, and OpenMP compatibility users do not need source changes to keep their current behavior; the true OpenMP and hybrid examples are additive opt-in paths.
 
 ## CSV Export
 
@@ -365,7 +377,7 @@ FC=/path/to/mpi-mpifort cmake -B build-mpi -DFTIMER_USE_MPI=ON -DFTIMER_BUILD_TE
 cmake --build build-mpi
 cmake -E chdir build-mpi ctest --output-on-failure -L mpi
 
-# MPI+OpenMP smoke build for compatibility plus strict and sparse union hybrid summaries
+# MPI+OpenMP smoke build for compatibility plus strict and sparse union hybrid examples/summaries
 FC=mpifort cmake -B build-mpi-openmp -DFTIMER_USE_MPI=ON -DFTIMER_USE_OPENMP=ON
 cmake --build build-mpi-openmp
 cmake -E chdir build-mpi-openmp ctest --output-on-failure
@@ -378,7 +390,8 @@ cmake -E chdir build-openmp ctest --output-on-failure
 # OpenMP smoke build (LLVM Flang)
 FC=flang-19 cmake -B build-openmp-flang -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=OFF
 cmake --build build-openmp-flang
-./build-openmp-flang/examples/openmp_example
+cmake -E chdir build-openmp-flang ctest --output-on-failure \
+  -R '^(ftimer_openmp_example_smoke|ftimer_openmp_worker_example_smoke)$'
 
 # Convenience Makefile wrapper
 make
@@ -401,8 +414,8 @@ Supported toolchain matrix:
 - Serial smoke/library build: GNU Fortran and LLVM Flang are validated in automation
 - Serial plus pFUnit tests: GNU Fortran with a matching pFUnit installation
 - MPI: GNU Fortran wrapper compiler paths are validated with OpenMPI and MPICH; smoke/install-consumer coverage runs for both, and MPI pFUnit coverage runs for OpenMPI plus MPICH on hosted Ubuntu 22.04 with a matching MPICH-built pFUnit
-- OpenMP: GNU Fortran with pFUnit guard coverage, plus LLVM Flang smoke/example coverage for the documented master-thread-only carve-out
-- MPI+OpenMP: OpenMPI wrapper builds with OpenMP are smoke-tested for current compatibility mode, the opt-in `ftimer_openmp` worker API, strict and sparse union MPI+OpenMP hybrid summary/report/CSV output, and MPI-initialized OpenMP installed consumers
+- OpenMP: GNU Fortran with pFUnit guard coverage, plus LLVM Flang smoke/example coverage for the documented master-thread-only carve-out and the opt-in `examples/openmp_worker_example.F90` path
+- MPI+OpenMP: OpenMPI wrapper builds with OpenMP are smoke-tested for current compatibility mode, `examples/mpi_openmp_example.F90`, the opt-in `ftimer_openmp` worker API, strict and sparse union MPI+OpenMP hybrid summary/report/CSV output, and MPI-initialized OpenMP installed consumers
 
 Other serial compilers may still work, but they are not part of the current release-validated matrix unless the repo adds direct automation for them.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -62,7 +62,9 @@ fTimer/
 │   ├── basic_usage.F90
 │   ├── nested_timers.F90
 │   ├── mpi_example.F90
-│   └── openmp_example.F90
+│   ├── openmp_example.F90
+│   ├── openmp_worker_example.F90
+│   └── mpi_openmp_example.F90
 ├── bench/
 │   └── ftimer_bench.F90
 ├── docs/
@@ -271,11 +273,11 @@ The MPI and OpenMP enablement paths are guarded at configure time:
 
 The current test inventory is:
 
-- smoke tests in `tests/test_phase0_smoke.F90` and `tests/test_openmp_api_smoke.F90`, OpenMP diagnostic stderr capture through `tests/test_openmp_api_diagnostics.F90` when `FTIMER_USE_OPENMP=ON`, runtime execution of `basic_usage`, OpenMP example execution when `FTIMER_USE_OPENMP=ON`, MPI example execution when `FTIMER_USE_MPI=ON`, installed-package consumer build-and-run checks, and build-contract regression checks under `tests/check_*_contracts.cmake`
+- smoke tests in `tests/test_phase0_smoke.F90` and `tests/test_openmp_api_smoke.F90`, OpenMP diagnostic stderr capture through `tests/test_openmp_api_diagnostics.F90` when `FTIMER_USE_OPENMP=ON`, runtime execution of `basic_usage`, OpenMP compatibility and worker example execution when `FTIMER_USE_OPENMP=ON`, MPI example execution when `FTIMER_USE_MPI=ON`, MPI+OpenMP example execution when both feature flags are enabled, installed-package consumer build-and-run checks, and build-contract regression checks under `tests/check_*_contracts.cmake`
 - serial pFUnit tests for core behavior, summaries, callbacks, reset behavior, call-stack behavior, and procedural parity
 - MPI pFUnit tests under `tests/mpi/`, validated in CI with GNU Fortran against OpenMPI and MPICH
 - OpenMP guard tests enabled when `FTIMER_USE_OPENMP=ON`, covering the master-thread-only carve-out plus `ftimer_openmp_t` thread-lane timing smoke coverage
-- MPI+OpenMP installed-consumer smoke coverage for the current exported-package dependency story, including an MPI-initialized OpenMP region, explicit `ftimer_openmp_t` worker calls, and a strict hybrid summary call from an installed consumer
+- MPI+OpenMP example and installed-consumer smoke coverage for the current exported-package dependency story, including an MPI-initialized OpenMP region, explicit `ftimer_openmp_t` worker calls, strict hybrid summaries, and sparse union hybrid summaries
 
 The default repository baseline is still the smoke/build-contract path. The full behavioral suite is enabled explicitly with `FTIMER_BUILD_TESTS=ON`.
 

--- a/docs/installed-api.md
+++ b/docs/installed-api.md
@@ -51,6 +51,14 @@ The supported source-level import surface is intentionally narrow:
   fields.
 - `use ftimer_types` for shared constants, status codes, callback interfaces, and summary types
 
+The source examples that exercise the installed import paths are
+`examples/openmp_example.F90` for the compatibility carve-out,
+`examples/openmp_worker_example.F90` for true OpenMP worker timing through
+`use ftimer_openmp`, and `examples/mpi_openmp_example.F90` for strict plus
+sparse union MPI+OpenMP hybrid timing through the same object API. Existing
+serial, pure-MPI, and compatibility users do not need source changes to keep
+their current behavior.
+
 ## MPI lifecycle and communicator ownership
 
 MPI-enabled fTimer must be used after `MPI_Init` and before `MPI_Finalize`.

--- a/docs/openmp-timing-modes.md
+++ b/docs/openmp-timing-modes.md
@@ -82,6 +82,21 @@ barriers around the measured region.
 intentionally exercises a worker-thread no-op call and verifies that only the
 outer `parallel_region` timer appears in the summary.
 
+`examples/openmp_worker_example.F90` is the reference true OpenMP worker-timing
+example. It imports `ftimer_openmp`, constructs `type(ftimer_openmp_t)`,
+registers timer ids in serial context, opens one timed level-1 OpenMP region,
+uses id-first `start_id`/`stop_id` calls on worker lanes, and then consumes the
+stopped-run local OpenMP summary/report/CSV family.
+
+`examples/mpi_openmp_example.F90` is the reference MPI+OpenMP example. It keeps
+MPI initialization and finalization outside the fTimer object lifetime, captures
+`MPI_COMM_WORLD` through `init(config=..., comm=...)`, uses the same id-first
+worker timing pattern, prints a strict `mpi_openmp_summary`, then records a
+rank/lane-conditional timer and prints the separate sparse union
+`mpi_openmp_union_summary`. fTimer does not add barriers around either timed
+region; applications should add synchronization only when it is part of their
+intended measurement.
+
 ## Patterns To Avoid On Current Main
 
 Do not place current `ftimer_start`/`ftimer_stop` calls inside an OpenMP
@@ -151,26 +166,26 @@ The lifecycle/configuration, timer catalog, timed-region, and worker
 OpenMP summaries, strict MPI+OpenMP summaries, sparse union MPI+OpenMP
 summaries, and report/CSV output.
 
-## Future Example Policy
+## Example Policy
 
 Keep current and future examples separate.
 
 - `examples/openmp_example.F90` remains the compatibility example for
   `FTIMER_USE_OPENMP=ON`.
-- Future true OpenMP worker examples should use `ftimer_openmp_t` and should be
-  added only when the example can present a complete stopped-run reporting story
-  without implying trace/profiler behavior.
-- MPI+OpenMP examples should use the strict or sparse union `ftimer_openmp_t`
-  hybrid summary paths, not the procedural default instance.
-- Future examples should show the id-first worker hot path, explicit timed
-  region begin/end, stopped-run summaries, and participation-aware terminology.
+- `examples/openmp_worker_example.F90` uses `ftimer_openmp_t` and presents a
+  complete stopped-run local OpenMP summary/CSV story without implying
+  trace/profiler behavior.
+- `examples/mpi_openmp_example.F90` uses the strict and sparse union
+  `ftimer_openmp_t` hybrid summary paths, not the procedural default instance.
+- True OpenMP and hybrid examples show the id-first worker hot path, explicit
+  timed-region begin/end, stopped-run summaries, and participation-aware
+  terminology.
 - Examples must not imply support for nested OpenMP teams, OpenMP task
   migration, accelerator/device timing, hardware counters, automatic MPI
   barriers, callback event streams from workers, or full profiler behavior.
 
-When future APIs become available, release notes should say which mode was
-added, which examples compile on that release, which toolchain matrix validates
-the examples, and which non-goals still apply.
+Release notes name the supported examples, the toolchain matrix that validates
+them, and the remaining non-goals for the first release containing these APIs.
 
 ## Design References
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -37,9 +37,11 @@ Before starting a release candidate:
   smoke/contract checks in the same release-prep PR.
 - Treat release notes as part of the compatibility contract: describe
   user-visible behavior changes, limitations, and migration notes directly.
-- If future OpenMP or MPI+OpenMP APIs become available, update
-  `docs/openmp-timing-modes.md` and name the supported examples, validation
-  matrix, and remaining non-goals in the release notes.
+- For the first release containing the true OpenMP and hybrid APIs, name
+  `examples/openmp_example.F90`, `examples/openmp_worker_example.F90`, and
+  `examples/mpi_openmp_example.F90`; state that serial, pure-MPI, and
+  compatibility users need no source changes; include the validation matrix;
+  and keep the remaining non-goals explicit.
 
 ## Validation Matrix
 
@@ -51,8 +53,8 @@ then require GitHub CI to pass before tagging.
 | Smoke/install path | Yes |
 | Serial pFUnit path | Yes when pFUnit is available |
 | MPI path | Yes when MPI and matching pFUnit are available |
-| MPI+OpenMP compatibility and hybrid paths | Yes when validating the hybrid compatibility matrix; this proves current feature-flag coexistence, the installed `ftimer_openmp` worker API, and strict plus sparse union hybrid rank/lane summaries/reports/CSV |
-| OpenMP carve-out | Yes: GNU pFUnit guard coverage when OpenMP and matching pFUnit are available; LLVM Flang smoke/example coverage when validating the OpenMP compiler matrix |
+| MPI+OpenMP compatibility and hybrid paths | Yes when validating the hybrid compatibility matrix; this proves current feature-flag coexistence, `examples/mpi_openmp_example.F90`, the installed `ftimer_openmp` worker API, and strict plus sparse union hybrid rank/lane summaries/reports/CSV |
+| OpenMP carve-out and true worker example | Yes: GNU pFUnit guard coverage when OpenMP and matching pFUnit are available; LLVM Flang smoke/example coverage for `examples/openmp_example.F90` and `examples/openmp_worker_example.F90` when validating the OpenMP compiler matrix |
 | Bench harness | Yes for hot-path or summary-performance changes |
 | Formatting | Yes for source/test/example changes |
 | Diff hygiene | Yes |
@@ -91,7 +93,7 @@ FC=mpifort cmake -B build-mpi-openmp \
 cmake --build build-mpi-openmp
 cmake -E chdir build-mpi-openmp ctest --output-on-failure
 cmake -E chdir build-mpi-openmp ctest --output-on-failure \
-  --no-tests=error -R '^ftimer_installed_package_consumer_mpi_openmp$'
+  --no-tests=error -R '^(ftimer_mpi_openmp_example_smoke|ftimer_installed_package_consumer_mpi_openmp)$'
 
 FC=gfortran cmake -B build-openmp \
   -DFTIMER_USE_OPENMP=ON \
@@ -105,7 +107,7 @@ FC=flang-19 cmake -B build-openmp-flang \
   -DFTIMER_BUILD_TESTS=OFF
 cmake --build build-openmp-flang
 cmake -E chdir build-openmp-flang ctest --output-on-failure \
-  -R '^(ftimer_openmp_example_smoke|ftimer_installed_package_consumer_openmp_flang)$'
+  -R '^(ftimer_openmp_example_smoke|ftimer_openmp_worker_example_smoke|ftimer_installed_package_consumer_openmp_flang)$'
 
 Add `-DOpenMP_ROOT=/path/to/libomp` on LLVM Flang platforms where CMake does
 not discover the OpenMP runtime automatically.
@@ -164,6 +166,8 @@ Release notes should be short and evidence-backed. Include:
 
 - the version and tag,
 - the intended audience and supported workflows,
+- supported examples: serial basics, pure MPI, OpenMP compatibility,
+  true OpenMP worker timing, and strict/sparse MPI+OpenMP hybrid timing,
 - user-visible API, packaging, CSV, MPI, OpenMP, or behavior changes,
 - compatibility and migration notes,
 - known limitations and deferred work,

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -513,6 +513,10 @@ enforcement should pass `ierr` and check it.
 - For user-facing mode selection, accepted instrumentation patterns, and
   migration guidance, see
   [`docs/openmp-timing-modes.md`](openmp-timing-modes.md).
+  The compiling examples are `examples/openmp_example.F90` for compatibility
+  timing, `examples/openmp_worker_example.F90` for true OpenMP worker timing,
+  and `examples/mpi_openmp_example.F90` for strict plus sparse union hybrid
+  timing.
 - Sparse union hybrid MPI+OpenMP participation is implemented as a separate
   `ftimer_openmp_t` family; see
   [`docs/openmp-hybrid-strategy-decision.md`](openmp-hybrid-strategy-decision.md)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -32,6 +32,25 @@ if(FTIMER_BUILD_SMOKE_TESTS)
 endif()
 
 if(FTIMER_USE_MPI)
+  set(ftimer_examples_mpiexec_oversubscribe_flags)
+  if(DEFINED MPIEXEC_EXECUTABLE AND NOT MPIEXEC_EXECUTABLE STREQUAL "")
+    execute_process(
+      COMMAND "${MPIEXEC_EXECUTABLE}" --version
+      OUTPUT_VARIABLE ftimer_examples_mpiexec_version_stdout
+      ERROR_VARIABLE ftimer_examples_mpiexec_version_stderr
+      RESULT_VARIABLE ftimer_examples_mpiexec_version_result
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_STRIP_TRAILING_WHITESPACE
+    )
+    if(ftimer_examples_mpiexec_version_result EQUAL 0)
+      set(ftimer_examples_mpiexec_version_text
+        "${ftimer_examples_mpiexec_version_stdout}\n${ftimer_examples_mpiexec_version_stderr}")
+      if(ftimer_examples_mpiexec_version_text MATCHES "Open MPI|OpenRTE|PRTE|PRRTE")
+        set(ftimer_examples_mpiexec_oversubscribe_flags --map-by slot:OVERSUBSCRIBE)
+      endif()
+    endif()
+  endif()
+
   add_executable(mpi_example mpi_example.F90)
   target_link_libraries(mpi_example PRIVATE ftimer)
 
@@ -44,6 +63,9 @@ if(FTIMER_USE_MPI)
     endif()
     if(DEFINED MPIEXEC_PREFLAGS AND NOT MPIEXEC_PREFLAGS STREQUAL "")
       list(APPEND ftimer_mpi_example_command ${MPIEXEC_PREFLAGS})
+    endif()
+    if(ftimer_examples_mpiexec_oversubscribe_flags)
+      list(APPEND ftimer_mpi_example_command ${ftimer_examples_mpiexec_oversubscribe_flags})
     endif()
     list(APPEND ftimer_mpi_example_command "$<TARGET_FILE:mpi_example>")
     if(DEFINED MPIEXEC_POSTFLAGS AND NOT MPIEXEC_POSTFLAGS STREQUAL "")
@@ -59,7 +81,45 @@ if(FTIMER_USE_OPENMP)
   add_executable(openmp_example openmp_example.F90)
   target_link_libraries(openmp_example PRIVATE ftimer)
 
+  add_executable(openmp_worker_example openmp_worker_example.F90)
+  target_link_libraries(openmp_worker_example PRIVATE ftimer)
+
   if(FTIMER_BUILD_SMOKE_TESTS)
     add_test(NAME ftimer_openmp_example_smoke COMMAND openmp_example)
+    add_test(NAME ftimer_openmp_worker_example_smoke COMMAND openmp_worker_example)
+  endif()
+endif()
+
+if(FTIMER_USE_MPI AND FTIMER_USE_OPENMP)
+  add_executable(mpi_openmp_example mpi_openmp_example.F90)
+  target_link_libraries(mpi_openmp_example PRIVATE ftimer)
+
+  if(FTIMER_BUILD_SMOKE_TESTS)
+    set(ftimer_mpi_openmp_example_command "${MPIEXEC_EXECUTABLE}")
+    if(DEFINED MPIEXEC_NUMPROC_FLAG AND NOT MPIEXEC_NUMPROC_FLAG STREQUAL "")
+      list(APPEND ftimer_mpi_openmp_example_command "${MPIEXEC_NUMPROC_FLAG}" 2)
+    else()
+      list(APPEND ftimer_mpi_openmp_example_command -n 2)
+    endif()
+    if(DEFINED MPIEXEC_PREFLAGS AND NOT MPIEXEC_PREFLAGS STREQUAL "")
+      list(APPEND ftimer_mpi_openmp_example_command ${MPIEXEC_PREFLAGS})
+    endif()
+    if(ftimer_examples_mpiexec_oversubscribe_flags)
+      list(APPEND ftimer_mpi_openmp_example_command ${ftimer_examples_mpiexec_oversubscribe_flags})
+    endif()
+    list(APPEND ftimer_mpi_openmp_example_command "$<TARGET_FILE:mpi_openmp_example>")
+    if(DEFINED MPIEXEC_POSTFLAGS AND NOT MPIEXEC_POSTFLAGS STREQUAL "")
+      list(APPEND ftimer_mpi_openmp_example_command ${MPIEXEC_POSTFLAGS})
+    endif()
+
+    add_test(NAME ftimer_mpi_openmp_example_smoke
+      COMMAND ${CMAKE_COMMAND}
+        "-DTEST_COMMAND=${ftimer_mpi_openmp_example_command}"
+        -DTEST_NAME=ftimer_mpi_openmp_example_smoke
+        "-DTEST_REQUIRED_STDOUT=Strict MPI+OpenMP;Sparse MPI+OpenMP"
+        -P ${CMAKE_SOURCE_DIR}/tests/check_example_smoke.cmake
+    )
+    set_tests_properties(ftimer_mpi_openmp_example_smoke
+      PROPERTIES LABELS "mpi;openmp")
   endif()
 endif()

--- a/examples/mpi_openmp_example.F90
+++ b/examples/mpi_openmp_example.F90
@@ -1,0 +1,179 @@
+program mpi_openmp_example
+   use ftimer_openmp, only: ftimer_mpi_openmp_summary_t, ftimer_mpi_openmp_union_summary_t, &
+                            ftimer_openmp_config_t, &
+                            ftimer_openmp_parallel_region_t, ftimer_openmp_t
+   use ftimer_types, only: FTIMER_SUCCESS, wp
+   use mpi_f08, only: MPI_COMM_WORLD, MPI_Comm_rank, MPI_Comm_size, MPI_Finalize, &
+                      MPI_Init, MPI_SUCCESS
+   use omp_lib, only: omp_get_thread_num, omp_set_dynamic
+   implicit none
+
+   integer :: all_lanes_id
+   integer :: all_lanes_idx
+   integer :: ierr
+   integer :: i
+   integer :: nprocs
+   integer :: rank
+   integer :: sparse_id
+   integer :: sparse_idx
+   integer :: worker_bad
+   integer :: worker_seen
+   real(wp) :: accumulator
+   type(ftimer_openmp_config_t) :: config
+   type(ftimer_openmp_parallel_region_t) :: region
+   type(ftimer_mpi_openmp_summary_t) :: strict_summary
+   type(ftimer_mpi_openmp_union_summary_t) :: union_summary
+   type(ftimer_openmp_t) :: timer
+
+   call MPI_Init(ierr)
+   if (ierr /= MPI_SUCCESS) error stop "MPI_Init failed"
+   call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierr)
+   if (ierr /= MPI_SUCCESS) error stop "MPI_Comm_rank failed"
+   call MPI_Comm_size(MPI_COMM_WORLD, nprocs, ierr)
+   if (ierr /= MPI_SUCCESS) error stop "MPI_Comm_size failed"
+
+   call omp_set_dynamic(.false.)
+
+   config%max_lanes = 3
+   config%max_worker_diagnostics = 4
+
+   call timer%init(config=config, comm=MPI_COMM_WORLD, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "ftimer_openmp init failed"
+
+   call timer%register_timer("hybrid_all_lanes", all_lanes_id, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "register hybrid_all_lanes failed"
+
+   call timer%begin_parallel_region(region, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "begin strict hybrid region failed"
+
+   accumulator = 0.0_wp
+   worker_bad = 0
+   worker_seen = 0
+
+!$omp parallel num_threads(2) default(shared) private(ierr, i) &
+!$omp& reduction(+:accumulator, worker_bad, worker_seen)
+   worker_seen = worker_seen + 1
+
+   call timer%start_id(all_lanes_id, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) worker_bad = worker_bad + 1
+
+   do i = 1, (rank + omp_get_thread_num() + 1)*40000
+      accumulator = accumulator + real(i, wp)*0.25_wp
+   end do
+
+   call timer%stop_id(all_lanes_id, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) worker_bad = worker_bad + 1
+!$omp end parallel
+
+   if (worker_seen /= 2) error stop "strict hybrid example expected two threads"
+   if (worker_bad /= 0) error stop "strict hybrid worker timing failed"
+
+   call timer%end_parallel_region(region, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "end strict hybrid region failed"
+
+   call timer%mpi_openmp_summary(strict_summary, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "strict MPI+OpenMP summary failed"
+
+   all_lanes_idx = find_strict_entry(strict_summary, "hybrid_all_lanes")
+   if (all_lanes_idx <= 0) error stop "strict hybrid summary missing hybrid_all_lanes"
+   if (strict_summary%num_ranks /= nprocs) error stop "strict hybrid rank count mismatch"
+   if (strict_summary%entries(all_lanes_idx)%participating_rank_count /= nprocs) &
+      error stop "strict hybrid participating rank count mismatch"
+   if (strict_summary%entries(all_lanes_idx)%participating_rank_lane_sample_count /= nprocs*2) &
+      error stop "strict hybrid participating rank/lane count mismatch"
+
+   if (rank == 0) then
+      print '(a)', "Strict MPI+OpenMP worker timing with ftimer_openmp_t"
+      print '(a,i0)', "MPI ranks: ", nprocs
+      print '(a,i0)', "Participating rank/lane samples: ", &
+         strict_summary%entries(all_lanes_idx)%participating_rank_lane_sample_count
+   end if
+   call timer%print_mpi_openmp_summary(ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "print strict MPI+OpenMP summary failed"
+   call timer%write_mpi_openmp_summary_csv("mpi_openmp_strict_summary.csv", ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "write strict MPI+OpenMP CSV failed"
+
+   call timer%register_timer("rank0_lane0_only", sparse_id, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "register rank0_lane0_only failed"
+
+   call timer%begin_parallel_region(region, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "begin sparse hybrid region failed"
+
+   worker_bad = 0
+!$omp parallel num_threads(2) default(shared) private(ierr, i) reduction(+:accumulator, worker_bad)
+   if (rank == 0 .and. omp_get_thread_num() == 0) then
+      call timer%start_id(sparse_id, ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) worker_bad = worker_bad + 1
+
+      do i = 1, 30000
+         accumulator = accumulator + real(i, wp)*0.125_wp
+      end do
+
+      call timer%stop_id(sparse_id, ierr=ierr)
+      if (ierr /= FTIMER_SUCCESS) worker_bad = worker_bad + 1
+   end if
+!$omp end parallel
+
+   if (worker_bad /= 0) error stop "sparse hybrid worker timing failed"
+
+   call timer%end_parallel_region(region, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "end sparse hybrid region failed"
+
+   call timer%mpi_openmp_union_summary(union_summary, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "sparse MPI+OpenMP union summary failed"
+
+   sparse_idx = find_union_entry(union_summary, "rank0_lane0_only")
+   if (sparse_idx <= 0) error stop "sparse hybrid summary missing rank0_lane0_only"
+   if (union_summary%entries(sparse_idx)%participating_rank_count /= 1) &
+      error stop "sparse hybrid participating rank count mismatch"
+   if (union_summary%entries(sparse_idx)%participating_rank_lane_sample_count /= 1) &
+      error stop "sparse hybrid participating rank/lane count mismatch"
+
+   if (rank == 0) then
+      print '(a)', "Sparse MPI+OpenMP union summary for rank/lane-conditional timing"
+      print '(a,i0)', "Sparse participating ranks: ", &
+         union_summary%entries(sparse_idx)%participating_rank_count
+   end if
+   call timer%print_mpi_openmp_union_summary(ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "print sparse MPI+OpenMP union summary failed"
+   call timer%write_mpi_openmp_union_summary_csv("mpi_openmp_union_summary.csv", ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "write sparse MPI+OpenMP union CSV failed"
+
+   call timer%finalize(ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "ftimer_openmp finalize failed"
+   call MPI_Finalize(ierr)
+   if (ierr /= MPI_SUCCESS) error stop "MPI_Finalize failed"
+
+   if (accumulator < 0.0_wp) print *, accumulator
+
+contains
+
+   integer function find_strict_entry(summary, name) result(entry_idx)
+      type(ftimer_mpi_openmp_summary_t), intent(in) :: summary
+      character(len=*), intent(in) :: name
+      integer :: i
+
+      entry_idx = 0
+      do i = 1, summary%num_entries
+         if (trim(summary%entries(i)%name) == name) then
+            entry_idx = i
+            return
+         end if
+      end do
+   end function find_strict_entry
+
+   integer function find_union_entry(summary, name) result(entry_idx)
+      type(ftimer_mpi_openmp_union_summary_t), intent(in) :: summary
+      character(len=*), intent(in) :: name
+      integer :: i
+
+      entry_idx = 0
+      do i = 1, summary%num_entries
+         if (trim(summary%entries(i)%name) == name) then
+            entry_idx = i
+            return
+         end if
+      end do
+   end function find_union_entry
+
+end program mpi_openmp_example

--- a/examples/openmp_worker_example.F90
+++ b/examples/openmp_worker_example.F90
@@ -1,0 +1,101 @@
+program openmp_worker_example
+   use ftimer_openmp, only: ftimer_openmp_config_t, ftimer_openmp_parallel_region_t, &
+                            ftimer_openmp_summary_t, ftimer_openmp_t
+   use ftimer_types, only: FTIMER_SUCCESS, wp
+   use omp_lib, only: omp_get_thread_num, omp_set_dynamic
+   implicit none
+
+   integer :: entry_idx
+   integer :: ierr
+   integer :: i
+   integer :: team_work_id
+   integer :: worker_bad
+   integer :: worker_seen
+   real(wp) :: accumulator
+   type(ftimer_openmp_config_t) :: config
+   type(ftimer_openmp_parallel_region_t) :: region
+   type(ftimer_openmp_summary_t) :: summary
+   type(ftimer_openmp_t) :: timer
+
+   call omp_set_dynamic(.false.)
+
+   config%max_lanes = 3
+   config%max_worker_diagnostics = 4
+
+   call timer%init(config=config, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "ftimer_openmp init failed"
+
+   call timer%register_timer("team_work", team_work_id, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "ftimer_openmp register_timer failed"
+
+   call timer%begin_parallel_region(region, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "ftimer_openmp begin_parallel_region failed"
+
+   accumulator = 0.0_wp
+   worker_bad = 0
+   worker_seen = 0
+
+!$omp parallel num_threads(2) default(shared) private(ierr, i) &
+!$omp& reduction(+:accumulator, worker_bad, worker_seen)
+   worker_seen = worker_seen + 1
+
+   call timer%start_id(team_work_id, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) worker_bad = worker_bad + 1
+
+   do i = 1, (omp_get_thread_num() + 1)*60000
+      accumulator = accumulator + real(i, wp)*0.5_wp
+   end do
+
+   call timer%stop_id(team_work_id, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) worker_bad = worker_bad + 1
+!$omp end parallel
+
+   if (worker_seen /= 2) error stop "OpenMP worker example expected two threads"
+   if (worker_bad /= 0) error stop "OpenMP worker timing failed"
+
+   call timer%end_parallel_region(region, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "ftimer_openmp end_parallel_region failed"
+
+   call timer%get_openmp_summary(summary, ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "ftimer_openmp get_openmp_summary failed"
+
+   entry_idx = find_entry(summary, "team_work")
+   if (entry_idx <= 0) error stop "OpenMP worker example did not record team_work"
+   if (summary%entries(entry_idx)%participating_lane_count /= 2) &
+      error stop "OpenMP worker example expected two participating lanes"
+   if (summary%entries(entry_idx)%min_lane_call_count /= 1) &
+      error stop "OpenMP worker example expected one call per lane"
+   if (summary%entries(entry_idx)%max_lane_call_count /= 1) &
+      error stop "OpenMP worker example expected one call per lane"
+
+   print '(a)', "True OpenMP worker timing with ftimer_openmp_t"
+   print '(a,i0)', "Recorded OpenMP entries: ", summary%num_entries
+   print '(a,i0)', "Participating lanes for team_work: ", &
+      summary%entries(entry_idx)%participating_lane_count
+   call timer%print_openmp_summary(ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "ftimer_openmp print_openmp_summary failed"
+   call timer%write_openmp_summary_csv("openmp_worker_summary.csv", ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "ftimer_openmp write_openmp_summary_csv failed"
+
+   call timer%finalize(ierr=ierr)
+   if (ierr /= FTIMER_SUCCESS) error stop "ftimer_openmp finalize failed"
+
+   if (accumulator < 0.0_wp) print *, accumulator
+
+contains
+
+   integer function find_entry(summary, name) result(entry_idx)
+      type(ftimer_openmp_summary_t), intent(in) :: summary
+      character(len=*), intent(in) :: name
+      integer :: i
+
+      entry_idx = 0
+      do i = 1, summary%num_entries
+         if (trim(summary%entries(i)%name) == name) then
+            entry_idx = i
+            return
+         end if
+      end do
+   end function find_entry
+
+end program openmp_worker_example

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,7 +58,7 @@ if(FTIMER_BUILD_SMOKE_TESTS)
       test_openmp_mpi_summary_3rank_smoke.F90)
     target_link_libraries(ftimer_openmp_mpi_summary_3rank_smoke PRIVATE ftimer_smoke_test)
 
-    set(ftimer_mpiexec_oversubscribe_flag "")
+    set(ftimer_mpiexec_oversubscribe_flags)
     if(DEFINED MPIEXEC_EXECUTABLE AND NOT MPIEXEC_EXECUTABLE STREQUAL "")
       execute_process(
         COMMAND "${MPIEXEC_EXECUTABLE}" --version
@@ -72,7 +72,7 @@ if(FTIMER_BUILD_SMOKE_TESTS)
         set(ftimer_mpiexec_version_text
           "${ftimer_mpiexec_version_stdout}\n${ftimer_mpiexec_version_stderr}")
         if(ftimer_mpiexec_version_text MATCHES "Open MPI|OpenRTE|PRTE|PRRTE")
-          set(ftimer_mpiexec_oversubscribe_flag "--oversubscribe")
+          set(ftimer_mpiexec_oversubscribe_flags --map-by slot:OVERSUBSCRIBE)
         endif()
       endif()
     endif()
@@ -85,6 +85,9 @@ if(FTIMER_BUILD_SMOKE_TESTS)
     endif()
     if(DEFINED MPIEXEC_PREFLAGS AND NOT MPIEXEC_PREFLAGS STREQUAL "")
       list(APPEND ftimer_openmp_mpi_summary_command ${MPIEXEC_PREFLAGS})
+    endif()
+    if(ftimer_mpiexec_oversubscribe_flags)
+      list(APPEND ftimer_openmp_mpi_summary_command ${ftimer_mpiexec_oversubscribe_flags})
     endif()
     list(APPEND ftimer_openmp_mpi_summary_command "$<TARGET_FILE:ftimer_openmp_mpi_summary_smoke>")
     if(DEFINED MPIEXEC_POSTFLAGS AND NOT MPIEXEC_POSTFLAGS STREQUAL "")
@@ -109,9 +112,9 @@ if(FTIMER_BUILD_SMOKE_TESTS)
     if(DEFINED MPIEXEC_PREFLAGS AND NOT MPIEXEC_PREFLAGS STREQUAL "")
       list(APPEND ftimer_openmp_mpi_summary_3rank_command ${MPIEXEC_PREFLAGS})
     endif()
-    if(NOT ftimer_mpiexec_oversubscribe_flag STREQUAL "")
+    if(ftimer_mpiexec_oversubscribe_flags)
       list(APPEND ftimer_openmp_mpi_summary_3rank_command
-        ${ftimer_mpiexec_oversubscribe_flag})
+        ${ftimer_mpiexec_oversubscribe_flags})
     endif()
     list(APPEND ftimer_openmp_mpi_summary_3rank_command
       "$<TARGET_FILE:ftimer_openmp_mpi_summary_3rank_smoke>")
@@ -218,6 +221,14 @@ add_test(NAME ftimer_installed_openmp_hybrid_api_surface
     -P ${CMAKE_CURRENT_SOURCE_DIR}/check_installed_openmp_hybrid_api_surface.cmake
 )
 set_tests_properties(ftimer_installed_openmp_hybrid_api_surface
+  PROPERTIES LABELS "mpi;openmp")
+
+add_test(NAME ftimer_openmp_hybrid_examples_contract
+  COMMAND ${CMAKE_COMMAND}
+    -DREPO_ROOT=${CMAKE_SOURCE_DIR}
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/check_openmp_hybrid_examples_contract.cmake
+)
+set_tests_properties(ftimer_openmp_hybrid_examples_contract
   PROPERTIES LABELS "mpi;openmp")
 
 if(FTIMER_BUILD_SMOKE_TESTS)

--- a/tests/check_example_smoke.cmake
+++ b/tests/check_example_smoke.cmake
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.16)
+
+if(NOT DEFINED TEST_COMMAND OR TEST_COMMAND STREQUAL "")
+  message(FATAL_ERROR "TEST_COMMAND must be provided.")
+endif()
+
+if(NOT DEFINED TEST_NAME OR TEST_NAME STREQUAL "")
+  set(TEST_NAME "example smoke")
+endif()
+
+if(NOT DEFINED SMOKE_TIMEOUT_SECONDS OR SMOKE_TIMEOUT_SECONDS STREQUAL "")
+  set(SMOKE_TIMEOUT_SECONDS 60)
+endif()
+
+execute_process(
+  COMMAND ${TEST_COMMAND}
+  TIMEOUT ${SMOKE_TIMEOUT_SECONDS}
+  RESULT_VARIABLE example_result
+  OUTPUT_VARIABLE example_stdout
+  ERROR_VARIABLE example_stderr
+)
+
+if(NOT example_result EQUAL 0)
+  message(FATAL_ERROR
+    "${TEST_NAME} exited with a nonzero status.\n"
+    "stdout:\n${example_stdout}\n"
+    "stderr:\n${example_stderr}"
+  )
+endif()
+
+foreach(required_stdout IN LISTS TEST_REQUIRED_STDOUT)
+  string(FIND "${example_stdout}" "${required_stdout}" required_stdout_index)
+  if(required_stdout_index EQUAL -1)
+    message(FATAL_ERROR
+      "${TEST_NAME} stdout did not contain expected text: ${required_stdout}\n"
+      "stdout:\n${example_stdout}\n"
+      "stderr:\n${example_stderr}"
+    )
+  endif()
+endforeach()

--- a/tests/check_installed_package_consumer.cmake
+++ b/tests/check_installed_package_consumer.cmake
@@ -877,6 +877,21 @@ if(TEST_ENABLE_MPI)
   if(DEFINED TEST_MPIEXEC_PREFLAGS AND NOT TEST_MPIEXEC_PREFLAGS STREQUAL "")
     list(APPEND ftimer_mpi_launch_prefix ${TEST_MPIEXEC_PREFLAGS})
   endif()
+  execute_process(
+    COMMAND "${ftimer_mpiexec}" --version
+    OUTPUT_VARIABLE ftimer_mpiexec_version_stdout
+    ERROR_VARIABLE ftimer_mpiexec_version_stderr
+    RESULT_VARIABLE ftimer_mpiexec_version_result
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+  )
+  if(ftimer_mpiexec_version_result EQUAL 0)
+    set(ftimer_mpiexec_version_text
+      "${ftimer_mpiexec_version_stdout}\n${ftimer_mpiexec_version_stderr}")
+    if(ftimer_mpiexec_version_text MATCHES "Open MPI|OpenRTE|PRTE|PRRTE")
+      list(APPEND ftimer_mpi_launch_prefix --map-by slot:OVERSUBSCRIBE)
+    endif()
+  endif()
 
   set(ftimer_mpi_launch_command "${ftimer_mpi_launch_prefix}")
   list(APPEND ftimer_mpi_launch_command "${mpi_consumer_executable}")

--- a/tests/check_openmp_hybrid_examples_contract.cmake
+++ b/tests/check_openmp_hybrid_examples_contract.cmake
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.16)
+
+set(required_example_paths
+  examples/openmp_worker_example.F90
+  examples/mpi_openmp_example.F90
+)
+
+foreach(required_example_path IN LISTS required_example_paths)
+  if(NOT EXISTS "${REPO_ROOT}/${required_example_path}")
+    message(FATAL_ERROR "Documented OpenMP/hybrid example is missing: ${required_example_path}")
+  endif()
+endforeach()
+
+file(READ "${REPO_ROOT}/examples/CMakeLists.txt" examples_cmake)
+
+set(required_examples_cmake_phrases
+  "add_executable(openmp_worker_example openmp_worker_example.F90)"
+  "target_link_libraries(openmp_worker_example PRIVATE ftimer)"
+  "add_test(NAME ftimer_openmp_worker_example_smoke COMMAND openmp_worker_example)"
+  "add_executable(mpi_openmp_example mpi_openmp_example.F90)"
+  "target_link_libraries(mpi_openmp_example PRIVATE ftimer)"
+  "add_test(NAME ftimer_mpi_openmp_example_smoke"
+  "set_tests_properties(ftimer_mpi_openmp_example_smoke"
+  "PROPERTIES LABELS \"mpi;openmp\""
+)
+
+foreach(required_phrase IN LISTS required_examples_cmake_phrases)
+  string(FIND "${examples_cmake}" "${required_phrase}" phrase_index)
+  if(phrase_index EQUAL -1)
+    message(FATAL_ERROR "examples/CMakeLists.txt is missing OpenMP/hybrid example contract text: ${required_phrase}")
+  endif()
+endforeach()
+
+set(required_doc_mentions
+  "README.md|examples/openmp_worker_example.F90"
+  "README.md|examples/mpi_openmp_example.F90"
+  "docs/openmp-timing-modes.md|examples/openmp_worker_example.F90"
+  "docs/openmp-timing-modes.md|examples/mpi_openmp_example.F90"
+  "docs/release.md|examples/openmp_worker_example.F90"
+  "docs/release.md|examples/mpi_openmp_example.F90"
+)
+
+foreach(required_doc_mention IN LISTS required_doc_mentions)
+  string(REPLACE "|" ";" mention_parts "${required_doc_mention}")
+  list(GET mention_parts 0 doc_path)
+  list(GET mention_parts 1 required_text)
+  file(READ "${REPO_ROOT}/${doc_path}" doc_text)
+  string(FIND "${doc_text}" "${required_text}" doc_index)
+  if(doc_index EQUAL -1)
+    message(FATAL_ERROR "${doc_path} must mention ${required_text}.")
+  endif()
+endforeach()


### PR DESCRIPTION
## Summary

Closes #274.

- Add `examples/openmp_worker_example.F90` for true OpenMP worker timing through `ftimer_openmp_t`, registered ids, explicit timed-region lifecycle, local OpenMP summary printing, and local OpenMP CSV output.
- Add `examples/mpi_openmp_example.F90` for strict MPI+OpenMP rank/lane summaries plus sparse union MPI+OpenMP participation summaries through the real public API.
- Wire focused smoke/contract coverage for the new example targets and docs mentions, and make OpenMPI-family local smoke launches use `--map-by slot:OVERSUBSCRIBE` where needed.
- Update README, semantics, design, installed API docs, OpenMP timing mode guidance, and release checklist/release-note guidance to separate compatibility, true OpenMP, strict hybrid, and sparse hybrid paths.

## Validation

- TDD red step: `cmake -E chdir build-codex-274-contract ctest --output-on-failure -R '^ftimer_openmp_hybrid_examples_contract$'` failed before the new examples/docs were added.
- `cmake -E chdir build-codex-274-contract ctest --output-on-failure -R '^(ftimer_release_docs_contract|ftimer_openmp_hybrid_examples_contract)$'`
- `FC=gfortran cmake -S . -B build-codex-274-openmp-gfortran -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=OFF`
- `cmake --build build-codex-274-openmp-gfortran`
- `cmake -E chdir build-codex-274-openmp-gfortran ctest --output-on-failure`
- `FC=mpifort cmake -S . -B build-codex-274-mpi-openmp -DFTIMER_USE_MPI=ON -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=OFF`
- `cmake --build build-codex-274-mpi-openmp`
- `cmake -E chdir build-codex-274-mpi-openmp ctest --output-on-failure`
- `fprettify --diff examples/openmp_worker_example.F90 examples/mpi_openmp_example.F90`
- `git diff --check`