### PR TITLE
[codex] Add focused rationale comments

### DIFF
--- a/examples/basic_usage.F90
+++ b/examples/basic_usage.F90
@@ -12,10 +12,14 @@ program basic_usage
    type(ftimer_summary_t) :: summary
 
 #ifdef FTIMER_USE_MPI
+   ! In MPI builds, keep fTimer inside the MPI lifetime because the clock and
+   ! summary paths may use MPI services.
    call MPI_Init(ierr)
    if (ierr /= 0) error stop 7
 #endif
 
+   ! Minimal lifecycle to copy: initialize once, time named regions, then
+   ! inspect or print the summary before finalizing.
    call ftimer_init()
    call ftimer_start("work")
 
@@ -27,6 +31,8 @@ program basic_usage
    call ftimer_stop("work")
    call ftimer_get_summary(summary)
 
+   ! Structured summaries are intended for programmatic checks; printing is
+   ! just one formatting layer on top.
    if (summary%num_entries /= 1) error stop 1
    if (.not. allocated(summary%entries)) error stop 2
    if (trim(summary%entries(1)%name) /= "work") error stop 3

--- a/examples/instrumentation_facade_disabled.F90
+++ b/examples/instrumentation_facade_disabled.F90
@@ -17,6 +17,8 @@ contains
    subroutine timing_init(ierr)
       integer, intent(out), optional :: ierr
 
+      ! Disabled builds still return success so instrumentation calls can remain
+      ! in application code without creating timing data.
       if (present(ierr)) ierr = timing_success
    end subroutine timing_init
 

--- a/examples/instrumentation_facade_enabled.F90
+++ b/examples/instrumentation_facade_enabled.F90
@@ -20,6 +20,8 @@ contains
    subroutine timing_init(ierr)
       integer, intent(out), optional :: ierr
 
+      ! Keep facade status handling identical to fTimer so application code has
+      ! one error path whether instrumentation is enabled or disabled.
       call ftimer_init(ierr=ierr)
    end subroutine timing_init
 

--- a/examples/instrumentation_facade_example.F90
+++ b/examples/instrumentation_facade_example.F90
@@ -17,6 +17,8 @@ program instrumentation_facade_example
    if (ierr /= 0) error stop 9
 #endif
 
+   ! Applications can call a project facade instead of fTimer directly, then
+   ! swap enabled/disabled instrumentation modules at build time.
    call timing_init(ierr=ierr)
    if (ierr /= timing_success) error stop 1
 

--- a/examples/mpi_example.F90
+++ b/examples/mpi_example.F90
@@ -31,6 +31,9 @@ program mpi_example
    end do
 
    call ftimer_stop("rank_work", ierr=ierr)
+
+   ! Strict MPI summaries require every participating rank to expose the same
+   ! timer hierarchy. Use the union summary API for rank-conditional timers.
    call ftimer_mpi_summary(summary, ierr=ierr)
 
    if (rank == 0 .and. summary%num_entries > 0) then

--- a/examples/mpi_openmp_example.F90
+++ b/examples/mpi_openmp_example.F90
@@ -37,12 +37,16 @@ program mpi_openmp_example
    config%max_lanes = 3
    config%max_worker_diagnostics = 4
 
+   ! Keep the hybrid timer inside the MPI lifetime; the communicator is used
+   ! later for cross-rank reductions.
    call timer%init(config=config, comm=MPI_COMM_WORLD, ierr=ierr)
    if (ierr /= FTIMER_SUCCESS) error stop "ftimer_openmp init failed"
 
    call timer%register_timer("hybrid_all_lanes", all_lanes_id, ierr=ierr)
    if (ierr /= FTIMER_SUCCESS) error stop "register hybrid_all_lanes failed"
 
+   ! Strict hybrid summaries are for phases where every rank/lane follows the
+   ! same timer structure.
    call timer%begin_parallel_region(region, ierr=ierr)
    if (ierr /= FTIMER_SUCCESS) error stop "begin strict hybrid region failed"
 
@@ -54,6 +58,7 @@ program mpi_openmp_example
 !$omp& reduction(+:accumulator, worker_bad, worker_seen)
    worker_seen = worker_seen + 1
 
+   ! The registered id is safe to use from workers; begin/end stay outside.
    call timer%start_id(all_lanes_id, ierr=ierr)
    if (ierr /= FTIMER_SUCCESS) worker_bad = worker_bad + 1
 
@@ -96,6 +101,8 @@ program mpi_openmp_example
    call timer%register_timer("rank0_lane0_only", sparse_id, ierr=ierr)
    if (ierr /= FTIMER_SUCCESS) error stop "register rank0_lane0_only failed"
 
+   ! Rank/lane-conditional timing is sparse by design; the union summary reports
+   ! who participated instead of rejecting the missing lanes.
    call timer%begin_parallel_region(region, ierr=ierr)
    if (ierr /= FTIMER_SUCCESS) error stop "begin sparse hybrid region failed"
 

--- a/examples/nested_timers.F90
+++ b/examples/nested_timers.F90
@@ -13,11 +13,18 @@ program nested_timers
    metadata(2)%key = "steps"
    metadata(2)%value = "3"
 
+   ! Metadata is optional, but useful for tagging solver cases or timestep
+   ! batches in saved reports.
    call ftimer_init()
+
+   ! The parent timer remains open while child timers run, so the summary shows
+   ! both the total advance time and the sweep/io split underneath it.
    call ftimer_start("advance")
 
    accumulator = 0.0
    do i = 1, 3
+      ! Reusing the same child names across iterations accumulates call counts
+      ! and times under this parent context.
       call ftimer_start("sweep")
       do j = 1, 75000
          accumulator = accumulator + real(i + j)

--- a/examples/openmp_worker_example.F90
+++ b/examples/openmp_worker_example.F90
@@ -22,12 +22,18 @@ program openmp_worker_example
    config%max_lanes = 3
    config%max_worker_diagnostics = 4
 
+   ! ftimer_openmp_t is the opt-in path for true worker timings; configure lane
+   ! capacity before init so each OpenMP thread has storage to write into.
    call timer%init(config=config, ierr=ierr)
    if (ierr /= FTIMER_SUCCESS) error stop "ftimer_openmp init failed"
 
+   ! Register once outside the parallel region and use ids inside hot loops to
+   ! avoid repeated name lookups.
    call timer%register_timer("team_work", team_work_id, ierr=ierr)
    if (ierr /= FTIMER_SUCCESS) error stop "ftimer_openmp register_timer failed"
 
+   ! The region handle brackets one OpenMP team and must be opened and closed by
+   ! serial code around the !$omp parallel block.
    call timer%begin_parallel_region(region, ierr=ierr)
    if (ierr /= FTIMER_SUCCESS) error stop "ftimer_openmp begin_parallel_region failed"
 
@@ -39,6 +45,7 @@ program openmp_worker_example
 !$omp& reduction(+:accumulator, worker_bad, worker_seen)
    worker_seen = worker_seen + 1
 
+   ! Each worker lane records its own local interval for the same registered id.
    call timer%start_id(team_work_id, ierr=ierr)
    if (ierr /= FTIMER_SUCCESS) worker_bad = worker_bad + 1
 

--- a/src/ftimer_core.F90
+++ b/src/ftimer_core.F90
@@ -739,6 +739,7 @@ contains
 
       if (present(activation_token)) activation_token = 0_int64
 
+      ! Context is keyed by the parent stack before this timer is pushed.
       ctx = find_or_create_segment_context(self, segment_idx, self%call_stack)
       call ensure_context_storage(self%segments(segment_idx), ctx)
 
@@ -944,12 +945,14 @@ contains
 
       if (.not. stack_contains(self%call_stack, idx)) return
 
+      ! One timestamp keeps all repaired timers on the same time boundary.
       now = self%wtime()
       allocate (unwound_ids(self%call_stack%depth))
       unwind_count = 0
 
       do while ((self%call_stack%depth > 0) .and. (self%call_stack%top() /= idx))
          top_id = self%call_stack%top()
+         ! Repair bookkeeping is not a user-visible profiling event.
          call stop_segment_with_now(self, top_id, now, fire_callback=.false.)
          unwind_count = unwind_count + 1
          unwound_ids(unwind_count) = top_id
@@ -1812,6 +1815,7 @@ contains
       integer :: ctx
       integer :: popped_id
 
+      ! Pop first so elapsed time is recorded against the parent context.
       popped_id = self%call_stack%pop()
       if (popped_id /= id) then
          error stop "ftimer internal stop_segment_with_now stack corruption"
@@ -1825,6 +1829,7 @@ contains
       self%segments(id)%time(ctx) = self%segments(id)%time(ctx) + now - self%segments(id)%start_time(ctx)
       self%segments(id)%is_running(ctx) = .false.
 
+      ! Internal repair stops pass fire_callback=.false. to avoid phantom events.
       if (fire_callback .and. associated(self%on_event)) then
          call self%on_event(public_segment_id(self, id), ctx, FTIMER_EVENT_STOP, now, self%user_data)
       end if

--- a/src/ftimer_core_summary_bindings.F90
+++ b/src/ftimer_core_summary_bindings.F90
@@ -251,6 +251,8 @@ contains
    collective_status = FTIMER_SUCCESS
    collective_message = ''
    if (rank == 0) then
+      ! Only rank 0 writes, then broadcasts the outcome so all ranks return the
+      ! same status to their caller.
       out_unit = output_unit
       if (present(unit)) out_unit = unit
 

--- a/src/ftimer_mpi.F90
+++ b/src/ftimer_mpi.F90
@@ -267,6 +267,8 @@ contains
          return
       end if
 
+      ! Strict summaries reduce timing arrays by canonical descriptor index, so
+      ! ranks must agree on the full timer hierarchy before any timing reduction.
       call build_descriptor_order(local_summary, descriptors, permutation)
       call hash_descriptor_list(descriptors, permutation, local_hashes)
 
@@ -1097,6 +1099,8 @@ contains
       allocate (char_counts(nprocs))
       allocate (char_displacements(nprocs))
 
+      ! Sparse union summaries exchange only the variable-length descriptors
+      ! each rank actually has; ranks do not need dummy timers for absent work.
       call MPI_Allgather(local_descriptor_count, 1, MPI_INTEGER, descriptor_counts, 1, MPI_INTEGER, &
                          active_comm, mpierr)
       if (mpierr /= MPI_SUCCESS) return

--- a/src/ftimer_openmp.F90
+++ b/src/ftimer_openmp.F90
@@ -5990,6 +5990,8 @@ contains
       epoch = 0
       worker_lane_count = 0
 
+      ! Lane 0 is the serial control lane; worker lanes require an open
+      ! top-level timed region so summaries know the team they belong to.
       if ((.not. allocated(self%lanes)) .or. (lane_idx < 1) .or. (lane_idx > size(self%lanes))) then
          status = FTIMER_ERR_UNKNOWN
          return
@@ -6161,6 +6163,7 @@ contains
       end if
 
       now = openmp_clock(self)
+      ! Pop before lookup so the elapsed time is attributed to the parent path.
       popped_id = self%lanes(lane_idx)%call_stack%pop(popped_epoch)
       if ((popped_id /= timer_id) .or. (popped_epoch /= int(epoch, int64))) then
          error stop "ftimer_openmp internal lane stack pop mismatch"

--- a/tests/mpi/test_mpi_consistency.pf
+++ b/tests/mpi/test_mpi_consistency.pf
@@ -234,6 +234,8 @@ contains
       parent_id = -1
       if (entry_count >= 2) parent_id = summary%entries(2)%parent_id
 
+      ! Matching descriptors take the cheap hash path and go straight to timing
+      ! reductions; no descriptor allgather should be needed.
       @assertEqual(2, entry_count)
       @assertEqual(1, parent_id)
       @assertEqual(0, allgather_count)
@@ -275,6 +277,8 @@ contains
       call ftimer_test_get_mpi_preflight_mismatch_flags(mismatch_flags)
       mismatch_flag_count = size(mismatch_flags)
 
+      ! On mismatch, gather flags for diagnostics but do not reduce timing data
+      ! by possibly different canonical indices.
       @assertEqual(1, allgather_count)
       @assertEqual(1, mismatch_flag_allgather_count)
       @assertEqual(0, summary_reduction_count)

--- a/tests/test_callbacks.pf
+++ b/tests/test_callbacks.pf
@@ -65,6 +65,8 @@ contains
                                                   FTIMER_EVENT_STOP, FTIMER_EVENT_STOP]
       real(wp), parameter :: expected_timestamps(5) = [0.0_wp, 1.0_wp, 2.0_wp, 5.0_wp, 8.0_wp]
 
+      ! Repair internally stops and restarts timers, but external profilers
+      ! should only see the user-visible events listed above.
       call reset_callback_log()
       call timer%init(mismatch_mode=FTIMER_MISMATCH_REPAIR, ierr=ierr)
       call attach_mock_clock(timer)

--- a/tests/test_context.pf
+++ b/tests/test_context.pf
@@ -50,6 +50,7 @@ contains
       call snapshot_timer(timer, state)
       stack_a = build_stack([1])
       stack_b = build_stack([3])
+      ! The same timer name under different parents must keep distinct totals.
       ctx_a = find_context_idx(state, id_work, stack_a)
       ctx_b = find_context_idx(state, id_work, stack_b)
       time_a = state%segments(id_work)%time(ctx_a)
@@ -140,6 +141,8 @@ contains
       call timer%init(mismatch_mode=FTIMER_MISMATCH_REPAIR, ierr=ierr)
       call attach_mock_clock(timer)
 
+      ! This stress path combines deep context growth with repair; callbacks
+      ! should still count only user-visible starts and stops.
       token = 17
       call timer%set_callback(record_deep_context_callback, c_loc(token), ierr=ierr)
       @assertEqual(FTIMER_SUCCESS, ierr)

--- a/tests/test_nesting.pf
+++ b/tests/test_nesting.pf
@@ -386,6 +386,8 @@ contains
       @assertEqual(10.0_wp, time_c_under_b)
       @assertFalse(state%segments(2)%is_running(ctx_b_root))
       @assertFalse(state%segments(3)%is_running(ctx_c_under_b))
+      ! Six reads means repair captured one shared timestamp, not one per
+      ! unwound/restarted timer.
       @assertEqual(6, call_count)
       @assertEqual(30.0_wp, state%segments(2)%start_time(ctx_b_root))
       @assertEqual(30.0_wp, state%segments(3)%start_time(ctx_c_under_b))

--- a/tests/test_openmp_guards.pf
+++ b/tests/test_openmp_guards.pf
@@ -153,6 +153,8 @@ contains
 
       @assertTrue(thread_seen(1))
       @assertTrue(thread_seen(2))
+      ! Worker calls to the guarded core API are silent no-ops and leave ierr
+      ! untouched when the caller supplied one.
       @assertEqual(NOOP_IERR_SENTINEL, worker_start_ierr)
       @assertEqual(NOOP_IERR_SENTINEL, worker_stop_ierr)
       @assertEqual(0, state%num_segments)


### PR DESCRIPTION
## Summary

- add short tutorial comments to copyable example patterns for lifecycle, nesting, MPI, OpenMP, hybrid timing, and instrumentation facades
- add rationale comments near key source invariants for context attribution, repair bookkeeping, MPI descriptor preflight, worker-lane timing, and rank-0 MPI output status
- add a few test comments documenting subtle contracts around context separation, repair callbacks, single-timestamp repair, OpenMP worker no-ops, and MPI preflight diagnostics

Closes #297.

## Validation

- `git diff --check`
- `cmake -B build-smoke`
- `cmake --build build-smoke`
- `cmake -E chdir build-smoke ctest --output-on-failure` (22/22 passed)
