### PR TITLE
docs: add troubleshooting guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,7 @@ Read additional docs only when the task requires them:
 
 - `docs/semantics.md` — when runtime behavior or contract is changing or unclear
 - `README.md` — when user-facing behavior, examples, or docs may need updates
+- `docs/troubleshooting.md` — when first-use build, MPI, OpenMP, CSV, or summary/report failures need practical remedies
 - `docs/design.md` — for architectural or repository-structure questions
 - `docs/implementation-history.md` — for historical roadmap context or landed implementation history
 - `docs/maintainer.md` — for workflow routing; then load only the workflow-specific doc you need:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,7 @@ Read additional docs only when the task requires them:
 
 - `docs/semantics.md` — when runtime behavior or contract is changing or unclear
 - `README.md` — when user-facing behavior, examples, or docs may need updates
+- `docs/troubleshooting.md` — when first-use build, MPI, OpenMP, CSV, or summary/report failures need practical remedies
 - `docs/design.md` — for architectural or repository-structure questions
 - `docs/implementation-history.md` — for historical roadmap context or landed implementation history
 - `docs/maintainer.md` — for workflow routing; then load only the workflow-specific doc you need:

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ The exact timings vary by machine and compiler, but a successful run should show
 
 This is the default happy path for first-time evaluation. It exercises the library build, links an example program, and produces believable summary output without requiring MPI or pFUnit.
 
+If the first build, MPI path, OpenMP path, CSV export, or first example fails,
+see the symptom-oriented [`docs/troubleshooting.md`](docs/troubleshooting.md)
+guide before digging into the full semantics reference.
+
 ## Install And Use From Another Project
 
 Install fTimer to a prefix:
@@ -410,6 +414,10 @@ compiler/runtime pair.
 
 The smoke-test path also runs the enabled and disabled instrumentation facade examples so the documented compile-out strategy stays buildable.
 
+For practical remedies to first-use build failures, MPI summary hangs, OpenMP
+worker-call surprises, and CSV append errors, see
+[`docs/troubleshooting.md`](docs/troubleshooting.md).
+
 Supported toolchain matrix:
 
 - Serial smoke/library build: GNU Fortran and LLVM Flang are validated in automation
@@ -487,6 +495,7 @@ The benchmark harness also includes reporting-scale rows for local text reports,
 ## More Detail
 
 - Runtime semantics: [`docs/semantics.md`](docs/semantics.md)
+- Troubleshooting guide: [`docs/troubleshooting.md`](docs/troubleshooting.md)
 - Current architecture reference: [`docs/design.md`](docs/design.md)
 - OpenMP timing modes and migration guide: [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md)
 - Release checklist and artifact policy: [`docs/release.md`](docs/release.md)

--- a/docs/design.md
+++ b/docs/design.md
@@ -357,6 +357,7 @@ The repository also carries a detailed prompt library under `.github/prompts/det
 The docs set is intentionally split by purpose:
 
 - [`README.md`](../README.md): user-facing setup, usage, limitations, and examples
+- [`docs/troubleshooting.md`](troubleshooting.md): symptom-oriented remedies for first-use build, MPI, OpenMP, CSV, and summary/report failures
 - [`docs/semantics.md`](semantics.md): current runtime contract and behavior
 - [`docs/design.md`](design.md): current repository architecture, validation reality, and workflow context
 - [`docs/openmp-timing-modes.md`](openmp-timing-modes.md): OpenMP and

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,297 @@
+> **When to read this:** When a first build, MPI summary/report, CSV export, or
+> OpenMP timing attempt fails and you want the practical next step. This is a
+> troubleshooting guide, not a replacement for the full runtime contract in
+> [`docs/semantics.md`](semantics.md).
+
+# fTimer Troubleshooting
+
+Start with the smallest build that exercises what you need:
+
+```bash
+cmake -B build-smoke
+cmake --build build-smoke
+cmake -E chdir build-smoke ctest --output-on-failure
+```
+
+For the first example only:
+
+```bash
+cmake --build build-smoke --target basic_usage
+./build-smoke/examples/basic_usage
+```
+
+That path should not require MPI or pFUnit. If it fails, fix the serial build
+first before adding MPI, OpenMP, or the pFUnit suite.
+
+## Configure Cannot Find A Fortran Compiler
+
+CMake needs a Fortran compiler with preprocessing support. Install or load a
+validated compiler, then configure with that compiler explicitly:
+
+```bash
+FC=gfortran cmake -B build-smoke
+```
+
+GNU Fortran and LLVM Flang are the validated serial smoke paths. Other serial
+compilers may work, but they are outside the current release-validated matrix.
+
+## Configure Fails After Switching Compilers Or Modes
+
+CMake build trees are not portable across compiler or mode changes. A build
+directory configured with `gfortran` should not be reused for `mpifort`,
+`flang-19`, `FTIMER_USE_MPI=ON`, or `FTIMER_USE_OPENMP=ON`.
+
+Use a separate build directory:
+
+```bash
+FC=gfortran cmake -B build-smoke
+FC=mpifort cmake -B build-mpi-smoke -DFTIMER_USE_MPI=ON
+FC=gfortran cmake -B build-openmp -DFTIMER_USE_OPENMP=ON
+```
+
+For a clean reconfigure, remove the old build directory or use a fresh one.
+With CMake 3.24 or newer, `cmake --fresh` is also available as a convenience.
+
+## Configure Fails With pFUnit Enabled
+
+`FTIMER_BUILD_TESTS=ON` enables the pFUnit behavioral suite. That requires a
+pFUnit installation built for the same compiler and, for MPI tests, the same MPI
+toolchain family.
+
+Pass the install prefix explicitly:
+
+```bash
+FC=gfortran cmake -B build -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
+```
+
+If you only want the smoke path and examples, leave `FTIMER_BUILD_TESTS=OFF`.
+The default smoke build does not require pFUnit.
+
+## Configure Fails With MPI Enabled
+
+`FTIMER_USE_MPI=ON` is intended for MPI wrapper compilers such as `mpifort`.
+Configure runs a small `mpi_f08` probe and fails early if the active compiler
+cannot consume the discovered MPI module files.
+
+Use a wrapper from the same toolchain as the MPI installation:
+
+```bash
+FC=mpifort cmake -B build-mpi-smoke -DFTIMER_USE_MPI=ON -DFTIMER_BUILD_TESTS=OFF
+```
+
+If the error mentions `mpi_f08`, `MPI_Type_match_size`, or
+`MPI_ERRORS_RETURN`, check that:
+
+- `FC` or `CMAKE_Fortran_COMPILER` points at the MPI wrapper you meant to use.
+- The wrapper belongs to the MPI installation CMake discovered.
+- The MPI implementation provides the `mpi_f08` interfaces fTimer validates.
+
+The supported communicator interface is `type(MPI_Comm)` from `mpi_f08`.
+Legacy integer communicator handles and `mpif.h` are not supported paths.
+
+## Configure Fails With OpenMP Enabled
+
+`FTIMER_USE_OPENMP=ON` is currently validated for GNU Fortran and LLVM Flang.
+The configure step rejects unvalidated compiler IDs before trying to discover
+the OpenMP runtime.
+
+Use one of the documented paths:
+
+```bash
+FC=gfortran cmake -B build-openmp -DFTIMER_USE_OPENMP=ON
+FC=flang-19 cmake -B build-openmp-flang -DFTIMER_USE_OPENMP=ON -DOpenMP_ROOT=/path/to/libomp
+```
+
+LLVM Flang OpenMP validation requires CMake 3.24 or newer so CMake reports the
+compiler ID as `LLVMFlang`. If runtime execution is unavailable because you are
+cross-compiling or packaging in a restricted environment,
+`FTIMER_OPENMP_ASSUME_MASTER_PROBE_OK=ON` is an advanced maintainer escape hatch
+and should be used only after independently validating equivalent OpenMP
+master-thread and worker-lane semantics.
+
+## OpenMP Worker Calls Do Not Appear In The Summary
+
+For the existing `ftimer` and `ftimer_core` APIs, `FTIMER_USE_OPENMP=ON` enables
+a master-thread-only compatibility carve-out. Worker-thread calls made inside an
+OpenMP parallel region are silent no-ops: no summary row, no call-count
+increment, and no changed `ierr`.
+
+To time a parallel region as one wall-clock interval, place `start` and `stop`
+outside the `!$omp parallel` block. To record worker-lane participation, use the
+explicit `ftimer_openmp_t` API with registered ids and an explicitly opened
+timed region. See [`docs/openmp-timing-modes.md`](openmp-timing-modes.md).
+
+Global compiler flags such as `-fopenmp` do not enable fTimer's guards when the
+library was configured with `FTIMER_USE_OPENMP=OFF`. The CMake option is the
+source-level switch for the guard code and the supported worker-timing runtime.
+
+## MPI Checklist
+
+Before debugging the output, confirm the lifecycle and communicator contract:
+
+- Call MPI-enabled fTimer only after `MPI_Init` and before `MPI_Finalize`.
+- Finish fTimer MPI summaries, reports, CSV writes, `finalize()`, and any
+  reinitialization before freeing a caller-owned communicator.
+- Keep `init(comm=...)` communicators valid; fTimer stores borrowed,
+  non-owning handles and does not call `MPI_Comm_dup` or `MPI_Comm_free`.
+- Have every rank in the captured communicator enter each MPI summary/report
+  collective.
+- Stop all timers before MPI summary/report calls. Local summaries can snapshot
+  active timers; MPI summaries are stopped-run-only.
+- Use strict MPI summary/report APIs only when all participating ranks have the
+  same descriptor tree.
+- Use sparse union APIs for rank-conditional timer trees.
+
+fTimer does not insert MPI barriers around timed regions. It reduces rank-local
+wall-clock intervals. If you need a synchronized global phase, add the barrier
+or synchronization you intend to measure in application code.
+
+## MPI Summary Returns `FTIMER_ERR_MPI_INCON`
+
+Strict MPI summaries and reports require identical timer descriptor trees across
+all ranks in the captured communicator. Extra timers, missing timers, renamed
+timers, or different parent/child structure cause `FTIMER_ERR_MPI_INCON`.
+
+Fix by making every participating rank create the same timer tree, or switch to
+the sparse union API for rank-conditional work:
+
+```fortran
+call ftimer_mpi_union_summary(summary, ierr=ierr)
+call ftimer_write_mpi_union_summary_csv("ftimer-mpi-union.csv", ierr=ierr)
+```
+
+Sparse union entries report explicit participation counts. A missing rank is
+absent from that descriptor; it is not the same as a rank that participated with
+a real zero-time, zero-call entry.
+
+## MPI Summary Returns `FTIMER_ERR_ACTIVE`
+
+MPI summaries and MPI report/CSV writers require a fully stopped timer set. If
+any participating rank still has an active timer, the collective summary/report
+path returns `FTIMER_ERR_ACTIVE` and leaves the MPI result or normal artifact
+empty.
+
+Stop every timer on every rank before calling:
+
+```fortran
+call ftimer_stop("phase", ierr=ierr)
+call ftimer_mpi_summary(summary, ierr=ierr)
+```
+
+For local debugging snapshots, use `ftimer_get_summary()` separately. Local
+summary APIs can show active timers; MPI summary APIs intentionally do not.
+
+## MPI Summary Hangs
+
+The practical failure mode for divergent communicators or missing collective
+participants is a hang. fTimer can detect descriptor disagreement only after all
+ranks have entered the same communicator collective. It cannot safely rendezvous
+across different communicator choices after the application has already split.
+
+Check that:
+
+- Every rank that belongs to the captured communicator reaches the same
+  `mpi_summary`, MPI report, or MPI CSV call.
+- All ranks captured the same communicator choice at `init`.
+- Caller-owned subcommunicators were not freed before fTimer finished using
+  them.
+- Rank-conditional code does not skip the collective itself. Use sparse union
+  APIs for conditional descriptors, not conditional collective entry.
+
+## MPI APIs Return `FTIMER_ERR_NOT_IMPLEMENTED`
+
+If fTimer was built with `FTIMER_USE_MPI=OFF`, MPI summary/report APIs return
+`FTIMER_ERR_NOT_IMPLEMENTED`. They do not fall back to local summaries and do
+not create or replace MPI report files.
+
+Reconfigure with MPI enabled if you need MPI reports:
+
+```bash
+FC=mpifort cmake -B build-mpi-smoke -DFTIMER_USE_MPI=ON -DFTIMER_BUILD_TESTS=OFF
+```
+
+If you only need rank-local data from a non-MPI build, call the local summary or
+CSV APIs instead.
+
+## CSV Columns Look Different Between Files
+
+fTimer has several CSV schemas. They are separate on purpose:
+
+- Local and strict MPI CSV use `format_version=2`.
+- Sparse MPI union CSV uses `format_version=1` and `summary_kind=mpi_union`.
+- Local OpenMP, strict MPI+OpenMP, and sparse MPI+OpenMP CSV each use their own
+  `format_version=1` schema.
+
+Small examples:
+
+```fortran
+call ftimer_write_summary_csv("local.csv", ierr=ierr)
+call ftimer_write_mpi_summary_csv("mpi-strict.csv", ierr=ierr)
+call ftimer_write_mpi_union_summary_csv("mpi-union.csv", ierr=ierr)
+```
+
+Do not append sparse union rows to a local/strict MPI CSV file or the reverse.
+Those headers are not append-compatible.
+
+## CSV Append Returns `FTIMER_ERR_IO`
+
+With `append=.true.`, fTimer validates the existing non-empty file before adding
+new records. It rejects the append with `FTIMER_ERR_IO` if the target has:
+
+- a mismatched header or older schema
+- rows with the wrong field count
+- unrecognized `summary_kind` or `record_type` combinations
+- malformed CSV quoting
+- a final record that is not newline-terminated
+- a schema from a different report family, such as sparse union CSV versus
+  local/strict MPI CSV
+
+The existing file is left unchanged on validation failure. Start a new output
+file, append only to files produced by the same API/schema, or repair the
+existing file so the header, records, quoting, and final newline are valid.
+
+## CSV Counts Or Text Fields Look Surprising
+
+Local `call_count` and strict MPI `min_call_count`/`max_call_count` are emitted
+as signed 64-bit decimal text. Parse them as at least signed 64-bit integers.
+Strict MPI `avg_call_count` remains a real-valued field.
+
+Timer names and metadata key/value fields use standard CSV quoting. CSV output
+does not use the visible escaping used by human text reports, and it is not
+spreadsheet-formula-sanitized. Treat CSV as data from the generating program
+when opening it in spreadsheet software.
+
+## Reports Look Incomplete
+
+Local, strict MPI, sparse MPI union, local OpenMP, strict MPI+OpenMP, and sparse
+MPI+OpenMP report APIs are distinct surfaces.
+
+- `print_summary()` and `write_summary()` are local snapshot reports.
+- `print_mpi_summary()` and `write_mpi_summary()` are strict MPI reports.
+- `print_mpi_union_summary()` and `write_mpi_union_summary()` are sparse MPI
+  union reports.
+- The `ftimer_openmp_t` report families are separate from the classic local and
+  pure-MPI report families.
+
+Strict MPI text reports are abbreviated human reports. The complete
+machine-facing data is in `ftimer_mpi_summary_t` or the strict MPI CSV output.
+For sparse/rank-conditional work, use `ftimer_mpi_union_summary_t` or sparse
+union CSV so participation and missing-rank counts are explicit.
+
+## Active Local Summaries Are Snapshots
+
+Local summaries can include active timers as a snapshot at summary time. That is
+useful for diagnostics, but it is not a final stopped-run report. Stop all
+timers first when you need a final local report, and check
+`summary%has_active_timers == .false.`.
+
+MPI summaries, MPI reports, OpenMP worker summaries, and hybrid summaries are
+stricter merge/report points. They require stopped timers or stopped timed
+regions and return `FTIMER_ERR_ACTIVE` when that preflight fails.
+
+## Timings Do Not Include Device Or Synchronized MPI Time
+
+fTimer records host wall-clock time between your `start` and `stop` calls. It
+does not synchronize GPU/device queues, and it does not insert MPI barriers. Add
+device synchronization or MPI synchronization in the application when that is
+the quantity you intend to measure.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,6 +16,7 @@ cmake -E chdir build-smoke ctest --output-on-failure
 For the first example only:
 
 ```bash
+cmake -B build-smoke
 cmake --build build-smoke --target basic_usage
 ./build-smoke/examples/basic_usage
 ```
@@ -66,6 +67,34 @@ FC=gfortran cmake -B build -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit
 
 If you only want the smoke path and examples, leave `FTIMER_BUILD_TESTS=OFF`.
 The default smoke build does not require pFUnit.
+
+## Downstream Configure Cannot Find fTimer
+
+Downstream projects should consume the installed CMake package with
+`find_package(fTimer CONFIG REQUIRED)`. If CMake reports that it cannot find
+`fTimerConfig.cmake`, point `CMAKE_PREFIX_PATH` at the prefix where fTimer was
+installed:
+
+```bash
+cmake -B build-install -DCMAKE_INSTALL_PREFIX=/path/to/ftimer-install
+cmake --build build-install
+cmake --install build-install
+cmake -S my_app -B my_app/build -DCMAKE_PREFIX_PATH=/path/to/ftimer-install
+```
+
+Check that the selected prefix contains the package files, usually under
+`lib/cmake/fTimer/`, and the Fortran module artifacts under `include/ftimer/`
+unless `CMAKE_INSTALL_INCLUDEDIR` was changed. If you switched compilers or
+feature modes, rebuild and reinstall into a fresh prefix so the downstream
+project does not mix stale module files with a new compiler or MPI/OpenMP mode.
+
+The smoke suite verifies this contract through the installed-package consumer:
+
+```bash
+cmake -B build-smoke
+cmake --build build-smoke
+cmake -E chdir build-smoke ctest --output-on-failure -R ftimer_installed_package_consumer$
+```
 
 ## Configure Fails With MPI Enabled
 

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -251,50 +251,137 @@ endforeach()
 
 file(READ "${REPO_ROOT}/docs/troubleshooting.md" troubleshooting_doc_text)
 file(READ "${REPO_ROOT}/tests/public_symbol_allowlist.txt" public_symbol_allowlist_text)
+file(READ "${REPO_ROOT}/CMakeLists.txt" root_cmakelists_text)
 
-set(troubleshooting_public_api_tokens
-  ftimer_mpi_union_summary
-  ftimer_write_mpi_union_summary_csv
-  ftimer_stop
+set(troubleshooting_routing_docs
+  AGENTS.md
+  CLAUDE.md
+  docs/design.md
+)
+
+foreach(troubleshooting_routing_doc IN LISTS troubleshooting_routing_docs)
+  file(READ "${REPO_ROOT}/${troubleshooting_routing_doc}" troubleshooting_routing_doc_text)
+  string(FIND "${troubleshooting_routing_doc_text}" "docs/troubleshooting.md" troubleshooting_routing_index)
+  if(troubleshooting_routing_index EQUAL -1)
+    message(FATAL_ERROR
+      "${troubleshooting_routing_doc} must route practical first-use, MPI, OpenMP, CSV, and summary/report failures to docs/troubleshooting.md."
+    )
+  endif()
+endforeach()
+
+set(troubleshooting_cmake_option_tokens
+  FTIMER_USE_MPI
+  FTIMER_USE_OPENMP
+  FTIMER_OPENMP_ASSUME_MASTER_PROBE_OK
+  FTIMER_BUILD_TESTS
+  FTIMER_BUILD_SMOKE_TESTS
+  FTIMER_BUILD_EXAMPLES
+  FTIMER_BUILD_BENCH
+)
+
+set(troubleshooting_public_aliases
+  finalize=ftimer_finalize
+  get_summary=ftimer_get_summary
+  init=ftimer_init
+  print_mpi_summary=ftimer_print_mpi_summary
+  print_mpi_union_summary=ftimer_print_mpi_union_summary
+  print_summary=ftimer_print_summary
+  start=ftimer_start
+  stop=ftimer_stop
+  write_mpi_summary=ftimer_write_mpi_summary
+  write_mpi_union_summary=ftimer_write_mpi_union_summary
+  write_summary=ftimer_write_summary
+)
+
+set(troubleshooting_ignored_identifier_tokens
+  ftimer
+  ftimer_core
+  ftimer_installed_package_consumer
+)
+
+string(REGEX MATCHALL "[A-Za-z][A-Za-z0-9_]*" troubleshooting_identifier_tokens "${troubleshooting_doc_text}")
+list(REMOVE_DUPLICATES troubleshooting_identifier_tokens)
+
+set(troubleshooting_documented_public_tokens)
+set(troubleshooting_documented_cmake_options)
+
+foreach(troubleshooting_identifier IN LISTS troubleshooting_identifier_tokens)
+  if(troubleshooting_identifier IN_LIST troubleshooting_ignored_identifier_tokens)
+    continue()
+  endif()
+
+  if(troubleshooting_identifier IN_LIST troubleshooting_cmake_option_tokens)
+    list(APPEND troubleshooting_documented_cmake_options "${troubleshooting_identifier}")
+    continue()
+  endif()
+
+  set(troubleshooting_canonical_symbol "")
+  foreach(troubleshooting_public_alias IN LISTS troubleshooting_public_aliases)
+    string(REPLACE "=" ";" troubleshooting_public_alias_parts "${troubleshooting_public_alias}")
+    list(GET troubleshooting_public_alias_parts 0 troubleshooting_public_alias_name)
+    list(GET troubleshooting_public_alias_parts 1 troubleshooting_public_alias_symbol)
+    if(troubleshooting_identifier STREQUAL troubleshooting_public_alias_name)
+      set(troubleshooting_canonical_symbol "${troubleshooting_public_alias_symbol}")
+    endif()
+  endforeach()
+
+  if(troubleshooting_canonical_symbol)
+    list(APPEND troubleshooting_documented_public_tokens "${troubleshooting_canonical_symbol}")
+    continue()
+  endif()
+
+  if(troubleshooting_identifier MATCHES "^(ftimer_[A-Za-z0-9_]+|FTIMER_[A-Za-z0-9_]+)$")
+    list(APPEND troubleshooting_documented_public_tokens "${troubleshooting_identifier}")
+    continue()
+  endif()
+
+  if(troubleshooting_identifier MATCHES "^(print_|write_)[A-Za-z0-9_]+$")
+    message(FATAL_ERROR
+      "docs/troubleshooting.md documents shorthand public API alias '${troubleshooting_identifier}', but tests/check_release_docs_contract.cmake does not map it to a stable public symbol."
+    )
+  endif()
+endforeach()
+
+list(REMOVE_DUPLICATES troubleshooting_documented_public_tokens)
+list(REMOVE_DUPLICATES troubleshooting_documented_cmake_options)
+
+foreach(troubleshooting_cmake_option IN LISTS troubleshooting_documented_cmake_options)
+  if(NOT root_cmakelists_text MATCHES "option\\([ \t\r\n]*${troubleshooting_cmake_option}([ \t\r\n]|\\))")
+    message(FATAL_ERROR
+      "docs/troubleshooting.md documents CMake option '${troubleshooting_cmake_option}', but CMakeLists.txt does not define it as an option."
+    )
+  endif()
+endforeach()
+
+foreach(troubleshooting_public_token IN LISTS troubleshooting_documented_public_tokens)
+  if(NOT public_symbol_allowlist_text MATCHES "(^|\n)[^|\n]+\\|${troubleshooting_public_token}\\|stable(\n|$)")
+    message(FATAL_ERROR
+      "docs/troubleshooting.md documents '${troubleshooting_public_token}', but tests/public_symbol_allowlist.txt does not mark it as a stable public symbol."
+    )
+  endif()
+endforeach()
+
+set(required_troubleshooting_public_tokens
+  FTIMER_ERR_MPI_INCON
+  FTIMER_ERR_ACTIVE
+  FTIMER_ERR_NOT_IMPLEMENTED
+  FTIMER_ERR_IO
+  ftimer_get_summary
   ftimer_mpi_summary
+  ftimer_mpi_union_summary
+  ftimer_openmp_t
+  ftimer_mpi_summary_t
+  ftimer_mpi_union_summary_t
   ftimer_write_summary_csv
   ftimer_write_mpi_summary_csv
   ftimer_write_mpi_union_summary_csv
 )
 
-foreach(troubleshooting_public_api_token IN LISTS troubleshooting_public_api_tokens)
-  string(FIND "${troubleshooting_doc_text}" "${troubleshooting_public_api_token}" token_doc_index)
-  if(token_doc_index EQUAL -1)
+foreach(required_troubleshooting_public_token IN LISTS required_troubleshooting_public_tokens)
+  list(FIND troubleshooting_documented_public_tokens "${required_troubleshooting_public_token}" required_troubleshooting_public_token_index)
+  if(required_troubleshooting_public_token_index EQUAL -1)
     message(FATAL_ERROR
-      "docs/troubleshooting.md must document public API token '${troubleshooting_public_api_token}'."
-    )
-  endif()
-
-  if(NOT public_symbol_allowlist_text MATCHES "(^|\n)ftimer\\|${troubleshooting_public_api_token}\\|stable(\n|$)")
-    message(FATAL_ERROR
-      "docs/troubleshooting.md documents '${troubleshooting_public_api_token}', but tests/public_symbol_allowlist.txt does not mark it as a stable ftimer API."
-    )
-  endif()
-endforeach()
-
-set(troubleshooting_status_tokens
-  FTIMER_ERR_MPI_INCON
-  FTIMER_ERR_ACTIVE
-  FTIMER_ERR_NOT_IMPLEMENTED
-  FTIMER_ERR_IO
-)
-
-foreach(troubleshooting_status_token IN LISTS troubleshooting_status_tokens)
-  string(FIND "${troubleshooting_doc_text}" "${troubleshooting_status_token}" status_doc_index)
-  if(status_doc_index EQUAL -1)
-    message(FATAL_ERROR
-      "docs/troubleshooting.md must document status token '${troubleshooting_status_token}'."
-    )
-  endif()
-
-  if(NOT public_symbol_allowlist_text MATCHES "(^|\n)ftimer_types\\|${troubleshooting_status_token}\\|stable(\n|$)")
-    message(FATAL_ERROR
-      "docs/troubleshooting.md documents '${troubleshooting_status_token}', but tests/public_symbol_allowlist.txt does not mark it as a stable ftimer_types API."
+      "docs/troubleshooting.md must continue to document public troubleshooting token '${required_troubleshooting_public_token}'."
     )
   endif()
 endforeach()

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -180,6 +180,7 @@ endforeach()
 set(release_command_paths
   ${benchmark_docs}
   CONTRIBUTING.md
+  docs/troubleshooting.md
   Makefile
 )
 
@@ -200,6 +201,7 @@ set(current_contract_docs
   docs/maintainer.md
   docs/openmp-timing-modes.md
   docs/semantics.md
+  docs/troubleshooting.md
 )
 
 set(forbidden_current_contract_phrases
@@ -229,6 +231,72 @@ foreach(current_contract_doc IN LISTS current_contract_docs)
       )
     endif()
   endforeach()
+endforeach()
+
+file(READ "${REPO_ROOT}/README.md" release_readme_text)
+set(readme_troubleshooting_needles
+  "see the symptom-oriented [`docs/troubleshooting.md`](docs/troubleshooting.md)"
+  "For practical remedies to first-use build failures, MPI summary hangs, OpenMP"
+  "- Troubleshooting guide: [`docs/troubleshooting.md`](docs/troubleshooting.md)"
+)
+
+foreach(readme_troubleshooting_needle IN LISTS readme_troubleshooting_needles)
+  string(FIND "${release_readme_text}" "${readme_troubleshooting_needle}" troubleshooting_link_index)
+  if(troubleshooting_link_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md must keep the troubleshooting guide discoverable: missing '${readme_troubleshooting_needle}'."
+    )
+  endif()
+endforeach()
+
+file(READ "${REPO_ROOT}/docs/troubleshooting.md" troubleshooting_doc_text)
+file(READ "${REPO_ROOT}/tests/public_symbol_allowlist.txt" public_symbol_allowlist_text)
+
+set(troubleshooting_public_api_tokens
+  ftimer_mpi_union_summary
+  ftimer_write_mpi_union_summary_csv
+  ftimer_stop
+  ftimer_mpi_summary
+  ftimer_write_summary_csv
+  ftimer_write_mpi_summary_csv
+  ftimer_write_mpi_union_summary_csv
+)
+
+foreach(troubleshooting_public_api_token IN LISTS troubleshooting_public_api_tokens)
+  string(FIND "${troubleshooting_doc_text}" "${troubleshooting_public_api_token}" token_doc_index)
+  if(token_doc_index EQUAL -1)
+    message(FATAL_ERROR
+      "docs/troubleshooting.md must document public API token '${troubleshooting_public_api_token}'."
+    )
+  endif()
+
+  if(NOT public_symbol_allowlist_text MATCHES "(^|\n)ftimer\\|${troubleshooting_public_api_token}\\|stable(\n|$)")
+    message(FATAL_ERROR
+      "docs/troubleshooting.md documents '${troubleshooting_public_api_token}', but tests/public_symbol_allowlist.txt does not mark it as a stable ftimer API."
+    )
+  endif()
+endforeach()
+
+set(troubleshooting_status_tokens
+  FTIMER_ERR_MPI_INCON
+  FTIMER_ERR_ACTIVE
+  FTIMER_ERR_NOT_IMPLEMENTED
+  FTIMER_ERR_IO
+)
+
+foreach(troubleshooting_status_token IN LISTS troubleshooting_status_tokens)
+  string(FIND "${troubleshooting_doc_text}" "${troubleshooting_status_token}" status_doc_index)
+  if(status_doc_index EQUAL -1)
+    message(FATAL_ERROR
+      "docs/troubleshooting.md must document status token '${troubleshooting_status_token}'."
+    )
+  endif()
+
+  if(NOT public_symbol_allowlist_text MATCHES "(^|\n)ftimer_types\\|${troubleshooting_status_token}\\|stable(\n|$)")
+    message(FATAL_ERROR
+      "docs/troubleshooting.md documents '${troubleshooting_status_token}', but tests/public_symbol_allowlist.txt does not mark it as a stable ftimer_types API."
+    )
+  endif()
 endforeach()
 
 set(retired_planning_docs

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -253,6 +253,150 @@ file(READ "${REPO_ROOT}/docs/troubleshooting.md" troubleshooting_doc_text)
 file(READ "${REPO_ROOT}/tests/public_symbol_allowlist.txt" public_symbol_allowlist_text)
 file(READ "${REPO_ROOT}/CMakeLists.txt" root_cmakelists_text)
 
+function(require_troubleshooting_contains needle)
+  string(FIND "${troubleshooting_doc_text}" "${needle}" troubleshooting_needle_index)
+  if(troubleshooting_needle_index EQUAL -1)
+    message(FATAL_ERROR
+      "docs/troubleshooting.md must keep troubleshooting contract text: missing '${needle}'."
+    )
+  endif()
+endfunction()
+
+function(require_troubleshooting_section_contains section_title needle)
+  set(section_header "## ${section_title}")
+  string(FIND "${troubleshooting_doc_text}" "${section_header}" troubleshooting_section_index)
+  if(troubleshooting_section_index EQUAL -1)
+    message(FATAL_ERROR
+      "docs/troubleshooting.md must keep troubleshooting section '${section_header}'."
+    )
+  endif()
+
+  string(SUBSTRING "${troubleshooting_doc_text}" "${troubleshooting_section_index}" -1 troubleshooting_section_tail)
+  string(FIND "${troubleshooting_section_tail}" "\n## " troubleshooting_next_section_index)
+  if(troubleshooting_next_section_index EQUAL -1)
+    set(troubleshooting_section_text "${troubleshooting_section_tail}")
+  else()
+    string(SUBSTRING "${troubleshooting_section_tail}" 0 "${troubleshooting_next_section_index}" troubleshooting_section_text)
+  endif()
+
+  string(FIND "${troubleshooting_section_text}" "${needle}" troubleshooting_section_needle_index)
+  if(troubleshooting_section_needle_index EQUAL -1)
+    message(FATAL_ERROR
+      "docs/troubleshooting.md section '${section_header}' must keep troubleshooting contract text: missing '${needle}'."
+    )
+  endif()
+endfunction()
+
+require_troubleshooting_contains("cmake -B build-smoke")
+require_troubleshooting_contains("cmake --build build-smoke")
+require_troubleshooting_contains("cmake -E chdir build-smoke ctest --output-on-failure")
+require_troubleshooting_contains("cmake --build build-smoke --target basic_usage")
+require_troubleshooting_contains("./build-smoke/examples/basic_usage")
+
+require_troubleshooting_section_contains("Configure Fails With pFUnit Enabled"
+  "FC=gfortran cmake -B build -DFTIMER_BUILD_TESTS=ON -DPFUNIT_DIR=/path/to/pfunit"
+)
+require_troubleshooting_section_contains("Configure Fails With pFUnit Enabled"
+  "If you only want the smoke path and examples, leave `FTIMER_BUILD_TESTS=OFF`."
+)
+require_troubleshooting_section_contains("Downstream Configure Cannot Find fTimer"
+  "find_package(fTimer CONFIG REQUIRED)"
+)
+require_troubleshooting_section_contains("Downstream Configure Cannot Find fTimer"
+  "CMAKE_PREFIX_PATH=/path/to/ftimer-install"
+)
+require_troubleshooting_section_contains("Downstream Configure Cannot Find fTimer"
+  "cmake -E chdir build-smoke ctest --output-on-failure -R ftimer_installed_package_consumer$"
+)
+require_troubleshooting_section_contains("Configure Fails With MPI Enabled"
+  "FC=mpifort cmake -B build-mpi-smoke -DFTIMER_USE_MPI=ON -DFTIMER_BUILD_TESTS=OFF"
+)
+require_troubleshooting_section_contains("Configure Fails With MPI Enabled"
+  "Configure runs a small `mpi_f08` probe and fails early"
+)
+require_troubleshooting_section_contains("Configure Fails With OpenMP Enabled"
+  "FC=gfortran cmake -B build-openmp -DFTIMER_USE_OPENMP=ON"
+)
+require_troubleshooting_section_contains("Configure Fails With OpenMP Enabled"
+  "FC=flang-19 cmake -B build-openmp-flang -DFTIMER_USE_OPENMP=ON -DOpenMP_ROOT=/path/to/libomp"
+)
+require_troubleshooting_section_contains("OpenMP Worker Calls Do Not Appear In The Summary"
+  "Worker-thread calls made inside an"
+)
+require_troubleshooting_section_contains("OpenMP Worker Calls Do Not Appear In The Summary"
+  "Global compiler flags such as `-fopenmp` do not enable fTimer's guards when the"
+)
+require_troubleshooting_section_contains("OpenMP Worker Calls Do Not Appear In The Summary"
+  "library was configured with `FTIMER_USE_OPENMP=OFF`"
+)
+
+require_troubleshooting_section_contains("MPI Summary Returns `FTIMER_ERR_MPI_INCON`"
+  "Strict MPI summaries and reports require identical timer descriptor trees"
+)
+require_troubleshooting_section_contains("MPI Summary Returns `FTIMER_ERR_MPI_INCON`"
+  "cause `FTIMER_ERR_MPI_INCON`"
+)
+require_troubleshooting_section_contains("MPI Summary Returns `FTIMER_ERR_MPI_INCON`"
+  "Sparse union entries report explicit participation counts."
+)
+require_troubleshooting_section_contains("MPI Summary Returns `FTIMER_ERR_ACTIVE`"
+  "MPI summaries and MPI report/CSV writers require a fully stopped timer set."
+)
+require_troubleshooting_section_contains("MPI Summary Returns `FTIMER_ERR_ACTIVE`"
+  "returns `FTIMER_ERR_ACTIVE`"
+)
+require_troubleshooting_section_contains("MPI Summary Returns `FTIMER_ERR_ACTIVE`"
+  "For local debugging snapshots, use `ftimer_get_summary()` separately."
+)
+require_troubleshooting_section_contains("MPI Summary Returns `FTIMER_ERR_ACTIVE`"
+  "MPI summary APIs intentionally do not."
+)
+require_troubleshooting_section_contains("MPI Summary Hangs"
+  "divergent communicators or missing collective"
+)
+require_troubleshooting_section_contains("MPI Summary Hangs"
+  "Rank-conditional code does not skip the collective itself."
+)
+require_troubleshooting_section_contains("MPI APIs Return `FTIMER_ERR_NOT_IMPLEMENTED`"
+  "They do not fall back to local summaries"
+)
+require_troubleshooting_section_contains("MPI APIs Return `FTIMER_ERR_NOT_IMPLEMENTED`"
+  "not create or replace MPI report files."
+)
+require_troubleshooting_section_contains("CSV Columns Look Different Between Files"
+  "Local and strict MPI CSV use `format_version=2`."
+)
+require_troubleshooting_section_contains("CSV Columns Look Different Between Files"
+  "Do not append sparse union rows to a local/strict MPI CSV file or the reverse."
+)
+require_troubleshooting_section_contains("CSV Append Returns `FTIMER_ERR_IO`"
+  "With `append=.true.`, fTimer validates the existing non-empty file before adding"
+)
+require_troubleshooting_section_contains("CSV Append Returns `FTIMER_ERR_IO`"
+  "a final record that is not newline-terminated"
+)
+require_troubleshooting_section_contains("CSV Append Returns `FTIMER_ERR_IO`"
+  "The existing file is left unchanged on validation failure."
+)
+require_troubleshooting_section_contains("Reports Look Incomplete"
+  "Strict MPI text reports are abbreviated human reports."
+)
+require_troubleshooting_section_contains("Reports Look Incomplete"
+  "The complete"
+)
+require_troubleshooting_section_contains("Reports Look Incomplete"
+  "machine-facing data is in `ftimer_mpi_summary_t` or the strict MPI CSV output."
+)
+require_troubleshooting_section_contains("Reports Look Incomplete"
+  "For sparse/rank-conditional work, use `ftimer_mpi_union_summary_t` or sparse"
+)
+require_troubleshooting_section_contains("Timings Do Not Include Device Or Synchronized MPI Time"
+  "does not synchronize GPU/device queues"
+)
+require_troubleshooting_section_contains("Timings Do Not Include Device Or Synchronized MPI Time"
+  "does not insert MPI barriers"
+)
+
 set(troubleshooting_routing_docs
   AGENTS.md
   CLAUDE.md

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -11,6 +11,7 @@ set(required_paths
   docs/openmp-timing-modes.md
   docs/release.md
   docs/semantics.md
+  docs/troubleshooting.md
   CONTRIBUTING.md
   SECURITY.md
   SUPPORT.md
@@ -256,6 +257,7 @@ set(release_navigation_docs
   docs/installed-api.md
   docs/release.md
   docs/openmp-timing-modes.md
+  docs/troubleshooting.md
 )
 
 foreach(release_navigation_doc IN LISTS release_navigation_docs)


### PR DESCRIPTION
## Summary

- Add `docs/troubleshooting.md` as a concise first-use troubleshooting guide for serial build, MPI, OpenMP, CSV append/export, and summary/report interpretation failures.
- Link the guide from README near the first-success path, build/test guidance, and the More Detail documentation list.
- Add the new guide to the release-facing documentation contract so smoke tests verify its local Markdown links.

## Behavior clarified

- MPI wrapper and `mpi_f08` probe failures, borrowed communicator lifetime, stopped-run MPI summary requirements, strict descriptor mismatches, and sparse union participation semantics.
- CSV schema separation, append validation failures, signed 64-bit call-count text, CSV quoting, and spreadsheet formula-safety caveat.
- OpenMP master-thread-only compatibility behavior, global OpenMP flags with `FTIMER_USE_OPENMP=OFF`, and the explicit `ftimer_openmp_t` path for worker timing.

## Tests

- `cmake -DREPO_ROOT=/Users/hrh/claude_projects/fTimer -P tests/check_release_docs_contract.cmake`
- `git diff --check`
- `cmake -B build-smoke`
- `cmake --build build-smoke`
- `cmake -E chdir build-smoke ctest --output-on-failure`

Closes #249.