### PR TITLE
Define operational support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,38 @@ lane-conditional work should be represented with explicit participation metadata
 
 Important limitations are documented later in this README. The short version is that serial and pure-MPI are the core supported stories on current `main`; OpenMP has a legacy master-thread-only compatibility path plus the explicit `ftimer_openmp_t` worker-timing object, local stopped-run summaries, strict MPI+OpenMP rank/lane reductions, and separate sparse union MPI+OpenMP rank/lane reductions.
 
+## Operational Support Matrix
+
+Support tiers mean:
+
+- **Core validated**: release-critical paths covered by CI smoke, install, and
+  behavior checks where the required toolchain is available.
+- **Supported advanced**: validated feature paths with a narrower runtime or
+  toolchain contract than the serial and pure-MPI core.
+- **Plausible but unvalidated**: paths that may work from the implementation
+  design, but are not part of release validation today.
+- **Experimental/deferred**: future ecosystem or integration work with no
+  current support commitment.
+- **Unsupported**: known out-of-contract paths, removed interfaces, or
+  combinations intentionally rejected by configure checks.
+
+| Area | Current support tier |
+| --- | --- |
+| Serial library, smoke tests, examples, and installed consumer | **Core validated** with GNU Fortran and LLVM Flang. Other modern Fortran compilers are **plausible but unvalidated** until a release issue adds direct automation. |
+| Serial pFUnit behavior suite | **Core validated** with GNU Fortran and a matching pFUnit installation. LLVM Flang pFUnit and other compiler/pFUnit combinations are **plausible but unvalidated**. |
+| Pure MPI | **Core validated** for GNU Fortran MPI wrapper compilers with OpenMPI and MPICH, using `mpi_f08`, after `MPI_Init` and before `MPI_Finalize`. OpenMPI and MPICH smoke/install-consumer paths are validated; MPI pFUnit coverage is validated where matching pFUnit is available. Legacy `mpif.h`, integer communicator handles, and MPI use outside the MPI lifetime are **unsupported**. |
+| OpenMP compatibility through `ftimer` / `ftimer_core` | **Supported advanced** with GNU Fortran pFUnit guard coverage and LLVM Flang smoke/example coverage. The contract is master-thread-only; worker-thread calls through these existing APIs are silent no-ops. |
+| Explicit `ftimer_openmp_t` worker timing | **Supported advanced** with GNU Fortran and LLVM Flang OpenMP smoke/example coverage. Use this object API for serial-lane and level-1 worker timing; active-region rejection and queued diagnostics are part of this path, not the legacy worker no-op carve-out. |
+| MPI+OpenMP hybrid summaries, reports, CSV, and installed consumer | **Supported advanced** today for OpenMPI wrapper builds with GNU Fortran and OpenMP. MPICH hybrid and other MPI/compiler/OpenMP runtime combinations are **plausible but unvalidated** until separate release evidence promotes them. |
+| Installed CMake package and `.mod` artifacts | **Core validated** for matching compiler, toolchain, and feature mode. Installed Fortran `.mod` files are compiler/toolchain/mode specific; cross-compiler or cross-mode reuse is **unsupported**. |
+| FPM/package-manager installs, profiler backends, hardware counters, traces, dashboards, accelerator timelines | **Experimental/deferred**. These are not part of the current release support claim. |
+
+For failure-oriented guidance, see
+[`docs/troubleshooting.md`](docs/troubleshooting.md). For the architecture and
+validation context behind the matrix, see [`docs/design.md`](docs/design.md).
+For installed package stability details, see
+[`docs/installed-api.md`](docs/installed-api.md).
+
 ## Quick Start
 
 ```fortran

--- a/docs/installed-api.md
+++ b/docs/installed-api.md
@@ -206,6 +206,13 @@ are never installed as stable API:
 Installed implementation module artifacts: `ftimer_clock.mod`,
 `ftimer_summary.mod`, `ftimer_mpi.mod`.
 
+Fortran `.mod` files are compiler-, toolchain-, and feature-mode-specific
+artifacts. A prefix installed by one compiler or MPI/OpenMP mode is intended for
+downstream builds that use the matching compiler family, MPI wrapper family,
+and fTimer feature mode. Reusing installed module files across compilers or
+across serial/MPI/OpenMP mode boundaries is outside the supported package
+contract unless a release issue adds explicit validation for that combination.
+
 Those implementation module files may be present in the installed include tree
 because Fortran consumers need a coherent compiler module artifact set when they
 import the supported modules above. They are not stable import targets, and

--- a/docs/release.md
+++ b/docs/release.md
@@ -22,6 +22,11 @@ Before starting a release candidate:
   reports, CSV, strict MPI+OpenMP hybrid summaries/reports/CSV, sparse union
   MPI+OpenMP hybrid participation summaries/reports/CSV, and the CMake package
   path.
+- Keep release notes and support claims aligned with the public operational
+  support matrix in `README.md`. In particular, MPI+OpenMP is release-validated
+  today for OpenMPI wrapper builds with GNU Fortran and OpenMP; MPICH hybrid and
+  other MPI/compiler/OpenMP runtime combinations remain plausible but
+  unvalidated until a release issue adds matching evidence.
 - Do not promote deferred non-goals into the release unless a linked issue has
   changed scope. Current non-goals include full profiler integration, FPM
   packaging, hardware counters, traces, accelerator timelines, automatic MPI
@@ -35,6 +40,10 @@ Before starting a release candidate:
 - If a stable source-level symbol, installed module artifact, CSV schema field,
   or package compatibility boundary changes, update the relevant docs and
   smoke/contract checks in the same release-prep PR.
+- Treat installed Fortran `.mod` artifacts as compiler/toolchain/mode-specific
+  outputs. Do not imply that one installed prefix can be reused across
+  different compilers, MPI wrappers, or feature modes unless release validation
+  explicitly proves that combination.
 - Treat release notes as part of the compatibility contract: describe
   user-visible behavior changes, limitations, and migration notes directly.
 - For the first release containing the true OpenMP and hybrid APIs, name


### PR DESCRIPTION
## Summary

Closes #305.

- Add a compact public operational support matrix to the README.
- Distinguish core validated, supported advanced, plausible but unvalidated, experimental/deferred, and unsupported paths.
- Clarify that MPI+OpenMP is validated today for OpenMPI wrapper builds with GNU Fortran and OpenMP, while MPICH hybrid remains plausible but unvalidated.
- Record that installed Fortran `.mod` artifacts are compiler/toolchain/mode specific in release policy and installed API docs.

## Validation

- `cmake -B build-issue-305-docs -DFTIMER_BUILD_EXAMPLES=OFF` passed locally with LLVMFlang 22.1.6; CMake emitted an existing GNUInstallDirs developer warning.
- `ctest --test-dir build-issue-305-docs --output-on-failure -R '^ftimer_release_docs_contract$'` passed.
- `git diff --check` passed.

## Scope

Docs and release policy only. No CI expansion, configure-gate changes, or new compiler/MPI support.