### PR TITLE
Add first-hour timing mode chooser

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ matters inside one level-1 team, strict MPI+OpenMP when all ranks and lanes must
 share the same descriptor tree, and sparse union MPI+OpenMP when rank- or
 lane-conditional work should be represented with explicit participation metadata.
 
+### First-Hour Timing Mode Chooser
+
+Start with the row that matches the measurement you want, then move to a more
+specialized mode only when the participation pattern requires it.
+
+| Measurement goal | Use this mode | First API or report family | Caveat to keep visible |
+| --- | --- | --- | --- |
+| One process, one thread, or rank-local data before any MPI reduction | Serial/local timing through `ftimer` or `ftimer_core` | `get_summary()`, `print_summary()`, `write_summary_csv()` | Local summaries are live snapshots. Active timers are included and marked; stop all timers first for a final report. |
+| Same timer tree on every MPI rank | Strict pure-MPI timing | `mpi_summary()`, `print_mpi_summary()`, `write_mpi_summary_csv()` | fTimer reduces rank-local intervals and does not add barriers. Descriptor mismatches are errors. |
+| Rank-conditional pure-MPI timers | Sparse pure-MPI union timing | `mpi_union_summary()`, `print_mpi_union_summary()`, `write_mpi_union_summary_csv()` | Missing ranks are explicit nonparticipants, not zero-time contributors. |
+| One wall-clock interval around an OpenMP parallel region | OpenMP compatibility timing with current `ftimer` / `ftimer_core` calls outside the parallel region | Local summaries, or strict/sparse pure-MPI summaries in MPI builds | Worker-thread calls through these existing APIs are silent no-ops; this does not produce per-worker data. |
+| Per-lane OpenMP worker participation inside one level-1 team | Explicit worker timing through `ftimer_openmp_t` | `get_openmp_summary()`, `print_openmp_summary()`, `write_openmp_summary_csv()` | OpenMP worker summaries are stopped-run merge points. Close the timed region and stop all lane stacks first. |
+| Same worker timer tree on every MPI rank and eligible lane | Strict MPI+OpenMP worker timing through `ftimer_openmp_t` | `mpi_openmp_summary()`, `print_mpi_openmp_summary()`, `write_mpi_openmp_summary_csv()` | These collective stopped-run APIs require matching rank/lane descriptors and eligible-lane participation. |
+| Rank- or lane-conditional MPI+OpenMP worker timers | Sparse MPI+OpenMP union timing through `ftimer_openmp_t` | `mpi_openmp_union_summary()`, `print_mpi_openmp_union_summary()`, `write_mpi_openmp_union_summary_csv()` | Missing ranks and lanes are explicit participation metadata, not zero-filled samples. |
+
+CSV schemas follow the same mode choice: local/strict MPI share one v2 family,
+while sparse MPI union, local OpenMP, strict MPI+OpenMP, and sparse
+MPI+OpenMP union each use dedicated schemas that are not append-compatible with
+one another. For the full OpenMP and hybrid lifecycle, see
+[`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md).
+
 Important limitations are documented later in this README. The short version is that serial and pure-MPI are the core supported stories on current `main`; OpenMP has a legacy master-thread-only compatibility path plus the explicit `ftimer_openmp_t` worker-timing object, local stopped-run summaries, strict MPI+OpenMP rank/lane reductions, and separate sparse union MPI+OpenMP rank/lane reductions.
 
 ## Operational Support Matrix

--- a/docs/history/first-hour-timing-mode-validation.md
+++ b/docs/history/first-hour-timing-mode-validation.md
@@ -1,0 +1,38 @@
+# First-Hour Timing Mode Validation
+
+Issue: #308
+Date: 2026-06-09
+
+## Method
+
+Six concrete onboarding scenarios were read against the current README,
+`docs/openmp-timing-modes.md`, CSV schema notes, and examples. Each row records
+the section a representative reader would likely choose first, whether that path
+selects the correct API family, and where the reader is likely to hesitate.
+
+## Scenario Record
+
+| Representative reader and scenario | First section chosen | Correct API choice | Hesitation observed |
+| --- | --- | --- | --- |
+| Serial application developer wants a final timing table and a CSV artifact for one process. | README "Quick Start", then "CSV Export". | `ftimer_init`, `ftimer_start`, `ftimer_stop`, `ftimer_get_summary`, and `ftimer_write_summary_csv`. | The README already says local summaries are live snapshots, but the first mode-selection paragraph did not make "stop all timers for a final report" part of the first choice. |
+| MPI maintainer wants a communicator-level phase summary where every rank times the same named phase. | README "Supported Workflows", then `examples/mpi_example.F90`. | `ftimer_init(comm=...)` inside the MPI lifetime, stopped timers, then `ftimer_mpi_summary` or strict MPI text/CSV reports. | The reader has to connect "strict" with "same descriptor tree" and remember that fTimer does not insert barriers. |
+| MPI user has rank-conditional setup work that exists only on rank 0. | README "Current Limitations And Contracts", then "CSV Export". | `ftimer_mpi_union_summary` / sparse MPI union report or CSV family. | The strict-vs-sparse decision is correct in the README, but the first-hour path requires jumping to limitations to learn that strict MPI rejects rank-conditional descriptors. |
+| OpenMP user wants one wall-clock interval around a parallel loop. | README "Supported Workflows", then `docs/openmp-timing-modes.md` "Current Accepted Patterns". | Existing `ftimer` or `ftimer_core` calls outside the `!$omp parallel` block. | The user may still ask whether `FTIMER_USE_OPENMP=ON` means per-worker timing; the no-op worker caveat needs to stay visible at mode-choice time. |
+| OpenMP user wants every worker lane to contribute timing data inside one level-1 team. | `docs/openmp-timing-modes.md` "Mode Summary", then `examples/openmp_worker_example.F90`. | `type(ftimer_openmp_t)`, pre-registered ids, `begin_parallel_region`, worker `start_id`/`stop_id`, `end_parallel_region`, then local OpenMP summary/report/CSV. | The correct path is clear once the user reaches the OpenMP guide, but stopped-run summaries versus local live snapshots is easy to miss from the README front door. |
+| Hybrid MPI+OpenMP maintainer has one all-rank/all-lane phase and one rank/lane-conditional phase. | `docs/openmp-timing-modes.md` "Mode Summary", then `examples/mpi_openmp_example.F90`. | `ftimer_openmp_t%mpi_openmp_summary` for the all-rank/all-lane phase, and `ftimer_openmp_t%mpi_openmp_union_summary` for rank/lane-conditional participation. | The current docs are accurate, but the reader must compare strict and sparse hybrid report families plus dedicated CSV schemas before choosing. |
+
+## Decision
+
+A one-screen chooser is needed in the README. The existing detailed docs are
+honest and should remain the source for lifecycle and contract caveats, but the
+first README path should expose the three high-risk decisions before a user
+chooses an example or API:
+
+- OpenMP compatibility timing versus true worker timing.
+- Strict MPI or strict MPI+OpenMP summaries versus sparse union summaries.
+- Local live snapshots versus stopped-run OpenMP and hybrid summary families.
+
+The chosen change is a compact README table that points each measurement goal to
+the smallest appropriate mode, names the first API or report family, and keeps
+the relevant caveat in the same row. This keeps onboarding simpler without
+adding new modes, changing API behavior, or hiding measurement semantics.


### PR DESCRIPTION
Closes #308.

## Summary

- Records the six-scenario first-hour timing-mode validation in `docs/history/first-hour-timing-mode-validation.md`.
- Adds a compact README chooser that maps measurement goals to the smallest appropriate timing mode and first API/report family.
- Keeps the high-risk caveats visible at selection time: OpenMP compatibility vs true worker timing, strict vs sparse MPI/hybrid summaries, local live snapshots vs stopped-run OpenMP/hybrid summaries, and dedicated CSV schema families.

## Validation

- `git diff --check`
- `cmake -DREPO_ROOT=/Users/hrh/claude_projects/fTimer -P tests/check_release_docs_contract.cmake`
- `cmake -DREPO_ROOT=/Users/hrh/claude_projects/fTimer -P tests/check_csv_schema_docs.cmake`

No source or runtime behavior changed.