### PR TITLE
Factor fTimer CMake target setup

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,35 @@ set(FTIMER_SOURCES
   ftimer.F90
 )
 
+function(ftimer_apply_feature_dependencies target_name)
+  if(FTIMER_USE_MPI)
+    target_compile_definitions(${target_name} PUBLIC FTIMER_USE_MPI)
+    target_link_libraries(${target_name} PUBLIC MPI::MPI_Fortran)
+  endif()
+
+  if(FTIMER_USE_OPENMP)
+    target_compile_definitions(${target_name} PUBLIC FTIMER_USE_OPENMP)
+    target_link_libraries(${target_name} PUBLIC OpenMP::OpenMP_Fortran)
+  endif()
+endfunction()
+
+function(ftimer_add_internal_library target_name module_dir build_definition)
+  add_library(${target_name} ${FTIMER_SOURCES})
+
+  set_target_properties(${target_name} PROPERTIES
+    Fortran_MODULE_DIRECTORY "${module_dir}"
+    OUTPUT_NAME ${target_name}
+  )
+
+  target_include_directories(${target_name}
+    PUBLIC
+      $<BUILD_INTERFACE:${module_dir}>
+  )
+
+  ftimer_apply_feature_dependencies(${target_name})
+  target_compile_definitions(${target_name} PRIVATE ${build_definition})
+endfunction()
+
 add_library(ftimer ${FTIMER_SOURCES})
 add_library(fTimer::ftimer ALIAS ftimer)
 
@@ -25,64 +54,20 @@ target_include_directories(ftimer
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ftimer>
 )
 
-if(FTIMER_USE_MPI)
-  target_compile_definitions(ftimer PUBLIC FTIMER_USE_MPI)
-  target_link_libraries(ftimer PUBLIC MPI::MPI_Fortran)
-endif()
-
-if(FTIMER_USE_OPENMP)
-  target_compile_definitions(ftimer PUBLIC FTIMER_USE_OPENMP)
-  target_link_libraries(ftimer PUBLIC OpenMP::OpenMP_Fortran)
-endif()
+ftimer_apply_feature_dependencies(ftimer)
 
 if(FTIMER_BUILD_TESTS)
-  add_library(ftimer_test ${FTIMER_SOURCES})
-
-  set_target_properties(ftimer_test PROPERTIES
-    Fortran_MODULE_DIRECTORY "${FTIMER_TEST_LIBRARY_MODULE_DIR}"
-    OUTPUT_NAME ftimer_test
+  ftimer_add_internal_library(
+    ftimer_test
+    "${FTIMER_TEST_LIBRARY_MODULE_DIR}"
+    FTIMER_BUILD_TESTS
   )
-
-  target_include_directories(ftimer_test
-    PUBLIC
-      $<BUILD_INTERFACE:${FTIMER_TEST_LIBRARY_MODULE_DIR}>
-  )
-
-  if(FTIMER_USE_MPI)
-    target_compile_definitions(ftimer_test PUBLIC FTIMER_USE_MPI)
-    target_link_libraries(ftimer_test PUBLIC MPI::MPI_Fortran)
-  endif()
-
-  if(FTIMER_USE_OPENMP)
-    target_compile_definitions(ftimer_test PUBLIC FTIMER_USE_OPENMP)
-    target_link_libraries(ftimer_test PUBLIC OpenMP::OpenMP_Fortran)
-  endif()
-
-  target_compile_definitions(ftimer_test PRIVATE FTIMER_BUILD_TESTS)
 endif()
 
 if(FTIMER_BUILD_SMOKE_TESTS)
-  add_library(ftimer_smoke_test ${FTIMER_SOURCES})
-
-  set_target_properties(ftimer_smoke_test PROPERTIES
-    Fortran_MODULE_DIRECTORY "${FTIMER_SMOKE_TEST_LIBRARY_MODULE_DIR}"
-    OUTPUT_NAME ftimer_smoke_test
+  ftimer_add_internal_library(
+    ftimer_smoke_test
+    "${FTIMER_SMOKE_TEST_LIBRARY_MODULE_DIR}"
+    FTIMER_BUILD_SMOKE_TESTS
   )
-
-  target_include_directories(ftimer_smoke_test
-    PUBLIC
-      $<BUILD_INTERFACE:${FTIMER_SMOKE_TEST_LIBRARY_MODULE_DIR}>
-  )
-
-  if(FTIMER_USE_MPI)
-    target_compile_definitions(ftimer_smoke_test PUBLIC FTIMER_USE_MPI)
-    target_link_libraries(ftimer_smoke_test PUBLIC MPI::MPI_Fortran)
-  endif()
-
-  if(FTIMER_USE_OPENMP)
-    target_compile_definitions(ftimer_smoke_test PUBLIC FTIMER_USE_OPENMP)
-    target_link_libraries(ftimer_smoke_test PUBLIC OpenMP::OpenMP_Fortran)
-  endif()
-
-  target_compile_definitions(ftimer_smoke_test PRIVATE FTIMER_BUILD_SMOKE_TESTS)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,127 @@ set(FTIMER_INSTALLED_CONSUMER_RUN_TIMEOUT 120 CACHE STRING
 math(EXPR FTIMER_OPENMP_MPI_SUMMARY_SMOKE_CTEST_TIMEOUT
   "${FTIMER_OPENMP_MPI_SUMMARY_SMOKE_TIMEOUT} + 15")
 
+function(ftimer_expect_target_property target_name property expected_value)
+  get_target_property(actual_value ${target_name} ${property})
+  if(NOT actual_value STREQUAL expected_value)
+    message(FATAL_ERROR
+      "${target_name} ${property} contract mismatch: expected '${expected_value}', got '${actual_value}'"
+    )
+  endif()
+endfunction()
+
+function(ftimer_expect_target_property_unset target_name property)
+  get_target_property(actual_value ${target_name} ${property})
+  if(actual_value)
+    message(FATAL_ERROR
+      "${target_name} ${property} contract mismatch: expected unset, got '${actual_value}'"
+    )
+  endif()
+endfunction()
+
+function(ftimer_expect_target_property_contains target_name property expected_item)
+  get_target_property(actual_values ${target_name} ${property})
+  if(NOT expected_item IN_LIST actual_values)
+    message(FATAL_ERROR
+      "${target_name} ${property} contract mismatch: expected list to contain '${expected_item}', got '${actual_values}'"
+    )
+  endif()
+endfunction()
+
+function(ftimer_expect_target_property_lacks target_name property unexpected_item)
+  get_target_property(actual_values ${target_name} ${property})
+  if(unexpected_item IN_LIST actual_values)
+    message(FATAL_ERROR
+      "${target_name} ${property} contract mismatch: expected list not to contain '${unexpected_item}', got '${actual_values}'"
+    )
+  endif()
+endfunction()
+
+function(ftimer_expect_feature_dependencies target_name)
+  if(FTIMER_USE_MPI)
+    ftimer_expect_target_property_contains(${target_name}
+      COMPILE_DEFINITIONS FTIMER_USE_MPI)
+    ftimer_expect_target_property_contains(${target_name}
+      INTERFACE_COMPILE_DEFINITIONS FTIMER_USE_MPI)
+    ftimer_expect_target_property_contains(${target_name}
+      LINK_LIBRARIES MPI::MPI_Fortran)
+    ftimer_expect_target_property_contains(${target_name}
+      INTERFACE_LINK_LIBRARIES MPI::MPI_Fortran)
+  else()
+    ftimer_expect_target_property_lacks(${target_name}
+      COMPILE_DEFINITIONS FTIMER_USE_MPI)
+    ftimer_expect_target_property_lacks(${target_name}
+      INTERFACE_COMPILE_DEFINITIONS FTIMER_USE_MPI)
+    ftimer_expect_target_property_lacks(${target_name}
+      LINK_LIBRARIES MPI::MPI_Fortran)
+    ftimer_expect_target_property_lacks(${target_name}
+      INTERFACE_LINK_LIBRARIES MPI::MPI_Fortran)
+  endif()
+
+  if(FTIMER_USE_OPENMP)
+    ftimer_expect_target_property_contains(${target_name}
+      COMPILE_DEFINITIONS FTIMER_USE_OPENMP)
+    ftimer_expect_target_property_contains(${target_name}
+      INTERFACE_COMPILE_DEFINITIONS FTIMER_USE_OPENMP)
+    ftimer_expect_target_property_contains(${target_name}
+      LINK_LIBRARIES OpenMP::OpenMP_Fortran)
+    ftimer_expect_target_property_contains(${target_name}
+      INTERFACE_LINK_LIBRARIES OpenMP::OpenMP_Fortran)
+  else()
+    ftimer_expect_target_property_lacks(${target_name}
+      COMPILE_DEFINITIONS FTIMER_USE_OPENMP)
+    ftimer_expect_target_property_lacks(${target_name}
+      INTERFACE_COMPILE_DEFINITIONS FTIMER_USE_OPENMP)
+    ftimer_expect_target_property_lacks(${target_name}
+      LINK_LIBRARIES OpenMP::OpenMP_Fortran)
+    ftimer_expect_target_property_lacks(${target_name}
+      INTERFACE_LINK_LIBRARIES OpenMP::OpenMP_Fortran)
+  endif()
+endfunction()
+
+function(ftimer_expect_internal_library_contract target_name module_dir build_definition)
+  ftimer_expect_target_property(${target_name}
+    Fortran_MODULE_DIRECTORY "${module_dir}")
+  ftimer_expect_target_property(${target_name}
+    OUTPUT_NAME ${target_name})
+  ftimer_expect_target_property_contains(${target_name}
+    INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${module_dir}>")
+  ftimer_expect_target_property_contains(${target_name}
+    INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${module_dir}>")
+  ftimer_expect_target_property_contains(${target_name}
+    COMPILE_DEFINITIONS ${build_definition})
+  ftimer_expect_target_property_lacks(${target_name}
+    INTERFACE_COMPILE_DEFINITIONS ${build_definition})
+  ftimer_expect_feature_dependencies(${target_name})
+endfunction()
+
+ftimer_expect_target_property(ftimer
+  Fortran_MODULE_DIRECTORY "${FTIMER_PUBLIC_MODULE_DIR}")
+ftimer_expect_target_property_unset(ftimer OUTPUT_NAME)
+ftimer_expect_target_property_contains(ftimer
+  INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${FTIMER_PUBLIC_MODULE_DIR}>")
+ftimer_expect_target_property_contains(ftimer
+  INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${FTIMER_PUBLIC_MODULE_DIR}>")
+ftimer_expect_target_property_contains(ftimer
+  INTERFACE_INCLUDE_DIRECTORIES "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ftimer>")
+ftimer_expect_feature_dependencies(ftimer)
+
+if(FTIMER_BUILD_TESTS)
+  ftimer_expect_internal_library_contract(
+    ftimer_test
+    "${FTIMER_TEST_LIBRARY_MODULE_DIR}"
+    FTIMER_BUILD_TESTS
+  )
+endif()
+
+if(FTIMER_BUILD_SMOKE_TESTS)
+  ftimer_expect_internal_library_contract(
+    ftimer_smoke_test
+    "${FTIMER_SMOKE_TEST_LIBRARY_MODULE_DIR}"
+    FTIMER_BUILD_SMOKE_TESTS
+  )
+endif()
+
 if(FTIMER_BUILD_SMOKE_TESTS)
   add_executable(ftimer_phase0_smoke test_phase0_smoke.F90)
   target_link_libraries(ftimer_phase0_smoke PRIVATE ftimer)


### PR DESCRIPTION
Closes #315.

## Summary

- Add a small local `src/CMakeLists.txt` helper for feature-mode compile definitions and link dependencies.
- Add a local helper for the repeated internal `ftimer_test` / `ftimer_smoke_test` library setup.
- Leave `bench/CMakeLists.txt` unchanged: the `mpiexec --version` oversubscribe sniff is noted in #315, but changing it would add a new cache/design surface outside this scoped cleanup.

## Target-property comparison

Compared normalized CMake file-API metadata for `ftimer`, `ftimer_test`, and `ftimer_smoke_test` before and after the refactor:

- Serial+pFUnit config: identical target type, artifact/name-on-disk, sources, include dirs/module flags, compile definitions, and link metadata.
- OpenMP+pFUnit config: identical target type, artifact/name-on-disk, sources, include dirs/module flags, compile definitions, and link metadata.

## Validation

- `cmake -S . -B /private/tmp/ftimer-issue315-before-gfortran -DCMAKE_Fortran_COMPILER=/opt/homebrew/bin/gfortran -DFTIMER_BUILD_TESTS=ON -DFTIMER_BUILD_SMOKE_TESTS=ON -DFTIMER_BUILD_EXAMPLES=OFF -DFTIMER_BUILD_BENCH=OFF`
- `cmake -S . -B /private/tmp/ftimer-issue315-after-gfortran -DCMAKE_Fortran_COMPILER=/opt/homebrew/bin/gfortran -DFTIMER_BUILD_TESTS=ON -DFTIMER_BUILD_SMOKE_TESTS=ON -DFTIMER_BUILD_EXAMPLES=OFF -DFTIMER_BUILD_BENCH=OFF`
- Normalized CMake file-API comparison for serial+pFUnit target metadata: match.
- `cmake -S . -B /private/tmp/ftimer-issue315-before-openmp -DCMAKE_Fortran_COMPILER=/opt/homebrew/bin/gfortran -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=ON -DFTIMER_BUILD_SMOKE_TESTS=ON -DFTIMER_BUILD_EXAMPLES=OFF -DFTIMER_BUILD_BENCH=OFF`
- `cmake -S . -B /private/tmp/ftimer-issue315-after-openmp -DCMAKE_Fortran_COMPILER=/opt/homebrew/bin/gfortran -DFTIMER_USE_OPENMP=ON -DFTIMER_BUILD_TESTS=ON -DFTIMER_BUILD_SMOKE_TESTS=ON -DFTIMER_BUILD_EXAMPLES=OFF -DFTIMER_BUILD_BENCH=OFF`
- Normalized CMake file-API comparison for OpenMP+pFUnit target metadata: match.
- `cmake -S . -B build-codex-315-smoke -DCMAKE_Fortran_COMPILER=/opt/homebrew/bin/gfortran`
- `cmake --build build-codex-315-smoke`
- `ctest --test-dir build-codex-315-smoke --output-on-failure` (24/24 passed)
- `cmake --build /private/tmp/ftimer-issue315-after-gfortran --target ftimer_test`
- `git diff --check`