### PR TITLE
Add release claim-evidence ledger

### DIFF
--- a/docs/release-evidence.md
+++ b/docs/release-evidence.md
@@ -1,0 +1,67 @@
+# Release Claim-Evidence Ledger
+
+This ledger is the release-prep scratchpad for matching user-visible claims to
+validation evidence. Use it before writing release notes: keep claims narrow,
+name the evidence that backs them, and call out plausible but unvalidated
+combinations directly.
+
+Status vocabulary:
+
+- **Release-validated**: covered by current documented local commands and CI
+  jobs for the named toolchain or mode.
+- **Evidence-backed**: covered by source, tests, examples, or docs, but not a
+  broad compatibility claim.
+- **Plausible but unvalidated**: may work, but is not part of the
+  release-validated support boundary.
+- **Non-goal**: intentionally outside the current release claim.
+
+## Dry-Run Release-Note Claim Map
+
+A current release note should be able to claim:
+
+- disciplined serial wall-clock timing with structured summaries, reports, CSV,
+  scoped guards, callbacks, mock-clock-friendly tests, and benchmark evidence;
+- pure MPI summaries and reports through the `mpi_f08` communicator contract;
+- OpenMP compatibility for existing `ftimer`/`ftimer_core` users through the
+  master-thread-only carve-out;
+- opt-in true OpenMP worker timing through `ftimer_openmp_t`;
+- strict and sparse union MPI+OpenMP rank/lane summary, report, and CSV output
+  for the currently validated hybrid path;
+- stable CSV/export schemas within the documented schema lines;
+- installed CMake package consumption for supported feature modes;
+- a curated public symbol boundary; and
+- benchmark harness evidence for release-readiness sweeps and performance-risk
+  PRs.
+
+The same release note should not claim broad compiler portability, MPICH
+MPI+OpenMP validation, package-manager availability, profiler-backend
+integration, hardware-counter support, FPM support, benchmark pass/fail
+thresholds, traces, dashboards, device synchronization, or automatic MPI
+barriers unless a later release issue adds matching evidence.
+
+## Claim Ledger
+
+| Release claim area | Current status | Evidence to cite | Caveats and compatibility boundary |
+| --- | --- | --- | --- |
+| Serial timing | Release-validated for GNU Fortran and LLVM Flang smoke/library builds; pFUnit behavioral coverage is GNU Fortran. | `build-serial`, `build-serial-flang`, and `test-serial` CI jobs; `tests/test_*.pf`; `tests/test_phase0_smoke.F90`; `examples/basic_usage.F90`; `README.md` "Supported toolchain matrix". | Other serial compilers may work, but are plausible and unvalidated until release evidence exists. Wall-clock timing does not synchronize accelerator/device queues. |
+| Pure MPI | Release-validated for GNU Fortran wrapper builds with OpenMPI and MPICH. | `build-mpi`, `build-mpi-mpich`, `test-mpi`, and `test-mpi-mpich` CI jobs; `tests/mpi/test_mpi_*.pf`; `examples/mpi_example.F90`; configure-time `mpi_f08` probe in `CMakeLists.txt`; `docs/semantics.md` MPI contract. | Requires MPI lifetime discipline and the `mpi_f08` `type(MPI_Comm)` contract. Legacy integer communicators, `mpif.h`, divergent collectives, and automatic MPI barriers are outside the claim. |
+| OpenMP compatibility | Release-validated for GNU Fortran OpenMP and LLVM Flang OpenMP smoke/example paths. | `build-openmp`, `build-openmp-flang`, and `test-openmp` CI jobs; `tests/test_openmp_guards.pf`; `tests/check_openmp_option_off_global_flags.cmake`; `examples/openmp_example.F90`; `docs/openmp-timing-modes.md`. | This is the master-thread-only carve-out for existing APIs. It is not general thread safety, thread-local timing, nested worker timing, or a hybrid timing model by itself. |
+| `ftimer_openmp_t` | Release-validated as the opt-in serial-lane and level-1 worker timing API in OpenMP builds; serial-context lifecycle/catalog/timing is available in non-OpenMP packages. | `tests/test_openmp_api_smoke.F90`; `tests/test_openmp_summary_smoke.F90`; OpenMP diagnostic smoke tests; `tests/check_installed_openmp_hybrid_api_surface.cmake`; `examples/openmp_worker_example.F90`; `docs/installed-api.md`. | Worker timing requires `FTIMER_USE_OPENMP=ON`, an opened level-1 timed region, pre-registered ids for the hot path, and stopped-run summary/report calls. Global downstream OpenMP flags do not retrofit OpenMP support into a non-OpenMP fTimer package. |
+| Strict/sparse hybrid output | Release-validated for OpenMPI wrapper MPI+OpenMP smoke/install-consumer coverage with GNU Fortran and OpenMP. MPICH MPI+OpenMP remains plausible but unvalidated. | `build-mpi-openmp` CI job; `tests/test_openmp_mpi_summary_smoke.F90`; `tests/test_openmp_mpi_summary_3rank_smoke.F90`; `tests/check_openmp_mpi_union_descriptor_contract.cmake`; `examples/mpi_openmp_example.F90`; `tests/install-consumer/mpi_openmp_main.F90`; `README.md` hybrid contract. | Strict hybrid output rejects descriptor or eligible-lane mismatches. Sparse union hybrid output is a separate participation-aware API and schema; it is not append-compatible with strict hybrid CSV. |
+| Stable CSV/export claims | Evidence-backed for the documented schema lines and append-validation behavior. | `tests/test_file_output.pf`; `tests/check_openmp_summary_smoke.cmake`; `tests/check_openmp_mpi_summary_smoke.cmake`; `tests/check_bench_csv_output.cmake`; CSV sections in `README.md`, `docs/semantics.md`, and `docs/troubleshooting.md`. | CSV is the first stable machine-readable export, not a trace/event/profiler format. Local/strict MPI, sparse MPI union, OpenMP, strict hybrid, and sparse hybrid schemas are dedicated and intentionally not append-compatible with one another. |
+| Installed CMake package behavior | Release-validated for the supported serial, MPI, OpenMP, and MPI+OpenMP installed-consumer paths. | `ftimer_installed_package_consumer*` CTest entries; `tests/check_installed_package_consumer.cmake`; `tests/install-consumer/*.F90`; installed docs check for `docs/installed-api.md` and `LICENSE`; `docs/installed-api.md`. | Installed `.mod` artifacts are compiler-, wrapper-, and feature-mode-specific. FPM, binary packages, cross-compiler module reuse, and broad package-manager support are non-goals unless separately validated. |
+| Public symbols | Evidence-backed by an allowlisted source-level API boundary. | `tests/public_symbol_allowlist.txt`; `tests/check_public_symbol_allowlist.cmake`; `docs/installed-api.md`; `src/ftimer.F90`, `src/ftimer_core.F90`, `src/ftimer_openmp.F90`, and `src/ftimer_types.F90`. | New module-level public names must be intentionally classified as stable, unstable public-by-necessity, or test-only. Installed implementation module artifacts are not stable import targets. |
+| Benchmark evidence | Evidence-backed for trend review and release-readiness sweeps, not pass/fail thresholds. | `build-bench`, `build-openmp-bench`, and `build-mpi-openmp-bench` CI jobs; `bench/ftimer_bench.F90`; `bench_csv_smoke`; serial CI artifact `ftimer-bench-serial-<sha>`; benchmark commands in `README.md` and `docs/release.md`. | GitHub-hosted runner timings are noisy. Serial CSV artifacts are uploaded by CI; OpenMP and MPI+OpenMP benchmark CI jobs currently smoke-check parseable CSV but do not upload durable feature-enabled artifacts. |
+
+## Release Prep Update Rules
+
+- Add a row only for a release-significant claim that maintainers may repeat in
+  release notes, README support text, or downstream compatibility guidance.
+- Keep evidence concrete: prefer CI job names, CTest names, examples, and
+  source-of-truth docs over broad phrases like "covered by tests".
+- When a new combination looks likely but lacks CI or local release evidence,
+  mark it **Plausible but unvalidated** instead of widening the support matrix.
+- When evidence changes because a CI job or smoke test is renamed, update this
+  ledger in the same PR as the rename.
+- Do not turn benchmark evidence into a threshold or gate here. This file records
+  what evidence exists; `docs/release.md` owns release execution policy.

--- a/docs/release.md
+++ b/docs/release.md
@@ -15,6 +15,10 @@ Before starting a release candidate:
   issues and ready PRs.
 - Review open `release-blocker`, `release-audit`, `bug`, and `post-release`
   issues for items that should affect the release notes or block the tag.
+- Review the compact claim-evidence ledger in
+  [`docs/release-evidence.md`](release-evidence.md) and update any rows whose
+  CI jobs, tests, examples, caveats, or support status changed since the last
+  release.
 - Keep the release claim within the documented support boundary: serial timing,
   pure-MPI timing, the narrow master-thread-only OpenMP carve-out, the
   `ftimer_openmp` lifecycle/configuration/timer-catalog and id-first

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -574,9 +574,33 @@ foreach(release_navigation_doc IN LISTS release_navigation_docs)
   endforeach()
 endforeach()
 
-file(READ "${REPO_ROOT}/docs/release.md" release_doc_text)
-string(FIND "${release_doc_text}" "docs/release-evidence.md" release_evidence_link_index)
-if(release_evidence_link_index EQUAL -1)
+file(STRINGS "${REPO_ROOT}/docs/release.md" release_doc_lines)
+get_filename_component(release_doc_dir "${REPO_ROOT}/docs/release.md" DIRECTORY)
+get_filename_component(release_evidence_abs "${REPO_ROOT}/docs/release-evidence.md" ABSOLUTE)
+set(release_links_to_evidence FALSE)
+
+foreach(release_doc_line IN LISTS release_doc_lines)
+  set(remaining_line "${release_doc_line}")
+  while(remaining_line MATCHES "\\[[^]]*\\]\\(([^)]+)\\)")
+    set(link_target "${CMAKE_MATCH_1}")
+    string(REGEX REPLACE "^[ \t]*<([^>]+)>.*$" "\\1" link_target "${link_target}")
+    string(REGEX REPLACE "^[ \t]*([^ \t\"']+).*$" "\\1" link_target "${link_target}")
+    string(REGEX REPLACE "#.*$" "" link_path "${link_target}")
+
+    if(NOT link_path STREQUAL "" AND
+       NOT link_path MATCHES "^[A-Za-z][A-Za-z0-9+.-]*:" AND
+       NOT link_path MATCHES "^#")
+      get_filename_component(link_abs "${release_doc_dir}/${link_path}" ABSOLUTE)
+      if(link_abs STREQUAL release_evidence_abs)
+        set(release_links_to_evidence TRUE)
+      endif()
+    endif()
+
+    string(REGEX REPLACE "^[^[]*\\[[^]]*\\]\\([^)]+\\)" "" remaining_line "${remaining_line}")
+  endwhile()
+endforeach()
+
+if(NOT release_links_to_evidence)
   message(FATAL_ERROR
     "docs/release.md must link to docs/release-evidence.md for release claim-evidence review."
   )
@@ -602,6 +626,65 @@ foreach(required_release_evidence_term IN LISTS required_release_evidence_terms)
   if(release_evidence_term_index EQUAL -1)
     message(FATAL_ERROR
       "docs/release-evidence.md must keep release ledger term '${required_release_evidence_term}'."
+    )
+  endif()
+endforeach()
+
+file(STRINGS "${REPO_ROOT}/docs/release-evidence.md" release_evidence_lines)
+set(required_release_evidence_rows
+  "Serial timing"
+  "Pure MPI"
+  "OpenMP compatibility"
+  "`ftimer_openmp_t`"
+  "Strict/sparse hybrid output"
+  "Stable CSV/export claims"
+  "Installed CMake package behavior"
+  "Public symbols"
+  "Benchmark evidence"
+)
+
+foreach(required_release_evidence_row IN LISTS required_release_evidence_rows)
+  set(release_evidence_row_found FALSE)
+  set(release_evidence_row_count 0)
+
+  foreach(release_evidence_line IN LISTS release_evidence_lines)
+    if(release_evidence_line MATCHES
+       "^\\|[ \t]*${required_release_evidence_row}[ \t]*\\|[ \t]*([^|]+)[ \t]*\\|[ \t]*([^|]+)[ \t]*\\|[ \t]*([^|]+)[ \t]*\\|[ \t]*$")
+      math(EXPR release_evidence_row_count "${release_evidence_row_count} + 1")
+      set(release_evidence_row_found TRUE)
+      set(release_evidence_status_cell "${CMAKE_MATCH_1}")
+      set(release_evidence_evidence_cell "${CMAKE_MATCH_2}")
+      set(release_evidence_caveat_cell "${CMAKE_MATCH_3}")
+      string(STRIP "${release_evidence_status_cell}" release_evidence_status_cell)
+      string(STRIP "${release_evidence_evidence_cell}" release_evidence_evidence_cell)
+      string(STRIP "${release_evidence_caveat_cell}" release_evidence_caveat_cell)
+
+      if(release_evidence_status_cell STREQUAL "" OR
+         release_evidence_evidence_cell STREQUAL "" OR
+         release_evidence_caveat_cell STREQUAL "")
+        message(FATAL_ERROR
+          "docs/release-evidence.md claim row '${required_release_evidence_row}' must keep non-empty status, evidence, and caveat cells."
+        )
+      endif()
+
+      if(NOT release_evidence_evidence_cell MATCHES
+         "(build-[A-Za-z0-9_-]+|test-[A-Za-z0-9_-]+|[A-Za-z0-9_]+_smoke|tests/|examples/|docs/|README\\.md|CMakeLists\\.txt|CI job|CTest)")
+        message(FATAL_ERROR
+          "docs/release-evidence.md claim row '${required_release_evidence_row}' must cite concrete evidence such as CI jobs, CTest names, tests, examples, or docs."
+        )
+      endif()
+    endif()
+  endforeach()
+
+  if(NOT release_evidence_row_found)
+    message(FATAL_ERROR
+      "docs/release-evidence.md must keep a claim ledger table row for '${required_release_evidence_row}'."
+    )
+  endif()
+
+  if(release_evidence_row_count GREATER 1)
+    message(FATAL_ERROR
+      "docs/release-evidence.md must keep exactly one claim ledger table row for '${required_release_evidence_row}'."
     )
   endif()
 endforeach()

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -9,6 +9,7 @@ set(required_paths
   docs/implementation-history.md
   docs/maintainer.md
   docs/openmp-timing-modes.md
+  docs/release-evidence.md
   docs/release.md
   docs/semantics.md
   docs/troubleshooting.md
@@ -554,6 +555,7 @@ set(release_navigation_docs
   docs/semantics.md
   docs/design.md
   docs/installed-api.md
+  docs/release-evidence.md
   docs/release.md
   docs/openmp-timing-modes.md
   docs/troubleshooting.md
@@ -570,4 +572,36 @@ foreach(release_navigation_doc IN LISTS release_navigation_docs)
       )
     endif()
   endforeach()
+endforeach()
+
+file(READ "${REPO_ROOT}/docs/release.md" release_doc_text)
+string(FIND "${release_doc_text}" "docs/release-evidence.md" release_evidence_link_index)
+if(release_evidence_link_index EQUAL -1)
+  message(FATAL_ERROR
+    "docs/release.md must link to docs/release-evidence.md for release claim-evidence review."
+  )
+endif()
+
+file(READ "${REPO_ROOT}/docs/release-evidence.md" release_evidence_text)
+set(required_release_evidence_terms
+  "Serial timing"
+  "Pure MPI"
+  "OpenMP compatibility"
+  "`ftimer_openmp_t`"
+  "Strict/sparse hybrid output"
+  "Stable CSV/export claims"
+  "Installed CMake package behavior"
+  "Public symbols"
+  "Benchmark evidence"
+  "Plausible but unvalidated"
+  "Release-validated"
+)
+
+foreach(required_release_evidence_term IN LISTS required_release_evidence_terms)
+  string(FIND "${release_evidence_text}" "${required_release_evidence_term}" release_evidence_term_index)
+  if(release_evidence_term_index EQUAL -1)
+    message(FATAL_ERROR
+      "docs/release-evidence.md must keep release ledger term '${required_release_evidence_term}'."
+    )
+  endif()
 endforeach()


### PR DESCRIPTION
Closes #304.

## Summary

- Adds `docs/release-evidence.md`, a lightweight release-facing ledger that maps release-significant claims to evidence and caveats.
- Covers serial timing, pure MPI, OpenMP compatibility, `ftimer_openmp_t`, strict/sparse hybrid output, stable CSV/export claims, installed CMake package behavior, public symbols, and benchmark evidence.
- Links the release checklist to the ledger and extends the release-doc contract check to keep the ledger present and anchored to the required claim areas.

## Validation

- `cmake -DREPO_ROOT=/Users/hrh/.codex/worktrees/0410/fTimer -P tests/check_release_docs_contract.cmake`
- `git diff --check`
- `cmake -B build-codex-304-docs -DFTIMER_BUILD_EXAMPLES=OFF` (succeeded; emitted existing CMake developer warning about `GNUInstallDirs` architecture detection with local Flang)
- `ctest --test-dir build-codex-304-docs --output-on-failure -R '^ftimer_release_docs_contract$'`