### PR TITLE
Split README contract detail into focused docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,12 @@ For metadata headers, construct `ftimer_metadata_t` values by assigning `%key` a
 
 ## Where To Go Next
 
-- Want a downstream CMake package path? See [Install And Use From Another Project](#install-and-use-from-another-project).
-- Need help choosing between serial, MPI, OpenMP compatibility, and true worker timing? See [Supported Workflows](#supported-workflows).
-- Need the exact runtime contract, support evidence, or installed-package stability details? See [`docs/semantics.md`](docs/semantics.md), [`docs/release-evidence.md`](docs/release-evidence.md), and [`docs/installed-api.md`](docs/installed-api.md).
-- Need practical help with first-use failures? See [`docs/troubleshooting.md`](docs/troubleshooting.md).
+Use the shortest path that matches your role:
+
+- First-time user: stay in this README for `First Success`, `Quick Start`, and `Install And Use From Another Project`, then see the symptom-oriented [`docs/troubleshooting.md`](docs/troubleshooting.md) guide if first use goes sideways.
+- Advanced user: use [Supported Workflows](#supported-workflows) to choose a mode, then jump to [`docs/semantics.md`](docs/semantics.md), [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md), [`docs/csv-schema.md`](docs/csv-schema.md), or [`docs/installed-api.md`](docs/installed-api.md) for the exact contract.
+- Maintainer or release reviewer: use [`docs/release-evidence.md`](docs/release-evidence.md), [`docs/release.md`](docs/release.md), and [`docs/maintainer.md`](docs/maintainer.md).
+- Coding agent: use [`AGENTS.md`](AGENTS.md) or [`CLAUDE.md`](CLAUDE.md) for repo workflow and source-of-truth rules, then read [`docs/semantics.md`](docs/semantics.md) and [`docs/maintainer.md`](docs/maintainer.md) as needed.
 
 ## Install And Use From Another Project
 
@@ -157,89 +159,40 @@ cmake -S my_app -B my_app/build -DCMAKE_PREFIX_PATH=/path/to/ftimer-install
 cmake --build my_app/build
 ```
 
-The supported downstream contract is the installed package export. New adopters should not need to infer the intended consumption model from the test suite.
+The supported downstream contract is the installed CMake package export. New adopters should not need to infer the consumption model from the test suite.
 
-Pre-1.0 CMake package compatibility is intentionally limited to the same minor release line. For example, a `0.2.z` install may satisfy `find_package(fTimer 0.2 CONFIG REQUIRED)` or an older compatible `0.2.x` request, but it will not satisfy a `0.1.x`, `0.3.x`, or later-minor request. Versionless `find_package(fTimer CONFIG REQUIRED)` remains available for consumers that deliberately accept whichever installed fTimer package appears on `CMAKE_PREFIX_PATH`. The `0.2` package line is the first line whose stable summary/result types expose local `call_count` and MPI `min_call_count`/`max_call_count` fields as `integer(int64)`; MPI `avg_call_count` remains `real(wp)`.
+Pre-1.0 CMake package compatibility is intentionally limited to the same minor release line. For example, a `0.2.z` install may satisfy `find_package(fTimer 0.2 CONFIG REQUIRED)` or an older compatible `0.2.x` request, but it will not satisfy a `0.1.x`, `0.3.x`, or later-minor request. Versionless `find_package(fTimer CONFIG REQUIRED)` remains available for consumers that deliberately accept whichever installed fTimer package appears on `CMAKE_PREFIX_PATH`.
 
-The downstream examples under [`tests/install-consumer/`](tests/install-consumer/) are also part of the smoke path. They show the supported installed-package happy path with `find_package(fTimer CONFIG REQUIRED)`, `use ftimer`, `use ftimer_types`, scoped timing, summary retrieval, and the explicit `use ftimer_openmp` API surface from an installed prefix.
-
-The supported source-level module surface is intentionally narrow: `ftimer`, `ftimer_core`, `ftimer_openmp`, and `ftimer_types`. `ftimer_openmp` is the explicit opt-in OpenMP timing surface; its lifecycle/configuration, timer registration/lookup, timed parallel-region, id-first thread-lane timing, local OpenMP summary/report entry points, strict MPI+OpenMP hybrid summary/report/CSV entry points, and sparse union MPI+OpenMP hybrid summary/report/CSV entry points are real. Module-level public symbols are checked against `tests/public_symbol_allowlist.txt`; visible implementation helpers are documented as unstable rather than implied stable API. The installed include tree is a curated compiler module artifact set and currently includes `ftimer_clock.mod`, `ftimer_csv_validation.mod`, `ftimer_summary.mod`, and `ftimer_mpi.mod` so consumers get a coherent Fortran module set. Those implementation modules are not stable import targets. The installed package includes `share/doc/fTimer/installed-api.md` with the same stability contract and `share/doc/fTimer/LICENSE` with the BSD terms. The smoke tests verify the exact module artifact set and installed documentation artifacts.
+The downstream examples under [`tests/install-consumer/`](tests/install-consumer/) stay in the smoke path as the supported installed-package happy path. For the full installed-module stability contract, public symbol boundary, installed docs/artifacts, and pre-1.0 compatibility notes, see [`docs/installed-api.md`](docs/installed-api.md).
 
 ## Supported Workflows
 
-fTimer currently supports these usage paths:
+fTimer currently supports a small set of distinct stories:
 
-- Serial timing with local summaries plus formatted text and CSV reports
-- Pure-MPI builds on the validated `mpi_f08` path that are used after `MPI_Init` and before `MPI_Finalize`, use `MPI_Wtime()`, produce global MPI summaries on every participating rank, and can emit strict communicator-level text/CSV reports or opt-in sparse union text/CSV reports
-- OpenMP compatibility guards for timing a parallel region as a whole through the existing APIs
-- Explicit opt-in OpenMP worker timing through `ftimer_openmp_t`, with local OpenMP summaries/reports plus strict and sparse union MPI+OpenMP hybrid summaries/reports/CSV over `MPI_COMM_WORLD` by default in MPI builds, or over an explicit `comm=` when supplied
+- Serial/local timing through `ftimer` or `ftimer_core`
+- Strict pure-MPI timing and sparse pure-MPI union timing on the validated `mpi_f08` path
+- OpenMP compatibility timing through the existing APIs when one timer brackets a parallel region
+- Explicit worker timing through `ftimer_openmp_t`, including strict and sparse MPI+OpenMP report families
 - Downstream consumption through `find_package(fTimer CONFIG REQUIRED)`
 - Application-owned instrumentation facades that can select either the real fTimer implementation or a dependency-free no-op implementation at build time
 
-Choose the smallest mode that matches the measurement you need. Use serial
-timing for one process, pure MPI for rank-local intervals reduced across a
-communicator, OpenMP compatibility mode when one wall-clock timer should bracket
-an entire parallel region, true OpenMP worker timing when per-lane participation
-matters inside one level-1 team, strict MPI+OpenMP when all ranks and lanes must
-share the same descriptor tree, and sparse union MPI+OpenMP when rank- or
-lane-conditional work should be represented with explicit participation metadata.
+Choose the smallest mode that matches the measurement you need. Start with serial, add strict MPI only when every rank shares the same descriptor tree, add sparse MPI union when participation is rank-conditional, keep existing OpenMP calls outside the parallel region for compatibility timing, and use `ftimer_openmp_t` only when you need per-lane worker data.
 
-### First-Hour Timing Mode Chooser
+CSV schemas follow the same split: local/strict MPI share one v2 family, while sparse MPI union, local OpenMP, strict MPI+OpenMP, and sparse MPI+OpenMP union each use dedicated schemas that are not append-compatible with one another.
 
-Start with the row that matches the measurement you want, then move to a more
-specialized mode only when the participation pattern requires it.
-
-| Measurement goal | Use this mode | First API or report family | Caveat to keep visible |
-| --- | --- | --- | --- |
-| One process, one thread, or rank-local data before any MPI reduction | Serial/local timing through `ftimer` or `ftimer_core` | `get_summary()`, `print_summary()`, `write_summary_csv()` | Local summaries are live snapshots. Active timers are included and marked; stop all timers first for a final report. |
-| Same timer tree on every MPI rank | Strict pure-MPI timing | `mpi_summary()`, `print_mpi_summary()`, `write_mpi_summary_csv()` | fTimer reduces rank-local intervals and does not add barriers. Descriptor mismatches are errors. |
-| Rank-conditional pure-MPI timers | Sparse pure-MPI union timing | `mpi_union_summary()`, `print_mpi_union_summary()`, `write_mpi_union_summary_csv()` | Missing ranks are explicit nonparticipants, not zero-time contributors. |
-| One wall-clock interval around an OpenMP parallel region | OpenMP compatibility timing with current `ftimer` / `ftimer_core` calls outside the parallel region | Local summaries, or strict/sparse pure-MPI summaries in MPI builds | Worker-thread calls through these existing APIs are silent no-ops; this does not produce per-worker data. |
-| Per-lane OpenMP worker participation inside one level-1 team | Explicit worker timing through `ftimer_openmp_t` | `get_openmp_summary()`, `print_openmp_summary()`, `write_openmp_summary_csv()` | OpenMP worker summaries are stopped-run merge points. Close the timed region and stop all lane stacks first. |
-| Same worker timer tree on every MPI rank and eligible lane | Strict MPI+OpenMP worker timing through `ftimer_openmp_t` | `mpi_openmp_summary()`, `print_mpi_openmp_summary()`, `write_mpi_openmp_summary_csv()` | These collective stopped-run APIs require matching rank/lane descriptors and eligible-lane participation. |
-| Rank- or lane-conditional MPI+OpenMP worker timers | Sparse MPI+OpenMP union timing through `ftimer_openmp_t` | `mpi_openmp_union_summary()`, `print_mpi_openmp_union_summary()`, `write_mpi_openmp_union_summary_csv()` | Missing ranks and lanes are explicit participation metadata, not zero-filled samples. |
-
-CSV schemas follow the same mode choice: local/strict MPI share one v2 family,
-while sparse MPI union, local OpenMP, strict MPI+OpenMP, and sparse
-MPI+OpenMP union each use dedicated schemas that are not append-compatible with
-one another. For the full OpenMP and hybrid lifecycle, see
-[`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md).
-
-Important limitations are documented later in this README. The short version is that serial and pure-MPI are the core supported stories on current `main`; OpenMP has a legacy master-thread-only compatibility path plus the explicit `ftimer_openmp_t` worker-timing object, local stopped-run summaries, strict MPI+OpenMP rank/lane reductions, and separate sparse union MPI+OpenMP rank/lane reductions.
+For the full OpenMP and hybrid lifecycle, accepted source shapes, and migration guidance, see [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md).
 
 ## Operational Support Matrix
 
-Support tiers mean:
+Support tiers still matter, but the detailed claim ledger lives outside the README:
 
-- **Core validated**: release-critical paths covered by CI smoke, install, and
-  behavior checks where the required toolchain is available.
-- **Supported advanced**: validated feature paths with a narrower runtime or
-  toolchain contract than the serial and pure-MPI core.
-- **Plausible but unvalidated**: paths that may work from the implementation
-  design, but are not part of release validation today.
-- **Experimental/deferred**: future ecosystem or integration work with no
-  current support commitment.
-- **Unsupported**: known out-of-contract paths, removed interfaces, or
-  combinations intentionally rejected by configure checks.
+- **Core validated** today: serial/library smoke, installed consumer coverage, and pure-MPI on the documented GNU wrapper path.
+- **Supported advanced**: OpenMP compatibility through `ftimer` / `ftimer_core`, plus explicit worker timing and strict/sparse MPI+OpenMP reporting through `ftimer_openmp_t`.
+- **Plausible but unvalidated**: compiler, MPI, or OpenMP combinations not yet backed by direct automation or recorded local evidence.
+- **Experimental/deferred**: package-manager installs, profiler backends, hardware counters, traces, dashboards, and similar ecosystem work.
+- Exact status, evidence, and caveats for each release-facing claim live in [`docs/release-evidence.md`](docs/release-evidence.md). Use that ledger, not this README, when you need release-review wording.
 
-| Area | Current support tier |
-| --- | --- |
-| Serial library, smoke tests, examples, and installed consumer | **Core validated** with GNU Fortran and LLVM Flang. Other modern Fortran compilers are **plausible but unvalidated** until a release issue adds direct automation. |
-| Serial pFUnit behavior suite | **Core validated** with GNU Fortran and a matching pFUnit installation. LLVM Flang pFUnit and other compiler/pFUnit combinations are **plausible but unvalidated**. |
-| Pure MPI | **Core validated** for GNU Fortran MPI wrapper compilers with OpenMPI and MPICH, using `mpi_f08`, after `MPI_Init` and before `MPI_Finalize`. OpenMPI and MPICH smoke/install-consumer paths are validated; MPI pFUnit coverage is validated where matching pFUnit is available. Legacy `mpif.h`, integer communicator handles, and MPI use outside the MPI lifetime are **unsupported**. |
-| OpenMP compatibility through `ftimer` / `ftimer_core` | **Supported advanced** with GNU Fortran pFUnit guard coverage and LLVM Flang smoke/example coverage. The contract is master-thread-only; worker-thread calls through these existing APIs are silent no-ops. |
-| Explicit `ftimer_openmp_t` worker timing | **Supported advanced** with GNU Fortran and LLVM Flang OpenMP smoke/example coverage. Use this object API for serial-lane and level-1 worker timing; active-region rejection and queued diagnostics are part of this path, not the legacy worker no-op carve-out. |
-| MPI+OpenMP hybrid summaries, reports, CSV, and installed consumer | **Supported advanced** today for OpenMPI wrapper builds with GNU Fortran and OpenMP, with focused MPICH wrapper smoke/install-consumer evidence recorded in the release ledger. Other MPI/compiler/OpenMP runtime combinations are **plausible but unvalidated** until separate release evidence promotes them. |
-| Installed CMake package and `.mod` artifacts | **Core validated** for matching compiler, toolchain, and feature mode. Installed Fortran `.mod` files are compiler/toolchain/mode specific; cross-compiler or cross-mode reuse is **unsupported**. |
-| FPM/package-manager installs, profiler backends, hardware counters, traces, dashboards, accelerator timelines | **Experimental/deferred**. These are not part of the current release support claim. |
-
-For failure-oriented guidance, see
-[`docs/troubleshooting.md`](docs/troubleshooting.md). For the architecture,
-validation context, and claim evidence behind the matrix, see
-[`docs/design.md`](docs/design.md) and
-[`docs/release-evidence.md`](docs/release-evidence.md).
-For installed package stability details, see
-[`docs/installed-api.md`](docs/installed-api.md).
+For failure-oriented guidance, see [`docs/troubleshooting.md`](docs/troubleshooting.md). For architecture and validation context, see [`docs/design.md`](docs/design.md). For installed package stability details, see [`docs/installed-api.md`](docs/installed-api.md).
 
 ## Compile-Out / No-Op Instrumentation Pattern
 
@@ -287,63 +240,21 @@ The repository includes a worked example under `examples/instrumentation_facade_
 
 ## API Surface
 
-The public API supports four stable import surfaces:
+The stable source-level import surfaces are `ftimer`, `ftimer_core`, `ftimer_openmp`, and `ftimer_types`.
 
-- Procedural API from `use ftimer`, including `ftimer_init`, `ftimer_finalize`, `ftimer_start`, `ftimer_stop`, `ftimer_scope`, `ftimer_guard_t`, `ftimer_start_id`, `ftimer_stop_id`, `ftimer_lookup`, `ftimer_reset`, `ftimer_get_summary`, `ftimer_mpi_summary`, `ftimer_mpi_union_summary`, `ftimer_print_summary`, `ftimer_write_summary`, `ftimer_write_summary_csv`, `ftimer_print_mpi_summary`, `ftimer_write_mpi_summary`, `ftimer_write_mpi_summary_csv`, `ftimer_print_mpi_union_summary`, `ftimer_write_mpi_union_summary`, `ftimer_write_mpi_union_summary_csv`, and `ftimer_default_instance`
-- OOP API through `type(ftimer_t)` in `ftimer_core`, including explicit `start`/`stop`, the configuration methods `set_clock`, `clear_clock`, `set_callback`, and `clear_callback`, plus pointer-based scoped timing with `ftimer_oop_guard_t` and `ftimer_oop_scope`
-- Explicit opt-in OpenMP API through `type(ftimer_openmp_t)` in `ftimer_openmp`, including keyword-required `init(config=...)`, optional MPI `comm=` in MPI builds, `reset`, `finalize`, `register_timer`, `lookup_timer`, `begin_parallel_region`, `end_parallel_region`, `start_id`, `stop_id`, `get_openmp_summary`, `print_openmp_summary`, `write_openmp_summary`, `write_openmp_summary_csv`, `mpi_openmp_summary`, `print_mpi_openmp_summary`, `write_mpi_openmp_summary`, `write_mpi_openmp_summary_csv`, `mpi_openmp_union_summary`, `print_mpi_openmp_union_summary`, `write_mpi_openmp_union_summary`, and `write_mpi_openmp_union_summary_csv`
-- Shared stable types, constants, and callback/clock interfaces from `ftimer_types`, including the summary/result types and `FTIMER_*` status, event, and mismatch constants
+- Start with `use ftimer` unless you already need instance-level control.
+- Use `ftimer_core` for `type(ftimer_t)`, clock/callback configuration, or pointer-based scoped timing with `ftimer_oop_guard_t` and `ftimer_oop_scope`.
+- Use `ftimer_openmp` only for the explicit opt-in worker-timing API, not as a general replacement for the existing procedural path.
+- Use `ftimer_types` for shared summary types, status codes, mismatch constants, and callback/clock interfaces.
+- Some helper names remain public by necessity, but they are not stable downstream API. The exact stable/unstable/test-only split lives in [`docs/installed-api.md`](docs/installed-api.md).
 
-New users should start with the procedural API unless they already know they need instance-level control. Reach for `type(ftimer_t)` when you want multiple independent timer objects, want to avoid the default global instance, or need to manage clock or callback configuration on a specific timer object. Procedural callers that need those advanced controls can use `ftimer_default_instance%...` explicitly.
-
-Some implementation-detail symbols are publicly visible from stable modules because current Fortran module layering requires them: `ftimer_call_stack_t`, `ftimer_context_list_t`, `ftimer_segment_t`, `ftimer_internal_start_scope_activation`, and `ftimer_internal_stop_scope_activation`. They are unstable public-by-necessity names, not supported downstream API. User code should avoid importing them and should rely on `ftimer_scope()`, `ftimer_oop_scope()`, explicit start/stop calls, and the structured summary result types instead. Test-only helper exports such as `ftimer_test_get_state`, `ftimer_test_set_call_count`, and `ftimer_test_state_t` are confined to `FTIMER_BUILD_TESTS` helper builds.
-
-Operational notes:
+A few contract details are worth keeping visible here:
 
 - `ierr` is now the last optional argument in the `init` signatures. In MPI builds, communicator capture uses `comm :: type(MPI_Comm)` from `mpi_f08`; integer communicator handles are not accepted. Integer `init` options such as `mismatch_mode` and `ierr` must be passed by keyword so legacy positional communicator handles cannot be mistaken for supported options. Keywords are recommended for readability on all `init` calls.
-- `ftimer_openmp_t%init` requires `config=` and accepts `comm=` only by keyword in MPI builds. If `comm=` is omitted in an MPI+OpenMP build, the object captures `MPI_COMM_WORLD`; pass `comm=` to use a caller-owned communicator explicitly. The MPI communicator handle is used by the strict and sparse union `mpi_openmp` report families and is otherwise non-owning; local OpenMP summary/report behavior does not consume it. Current `ftimer_openmp_t` timing uses the non-MPI wall clock even in MPI-enabled packages, so worker timing does not call `MPI_Wtime()` from OpenMP threads or require an `MPI_Init_thread` support level. The OpenMP object keeps registered timer ids valid across `reset()` and invalidates them across `finalize()`/reinit without recycling ids in the same object. `config%max_lanes` counts the serial lane plus worker lanes. In `FTIMER_USE_OPENMP=ON` fTimer builds, `begin_parallel_region`/`end_parallel_region` are called from serial context and `start_id`/`stop_id` may run inside the open level-1 OpenMP region. Worker calls outside an open timed region, over `config%max_lanes`, or on the wrong lane return errors without mutating unrelated lane state. Calls made inside an OpenMP parallel region without `ierr` queue bounded diagnostics instead of writing unordered stderr, except for valid worker timing calls. A later serial lifecycle call without `ierr` emits one aggregate message and proceeds. With `ierr`, a lifecycle call that observes queued worker diagnostics returns the first queued status without stderr and leaves lifecycle state unchanged; repeat the lifecycle call after that explicit drain to proceed. Local OpenMP summaries are stopped-run-only, use `ftimer_openmp_summary_t`, distinguish timed-region wall-clock envelope time from summed lane work, compute self time on each lane before aggregation, and report missing lanes from observed eligible team lanes rather than configured capacity. Strict MPI+OpenMP summaries are stopped-run collectives over the captured communicator, use `ftimer_mpi_openmp_summary_t`, require identical timer descriptors and eligible lane participation across ranks, and reject mismatches rather than zero-filling missing rank/lane data. Sparse union MPI+OpenMP summaries are stopped-run collectives over the same captured communicator, use `ftimer_mpi_openmp_union_summary_t`, build a descriptor union across ranks and lanes, and report explicit rank/lane participation so absent contributors are not confused with present zero work. In non-OpenMP fTimer packages, `ftimer_openmp` is a serial-context lifecycle/catalog/timing surface only, even if a downstream application separately enables OpenMP. In non-MPI fTimer packages, initialized `ftimer_openmp_t` objects return `FTIMER_ERR_NOT_IMPLEMENTED` from the MPI+OpenMP summary/report methods; the usual lifecycle checks still take precedence, so uninitialized objects return `FTIMER_ERR_NOT_INIT`.
-- MPI-enabled fTimer must be used after `MPI_Init` and before `MPI_Finalize`. The MPI build-default clock calls `MPI_Wtime()`, and MPI summaries/reports enter MPI collectives, so initializing, timing, summarizing, reporting, resetting, or finalizing an MPI-enabled timer outside the MPI lifetime is unsupported.
-- `init(config=...)` in an MPI build captures `MPI_COMM_WORLD` by default. `init(comm=...)` captures a caller-selected communicator to use for later MPI summaries and reports, but fTimer stores that communicator as a non-owning handle. It does not call `MPI_Comm_dup` or `MPI_Comm_free` for caller-provided communicators. If you pass a subcommunicator, keep it valid until all fTimer summaries, reports, `finalize()`, or any `init()` reinitialization that may use the old communicator are complete.
-- Current `ftimer` and `type(ftimer_t)` `init`, `reset`, and `finalize` calls are correctness-first on active timers: with `ierr` they return `FTIMER_ERR_ACTIVE`; without `ierr` they warn and leave state unchanged. In `FTIMER_USE_OPENMP=ON` builds, that diagnostic contract applies on the master thread; worker-thread lifecycle calls through the current APIs remain silent no-ops. These paths do not force-stop active timers or synthesize summary data.
-- Stop-mismatch repair remains an explicit `mismatch_mode` choice (`FTIMER_MISMATCH_WARN` or `FTIMER_MISMATCH_REPAIR`); omitted-`ierr` alone does not opt a caller into recovery.
-- The `ierr` contract covers normal validation, lifecycle, mismatch, unsupported-feature, MPI consistency, MPI datatype/collective, file/CSV I/O, stale-id, and explicit integer-space exhaustion checks. Arbitrary allocation failure and process resource exhaustion are not currently recoverable fTimer status paths; the Fortran runtime may terminate before fTimer can return an `ierr`. Remaining production `error stop` paths are reserved for impossible clock/backend conditions or internal stack/index invariants where continuing could corrupt timing data.
-- Timer names are right-trimmed and must be non-empty, must not begin with a blank, and must not contain ASCII control characters. fTimer does not silently truncate timer names and no longer rejects names solely for exceeding the legacy `FTIMER_NAME_LEN = 64` threshold.
-- Name-based `start`/`stop` remains the default ergonomic path. The runtime now uses internal mapped lookup for both resident timer names and per-segment parent-stack contexts, plus capacity-based growth, so that this default path avoids repeated resident-timer linear scans and context-list scans in steady state as the timer set and parent-stack variants grow.
-- For `ftimer_openmp_t`, register names in serial context and pass ids into worker regions for the hot path. The OpenMP runtime keeps private catalog and lane-context indexes and grows segment storage only on participating lanes, so a public reserve/warm API is not currently required. For benchmark-only overhead studies, callers may touch the same lane/timer/context combinations inside the same opened timed region/epoch before starting an external measurement loop, then ignore the fTimer summary from that run; current fTimer summaries include those warm-up calls, and a fresh timed region still pays one team-size observation per participating lane.
-- `ftimer_scope(guard, name, ierr)` is a small safety layer for scalar lexical-block timing on the default procedural instance. `call ftimer_oop_scope(timer_pointer, guard, name, ierr)` provides OOP scoped timing through `ftimer_core` when the caller passes an associated `type(ftimer_t), pointer` and uses `type(ftimer_oop_guard_t)`.
-- Scoped guards do not replace explicit `start`/`stop`; explicit `timer%start()` / `timer%stop()` remains the primary OOP API. A guard may stop only the exact activation it started; if that activation was already stopped, invalidated by lifecycle, or displaced by other timer operations, `guard%stop(ierr)` returns `FTIMER_ERR_MISMATCH` or the relevant lifecycle error and the finalizer warns when it cannot report `ierr`.
-- OOP scoped guards store a non-owning timer pointer. The timer target must outlive the guard and remain initialized until the guard is inactive; use a nested block/procedure for the guard or call `guard%stop(ierr=...)` before leaving a shared scope or calling timer lifecycle operations. Lifecycle calls reject the guard-owned activation while it is still active on the timer stack; if user code manually stops that activation first, the guard becomes stale and later `guard%stop(ierr=...)` reports a mismatch instead. Do not rely on finalization order for an automatic timer object and an active guard declared in the same scoping unit.
-- Guard assignment/copy is unsupported and does not copy or transfer active ownership; assignment involving an active guard warns and leaves ownership with the original guard. Guard arrays, saved/global guards, function-return guard constructors, cross-procedure lifetime patterns, deallocated timer targets, and block-local finalization inside OpenMP parallel regions are unsupported. `ftimer_scope_id` is deferred.
-- `lookup()` plus `start_id()`/`stop_id()` remains an optional hot-path optimization when one call site times the same known region in a very tight loop. That path is especially useful when a long scientific label would otherwise be validated and hashed on every name-based call.
-- Cached IDs returned by `lookup()` are opaque handles for the current timer runtime state, not segment-array indexes. They remain valid across `reset()`, but successful `init()` and `finalize()` calls invalidate them. Calls made while finalized follow the normal `FTIMER_ERR_NOT_INIT` lifecycle contract; after a later successful `init()`, passing a stale cached ID to `start_id()` or `stop_id()` returns `FTIMER_ERR_UNKNOWN` and leaves timer state unchanged.
-- Configure custom clocks through `set_clock()` and restore the build-default wall clock through `clear_clock()`. Direct mutation of raw runtime clock internals is not part of the supported API.
-- Clock changes are allowed before `init()` or before a run records timing data. If configured before `init()`, the next `init()` starts the local summary window in the selected clock epoch. If changed after `init()` but before timing data exists, `set_clock()` or `clear_clock()` immediately restarts that window in the newly selected clock epoch; the first later `start()` does not move it. Empty local summaries, text reports, and CSV exports therefore use one clock epoch for `summary%total_time` and `% Total`.
-- After timing has started, `set_clock()` and `clear_clock()` return `FTIMER_ERR_ACTIVE` (or warn to stderr when `ierr` is omitted) and leave state unchanged. Use `reset()`, `init()`, or `finalize()` to begin a fresh run on a different clock.
-- In non-MPI builds, the build-default wall clock is Fortran `system_clock(count, rate)` converted to seconds. fTimer assumes a positive rate and a nondecreasing count during a timing run; it does not clamp backward movement or compensate for counter wrap, so those backend behaviors remain visible in elapsed times and summaries.
-- The default serial clock's nominal resolution is `1 / count_rate` seconds and its uninterrupted useful range depends on the compiler/runtime `count_max` and `count_rate`. Current summary schemas and reports do not expose clock-rate or wrap metadata; applications that need to archive toolchain-specific clock characteristics can include them as user metadata.
-- Configure callbacks through `set_callback()` and `clear_callback()`. Callback configuration is rejected while timers are active, `clear_callback()` also clears callback `user_data`, and `finalize()` clears callback configuration.
-- `get_summary()`, `print_summary()`, and `write_summary()` are local-only summary/reporting paths.
-- `get_summary()`, `print_summary()`, and `write_summary()` are live snapshot APIs. They include active local timer contexts through the snapshot timestamp without stopping them, and mark that state with `summary%has_active_timers`, each entry's `is_active`, and, when active entries exist, the formatted report's `Active timers`/`Active` fields. For a final local report, stop all timers first and verify `summary%has_active_timers == .false.`.
-- Human-readable local, strict MPI, and sparse MPI text reports escape metadata header keys and values before writing them. Tabs, newlines, carriage returns, delete, terminal escape bytes, other C0/C1 controls, UTF-8 encoded C1 controls, backslashes, and leading blanks are rendered visibly instead of being emitted as raw log-control text; valid non-control UTF-8 text is preserved and blank metadata values remain blank.
-- Local summary entries retain preorder formatting compatibility and now expose explicit tree structure through `node_id` and `parent_id`. `node_id` values are stable only within one produced summary object, and roots use `parent_id = 0`.
-- Local structured summaries also expose context-cardinality diagnostics without changing runtime behavior by default. `summary%total_contexts` is the total number of allocated parent-stack contexts across resident timers, `summary%max_contexts_per_timer` is the largest per-timer context count, and `summary%context_diagnostics(:)` names each resident timer with its allocated context count, including timers whose contexts are currently hidden from visible summary rows. Each visible entry's `timer_context_count` repeats the count for that entry's timer name. These are structured-summary fields only; text and CSV report schemas are unchanged, no warning threshold or hard cap is enabled by default, and context-sensitive accounting remains unchanged.
-- Local summary `call_count` fields are signed-64-bit counts. If a timer context ever reaches the signed-64-bit maximum, the next `start` fails with `FTIMER_ERR_UNKNOWN` or the normal omitted-`ierr` warning path rather than wrapping the count. If the classic timer object's unique timer-id space is exhausted, new timer creation through `lookup()` or name-based `start()` also fails with `FTIMER_ERR_UNKNOWN` or the omitted-`ierr` warning path.
-- `write_summary_csv()` and `ftimer_write_summary_csv()` export local summaries as stable CSV records for dashboards, CI comparisons, plotting, and archives. The text report remains human-facing; consumers should use the CSV or structured Fortran summary rather than scraping fixed-width report output.
-- `mpi_summary()` and `ftimer_mpi_summary()` require `FTIMER_USE_MPI=ON`, a fully stopped timer set, and collective agreement on the communicator captured by `init`.
-- A successful MPI reduction returns a distinct `ftimer_mpi_summary_t` whose fields are globally meaningful on every participating rank.
-- The MPI result includes communicator-local rank attribution for total-time extrema and per-entry inclusive-time extrema. Ties resolve to the lowest rank that attains the extremum.
-- MPI call-count extrema remain exact `integer(int64)` fields. `avg_call_count` remains `real(wp)` and is computed without integer-sum overflow by reducing exact `integer(int64)` extrema first, then averaging nonnegative deltas from the exact minimum count. The final average is clamped to the representable `real(wp)` conversions of the exact min/max counts. Because `real(wp)` cannot represent every signed-64-bit integer exactly, a near-limit average may differ from the exact integer average by representable real rounding.
-- Sparse/union MPI summaries use the separate `mpi_union_summary()` / `ftimer_mpi_union_summary()` API and `ftimer_mpi_union_summary_t` result type. This opt-in path builds a canonical descriptor union across ranks instead of weakening strict `mpi_summary()`.
-- `ftimer_mpi_union_summary_t` keeps communicator total-time fields as all-rank statistics. Each entry records `participating_rank_count`; missing rank count is derived as `num_ranks - participating_rank_count`, and entry min/avg/max statistics are defined over participating ranks only.
-- Sparse entries are materialized from descriptors emitted by each rank's local summary. Lookup-only timer definitions are not a first-class sparse-registration contract, absent ranks are not zero-filled, and no all-rank amortized compatibility fields are included in the initial result model.
-- `print_mpi_union_summary()` / `ftimer_print_mpi_union_summary()` and `write_mpi_union_summary()` / `ftimer_write_mpi_union_summary()` are the explicit sparse text report paths. `write_mpi_union_summary_csv()` / `ftimer_write_mpi_union_summary_csv()` is the explicit sparse CSV export path. They build `ftimer_mpi_union_summary_t`, emit one communicator-root artifact, and expose `Participating` plus derived `Missing` rank counts so absent ranks are not confused with zero work.
-- Sparse union report entry statistics are over participating ranks only. A present zero-elapsed timer with a real start/stop contributes to participation and call-count statistics; lookup-only names are still not sparse registrations. Sparse CSV export keeps those same participation-only semantics in explicitly named columns.
-- `print_mpi_summary()` and `write_mpi_summary()` are the first-class strict MPI reporting paths. They perform the collective strict MPI summary build, emit one abbreviated report from communicator root, and synchronize root output failures so every participant observes `FTIMER_ERR_IO`. The printed per-entry table is not a serialization of every `ftimer_mpi_summary_t` field; inspect `mpi_summary()` results for min/max self time, self imbalance, min/max call counts, min/max rank-local `% Total`, and explicit `node_id`/`parent_id` tree links.
-- `write_mpi_summary_csv()` and `ftimer_write_mpi_summary_csv()` perform the same collective MPI summary build and write one CSV artifact from communicator root. The CSV includes the complete reduced MPI entry fields, including explicit tree links and inclusive-time extrema ranks.
-- In MPI text reports, `Avg %` means the arithmetic mean of each rank's local `% Total` for that timer, not `100*Avg Incl/Avg total time`.
-- Callbacks configured on `type(ftimer_t)` are lightweight intra-run hooks. They report normal start/stop events with runtime-local numeric ids; current `main` does not promise a stable semantic id-to-name/path mapping for profiler backends or durable cross-run tooling. Scoped guards produce only the normal underlying start/stop callback events; mutating timer state from callbacks during scoped guard start/stop is unsupported.
-- Import shared types and constants from `ftimer_types`; `use ftimer` does not re-export them.
-- `FTIMER_NAME_LEN` remains exported so code that only imports the constant still compiles, but timer names, summary names, MPI summary names, and metadata key/value fields now use allocatable-length storage rather than that fixed width. Pre-1.0 callers that treated those public components as preallocated fixed buffers, such as internal writes directly into `%value`, should write to a temporary string and assign the result.
+- `ftimer_openmp_t%init` requires `config=` and accepts `comm=` only by keyword in MPI builds. Omitted `comm=` captures `MPI_COMM_WORLD`, while local OpenMP summaries remain separate from the MPI and local-summary families.
+- `ftimer_scope(guard, name, ierr)` and `ftimer_oop_scope(timer_pointer, guard, name, ierr)` are the scoped helpers. Keep explicit `start`/`stop` as the primary OOP API when ownership is not purely lexical.
+
+For the exhaustive symbol list, installed `.mod` artifact contract, public-surface change map, and detailed API notes, see [`docs/installed-api.md`](docs/installed-api.md).
 
 ## Examples
 
@@ -359,33 +270,16 @@ See [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md) for the current
 
 ## CSV Export
 
-The first stable machine-readable export format is CSV, chosen because fTimer summaries are snapshot tables rather than event streams. The local and strict MPI schema is versioned by the `format_version` column and currently uses version `2`. Sparse union MPI CSV uses a separate participation-aware schema with `format_version=1` and `summary_kind=mpi_union`; local OpenMP CSV uses its own schema with `format_version=1` and `summary_kind=openmp`; strict MPI+OpenMP CSV uses a separate schema with `format_version=1` and `summary_kind=mpi_openmp`; sparse union MPI+OpenMP CSV uses a separate schema with `format_version=1`, `summary_kind=mpi_openmp_union`, and `participation_policy=sparse_union`. These dedicated schemas are intentionally not append-compatible with the local/strict MPI v2 header or with each other.
+CSV is the first stable machine-readable export format because fTimer summaries are snapshot tables rather than event streams.
 
-See [`docs/csv-schema.md`](docs/csv-schema.md) for the compact field dictionary,
-schema-family signatures, denominator choices, active snapshot fields, append
-constraints, and sparse participation interpretation used by CSV readers.
+- Local and strict MPI share the `format_version=2` family.
+- Sparse MPI union, local OpenMP, strict MPI+OpenMP, and sparse MPI+OpenMP union each use their own dedicated schema families.
+- Those families are intentionally not append-compatible with one another.
+- Missing sparse ranks or lanes are explicit participation metadata, not zero-filled samples.
 
-Each CSV starts with one header row followed by typed records. All schemas use:
+See [`docs/csv-schema.md`](docs/csv-schema.md) for the compact field dictionary, schema-family signatures, denominator choices, active snapshot fields, append constraints, and the tiny reader-aid fixtures used by the docs checks.
 
-- `record_type=summary` carries run-level fields.
-- `record_type=metadata` carries caller-supplied metadata as `key`/`value`.
-- `record_type=entry` carries one timer node per row.
-
-Participation-aware schemas may add records for their own aggregate surface.
-Strict MPI+OpenMP CSV also emits `record_type=rank` rows for per-rank
-summary-window, envelope, and summed-lane fields.
-
-Common local/strict columns include `summary_kind`, `node_id`, `parent_id`, `depth`, and `name`. Local entry rows populate `inclusive_time`, `self_time`, `call_count`, `avg_time`, `pct_time`, and `is_active`. Strict MPI entry rows keep `summary_kind=mpi` and populate the reduced fields from `ftimer_mpi_summary_t`, including min/avg/max inclusive and self time, call count extrema, rank-local percent extrema, imbalance fields, and inclusive-time extrema ranks. Local `call_count` and MPI `min_call_count`/`max_call_count` are `integer(int64)` values and are emitted as decimal text without narrowing to default integer. MPI `avg_call_count` remains a real-valued CSV field. CSV format version `2` is the compatibility signal for those widened integer count ranges; consumers should parse local `call_count` and MPI call-count extrema fields as at least signed 64-bit decimal integers.
-
-Sparse union CSV rows use `summary_kind=mpi_union`. Entry rows include `participating_rank_count` and explicit `missing_rank_count`, derived as `num_ranks - participating_rank_count`. Per-entry statistic columns are deliberately labeled as participating-rank fields, for example `min_participating_inclusive_time`, `avg_participating_self_time`, and `max_participating_call_count`. Participating call-count extrema are emitted as signed-64-bit decimal text. Missing ranks are not zero-filled, and no all-rank amortized entry view is emitted.
-
-OpenMP CSV rows use `summary_kind=openmp`. Summary rows distinguish `summary_window_time`, `timed_region_envelope_time`, `sum_lane_root_inclusive_time`, and `sum_lane_self_time`. Entry rows include explicit tree links, `eligible_lane_count`, `participating_lane_count`, `missing_lane_count`, `missing_lane_count_known`, and lane aggregate fields such as `sum_lane_inclusive_time`, `avg_lane_self_time`, and `max_lane_call_count`. Missing lanes are not zero-filled, and the schema is an aggregate summary table rather than a trace or profiler event stream. When one descriptor spans timed-region epochs with different OpenMP team sizes, `eligible_lane_count` is the maximum/union eligible lane count retained for that aggregate row and `missing_lane_count_known=false` marks `missing_lane_count` as non-precise; the text report prints `unknown` for that missing value.
-
-Strict MPI+OpenMP CSV rows use `summary_kind=mpi_openmp`. Summary rows carry communicator-level rank extrema, rank rows carry per-rank summary-window/envelope/summed-lane fields, and entry rows carry descriptor aggregates over participating rank/lane samples. Entry rows include `execution_domain`, `eligible_rank_lane_sample_count`, `participating_rank_lane_sample_count`, explicit missing-sample fields, participating-lane inclusive/self/call-count/percent extrema, and imbalance fields. Strict mismatches are rejected before numeric reductions; missing rank/lane data is not zero-filled.
-
-Sparse union MPI+OpenMP CSV rows use `summary_kind=mpi_openmp_union` and `participation_policy=sparse_union`. Summary and rank rows preserve the same communicator and per-rank OpenMP summary-window fields as the strict hybrid schema, while entry rows add `participating_rank_count`, `missing_rank_count`, `eligible_rank_lane_sample_count`, `participating_rank_lane_sample_count`, and explicit missing-sample fields. Per-entry statistics are over participating rank/lane samples only. Absent ranks and absent lanes are not zero-filled, and strict hybrid CSV append targets remain incompatible with this sparse union schema. Mixed OpenMP epochs with different team sizes retain aggregate eligible rank/lane sample counts but set `missing_rank_lane_sample_count_known=false`; sparse hybrid text reports print `unknown` rather than a precise missing-sample count.
-
-Appending to an existing non-empty CSV requires the existing first row to match the exact header for the API being used, existing rows to be well-formed CSV logical records with that header's field count and recognized `summary_kind`/`record_type` combinations, and the target to end with a newline; mismatched headers, older-format records, malformed record shape or quote placement, or unterminated final records are rejected instead of mixing schemas silently. Append validation is a schema-shape and CSV-syntax guard for existing files, not a semantic reparse of every numeric, logical, or timing payload field already present. CSV text fields emit trimmed raw timer names and metadata key/value text with standard CSV quoting; unlike human-readable text reports, they do not apply the visible `\t`/`\n`/`\xNN` display escaping. They are not spreadsheet-formula-sanitized, so treat CSV opened in spreadsheet software as data from the generating program.
+For machine consumption, prefer structured summaries or CSV. Treat the fixed-width text reports as human-facing output.
 
 Example:
 
@@ -475,11 +369,10 @@ worker-call surprises, and CSV append errors, see
 
 Supported toolchain matrix:
 
-- Serial smoke/library build: GNU Fortran and LLVM Flang are validated in automation
-- Serial plus pFUnit tests: GNU Fortran with a matching pFUnit installation
-- MPI: GNU Fortran wrapper compiler paths are validated with OpenMPI and MPICH; smoke/install-consumer coverage runs for both, and MPI pFUnit coverage runs for OpenMPI plus MPICH on hosted Ubuntu 22.04 with a matching MPICH-built pFUnit
-- OpenMP: GNU Fortran with pFUnit guard coverage, plus LLVM Flang smoke/example coverage for the documented master-thread-only carve-out and the opt-in `examples/openmp_worker_example.F90` path
-- MPI+OpenMP: OpenMPI wrapper builds with OpenMP are smoke-tested in CI for current compatibility mode, `examples/mpi_openmp_example.F90`, the opt-in `ftimer_openmp` worker API, strict and sparse union MPI+OpenMP hybrid summary/report/CSV output, and MPI-initialized OpenMP installed consumers; MPICH wrapper builds have focused local smoke/install-consumer evidence recorded in `docs/release-evidence.md`
+- Serial smoke/library build: GNU Fortran and LLVM Flang are validated in automation.
+- Serial plus pFUnit tests: GNU Fortran with a matching pFUnit installation.
+- OpenMP: GNU Fortran plus LLVM Flang coverage for the documented compatibility and worker examples.
+- MPI and MPI+OpenMP: see [`docs/release-evidence.md`](docs/release-evidence.md) for the exact OpenMPI/MPICH scope, CI coverage, and caveats.
 
 Other serial compilers may still work, but they are not part of the current release-validated matrix unless the repo adds direct automation for them.
 
@@ -488,36 +381,15 @@ Use a separate build directory for each compiler or mode. Reconfiguring the same
 ## Current Limitations And Contracts
 
 - CMake is the supported build and package path. FPM support is intentionally deferred.
-- fTimer is wall-clock only. It does not synchronize asynchronous accelerator/device work, so callers must perform any required device synchronization before `stop` when they intend to measure completed device work rather than host launch/enqueue latency.
-- fTimer does not insert MPI barriers around timed regions. MPI summaries reduce rank-local intervals; callers must add any desired MPI synchronization themselves when they intend to measure a synchronized global phase.
-- `FTIMER_USE_MPI=ON` is intended for wrapper-compiler setups such as `FC=mpifort`. Configure now fails early if the active compiler cannot compile a minimal `mpi_f08` probe against the discovered MPI installation, or if that `mpi_f08` path cannot compile the `MPI_Type_match_size`/`MPI_ERRORS_RETURN` calls fTimer uses to validate reduction datatypes.
+- fTimer is wall-clock only. It does not synchronize asynchronous accelerator/device work, and it does not insert MPI barriers around timed regions.
 - The current MPI interface contract is `mpi_f08` with `type(MPI_Comm)` communicator handles captured at `init`. Legacy integer communicator handles and `mpif.h` are not supported interface paths.
-- MPI-enabled fTimer must be used after `MPI_Init` and before `MPI_Finalize`. The runtime does not currently provide a separate pre-init/post-finalize guard contract for all MPI clock and collective entry points.
-- Communicators passed to `init(comm=...)` remain owned by the caller. fTimer stores a non-owning handle and may use it later in `mpi_summary()`, `mpi_union_summary()`, MPI report writers, `finalize()`, or reinitialization. Do not free a subcommunicator until those fTimer operations that could use it are complete.
-- MPI summary reductions select MPI datatypes with `MPI_Type_match_size` for fTimer's actual `real(wp)` and `integer(int64)` storage sizes instead of assuming fixed `MPI_DOUBLE_PRECISION`, `MPI_2DOUBLE_PRECISION`, or `MPI_INTEGER8` mappings. The compile-time MPI probe validates that this API is available through the `mpi_f08` path; if the API exists but no matching runtime datatype can be returned, `mpi_summary()` temporarily requests MPI error returns for the datatype lookup, fails with `FTIMER_ERR_UNKNOWN`, and leaves the MPI result empty.
-- `mpi_summary()` now returns a distinct `ftimer_mpi_summary_t`; it does not fall back to a local `ftimer_summary_t` on MPI-disabled or MPI-error paths. Call `get_summary()` separately if you need local data in those cases.
-- Descriptor-preflight failures inside one communicator now report the disagreeing communicator-local ranks in the omitted-`ierr` diagnostic path when possible.
-- Rank-conditional timer reductions are not supported by the strict `mpi_summary()` API. Use the separate opt-in `mpi_union_summary()` / `ftimer_mpi_union_summary()` API with `ftimer_mpi_union_summary_t` for sparse descriptor-union reductions. Sparse entries report explicit participation metadata and participating-rank statistics instead of zero-filling absent ranks.
-- Local summary `node_id` values are not a cross-run identity contract. Treat them as explicit links inside one produced summary object, not as durable ids across separate runs or independently produced summaries.
-- All ranks that participate in `mpi_summary()` must agree on the communicator captured by `init`. If would-be participants diverge onto different communicators, the library cannot safely discover that mistake after the split; the practical failure mode is a hang, not a clean local fallback.
-- `FTIMER_USE_OPENMP=ON` enables limited master-thread-only guards for the current `ftimer` and `ftimer_core` APIs. Worker-thread timer calls through those APIs inside an OpenMP parallel region are silent no-ops. To time a parallel region as a whole through existing APIs, place `start`/`stop` outside the `!$omp parallel` block. To time level-1 worker lanes, use the explicit `ftimer_openmp_t` object with pre-registered ids and an opened timed region.
-- `use ftimer_openmp` exposes the opt-in worker-timing API without changing current `ftimer` behavior. The object lifecycle/configuration, timer catalog, timed parallel-region, and id-first thread-lane timing calls are available now. Serial timing uses lane 0; worker timing uses one lane per level-1 OpenMP thread id inside an explicitly opened timed region. Cross-lane mismatches, calls outside an open timed region, and out-of-capacity lanes return errors without repairing or popping another lane.
-- `ftimer_openmp_t%get_openmp_summary`, `print_openmp_summary`, `write_openmp_summary`, and `write_openmp_summary_csv` are separate from current local and MPI summary/report APIs. They require a stopped OpenMP run and return `FTIMER_ERR_ACTIVE` without a normal artifact if any lane is active or a timed region remains open.
-- In MPI+OpenMP builds, `ftimer_openmp_t%mpi_openmp_summary`, `print_mpi_openmp_summary`, `write_mpi_openmp_summary`, and `write_mpi_openmp_summary_csv` provide the strict hybrid rank/lane result and report surface. These entry points are collective, require matching descriptor and lane-participation structure across ranks, and do not relax to sparse/union behavior.
-- In MPI+OpenMP builds, `ftimer_openmp_t%mpi_openmp_union_summary`, `print_mpi_openmp_union_summary`, `write_mpi_openmp_union_summary`, and `write_mpi_openmp_union_summary_csv` provide the separate sparse union hybrid rank/lane result and report surface. These entry points are collective, build a descriptor union across ranks and lanes, and expose explicit rank/lane participation metadata instead of pretending all ranks and lanes contributed.
-- `FTIMER_USE_OPENMP` is the source-level switch for that carve-out; global OpenMP compiler flags alone do not enable the guards when the option is `OFF`.
-- The `ftimer`/`ftimer_core` OpenMP guard path does not make those APIs thread-safe, does not provide thread-local timer instances, and should not be read as a general hybrid MPI+OpenMP timing model.
-- OpenMP mode selection, accepted instrumentation patterns, and migration
-  guidance are collected in
-  [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md). Strict and
-  sparse union MPI+OpenMP hybrid timing are separate `ftimer_openmp_t` report
-  families, not extensions of the master-thread-only compatibility mode.
-  Summary, report, and CSV contracts for those APIs are described in this
-  README, [`docs/semantics.md`](docs/semantics.md), and
-  [`docs/installed-api.md`](docs/installed-api.md).
+- MPI-enabled fTimer must be used after `MPI_Init` and before `MPI_Finalize`.
+- `init(comm=...)` captures a caller-selected communicator for later MPI summaries and reports, and fTimer stores that communicator as a non-owning handle.
+- `FTIMER_USE_OPENMP=ON` keeps the existing `ftimer` / `ftimer_core` APIs on the master-thread-only compatibility carve-out. Worker-thread calls through those existing APIs are silent no-ops.
+- Use `ftimer_openmp_t` when you need serial-lane or level-1 worker timing, stopped-run local OpenMP summaries, or strict/sparse MPI+OpenMP hybrid reports.
 - `on_event` remains a lightweight intra-run hook, not a serious profiler-backend integration contract with stable semantic timer identity.
-- If `FTIMER_USE_MPI=OFF`, `mpi_summary()` and `mpi_union_summary()` return `FTIMER_ERR_NOT_IMPLEMENTED` and leave their MPI result objects empty. MPI report APIs, including the sparse union report and CSV APIs, return `FTIMER_ERR_NOT_IMPLEMENTED` without emitting report output or creating/replacing report files. Initialized `ftimer_openmp_t` objects return the same status from both strict and sparse union MPI+OpenMP report families in non-MPI packages.
-- Formatted local, MPI, and MPI+OpenMP report output are separate paths: `print_summary()`/`write_summary()` are local, `print_mpi_summary()`/`write_mpi_summary()` are strict MPI reports, `print_mpi_union_summary()`/`write_mpi_union_summary()` are opt-in sparse MPI union reports, `print_mpi_openmp_summary()`/`write_mpi_openmp_summary()` are strict hybrid reports on `ftimer_openmp_t`, and `print_mpi_openmp_union_summary()`/`write_mpi_openmp_union_summary()` are sparse union hybrid reports on `ftimer_openmp_t`. MPI reports are deliberately abbreviated; `ftimer_mpi_summary_t`, `ftimer_mpi_union_summary_t`, `ftimer_mpi_openmp_summary_t`, and `ftimer_mpi_openmp_union_summary_t` remain the complete structured data models.
+
+The full runtime contract, reporting details, error-model edge cases, and OpenMP migration guidance live in [`docs/semantics.md`](docs/semantics.md), [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md), and [`docs/installed-api.md`](docs/installed-api.md).
 
 ## Performance Measurement
 
@@ -534,32 +406,24 @@ For a clean benchmark reconfigure, remove or use a separate `build-bench/`
 directory first. With CMake 3.24 or newer, `cmake --fresh` may be added to the
 configure command as a convenience for a clean reconfigure.
 
-This is useful for before/after regression checks when changing hot-path timing behavior. Compare the name-based lookup-scaling rows across resident timer counts to confirm the mapped default path stays much flatter than the old linear-scan baseline, and compare the context-scaling rows across larger `C` values to see how one hot timer behaves when it is reused under many distinct parent stacks. The first-touch rows measure the remaining allocation/growth cost for newly discovered timer names and parent-stack contexts after setup has prebuilt labels and initialized independent timer objects. The long-name rows show the extra validation/hash cost for labels above the legacy threshold. The flat name-based/id-based rows still help judge whether the optional cached-id path is worth it for one especially hot loop.
+Use the benchmark harness for before/after trend checks when a change touches start/stop hot paths, lookup or cached-id behavior, context growth, summary/report/CSV formatting, or MPI/OpenMP timing internals.
 
-Use benchmark evidence for PRs that touch start/stop hot paths, lookup or
-cached-id behavior, context growth or parent-stack accounting, summary
-construction, report/CSV formatting, MPI summary/report paths, and for
-release-readiness sweeps. Compare CSV rows first for flat name-based
-start/stop, cached-id start/stop, lookup scaling across resident timer counts,
-context scaling across parent-stack counts, timer/context first-touch
-allocation, summary builds, local text/CSV reports, sparse MPI-union
-formatting, and the strict MPI CSV row when MPI is enabled. For OpenMP worker
-hot-path changes, compare the `ftimer_openmp_t` serial-lane id, timed-region
-open/close, worker-lane id, worker context-scaling, OpenMP catalog
-register/lookup, concurrent worker-lane, split-object worker-lane,
-participating-lane first-touch, and local OpenMP summary-merge rows. For
-MPI+OpenMP changes, compare the strict and sparse union MPI+OpenMP CSV report
-rows.
+The detailed release policy and provenance-sidecar expectations live in [`docs/release.md`](docs/release.md). The current support boundary and evidence status for benchmark claims live in [`docs/release-evidence.md`](docs/release-evidence.md).
 
-The benchmark harness also includes reporting-scale rows for local text reports, local CSV reports, sparse MPI-union text formatting, long timer names, metadata-heavy output, and the `ftimer_openmp_t` serial-lane id path. When fTimer is built with `FTIMER_USE_MPI=ON`, the harness adds a strict MPI CSV report row. When built with `FTIMER_USE_OPENMP=ON`, it adds timed-region open/close, worker-lane, worker context-scaling, OpenMP catalog register/lookup, concurrent worker-lane, split-object worker-lane, participating-lane first-touch, and local OpenMP summary-merge rows. When built with both `FTIMER_USE_MPI=ON` and `FTIMER_USE_OPENMP=ON`, it adds strict and sparse union MPI+OpenMP CSV report rows. Passing a file path as the first argument writes parseable CSV benchmark observations; durable PR or release trend evidence should keep the provenance sidecar context described in [`docs/release.md`](docs/release.md) beside that CSV. The serial benchmark CI job uploads the validated CSV as a `ftimer-bench-serial-<sha>` artifact. OpenMP and MPI+OpenMP benchmark CI jobs build `ftimer_bench` and run CSV smoke checks, but durable CSV artifact upload for those feature-enabled benchmark jobs is deferred; run the feature-enabled harness locally when trend evidence beyond smoke coverage is needed. Report-writing rows use per-run scratch files in the system temporary directory and delete only those scratch files when they finish. The harness records trend evidence only, does not enforce timing thresholds, and GitHub-hosted runner numbers should be treated cautiously because absolute timings are noisy.
+The harness records trend evidence, not pass/fail thresholds, and GitHub-hosted runner numbers should be treated cautiously because absolute timings are noisy.
 
 ## More Detail
 
 - Runtime semantics: [`docs/semantics.md`](docs/semantics.md)
 - Troubleshooting guide: [`docs/troubleshooting.md`](docs/troubleshooting.md)
 - Current architecture reference: [`docs/design.md`](docs/design.md)
+- Installed API stability and public symbol boundary: [`docs/installed-api.md`](docs/installed-api.md)
+- CSV schema dictionary: [`docs/csv-schema.md`](docs/csv-schema.md)
 - OpenMP timing modes and migration guide: [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md)
+- Release claim evidence: [`docs/release-evidence.md`](docs/release-evidence.md)
+- Maintainer workflow: [`docs/maintainer.md`](docs/maintainer.md)
 - Release checklist and artifact policy: [`docs/release.md`](docs/release.md)
+- Coding-agent workflow guide: [`AGENTS.md`](AGENTS.md), [`CLAUDE.md`](CLAUDE.md)
 - Contributor guidance: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - Support and security reporting: [`SUPPORT.md`](SUPPORT.md), [`SECURITY.md`](SECURITY.md)
 

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -437,6 +437,77 @@ foreach(readme_route_destination_heading IN LISTS readme_route_destination_headi
   endif()
 endforeach()
 
+extract_markdown_section("${release_readme_text}" "First Success" readme_first_success_text)
+extract_markdown_section("${release_readme_text}" "Quick Start" readme_quick_start_text)
+extract_markdown_section("${release_readme_text}" "Install And Use From Another Project"
+  readme_install_text)
+extract_markdown_section("${release_readme_text}" "Supported Workflows"
+  readme_supported_workflows_text)
+
+set(readme_first_success_needles
+  "cmake -B build-smoke"
+  "cmake --build build-smoke --target basic_usage"
+  "./build-smoke/examples/basic_usage"
+  "Recorded timers: 1"
+)
+
+foreach(readme_first_success_needle IN LISTS readme_first_success_needles)
+  string(FIND "${readme_first_success_text}" "${readme_first_success_needle}"
+    first_success_index)
+  if(first_success_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md '## First Success' must keep the first-success guidance required by the #336 audience routing: missing '${readme_first_success_needle}'."
+    )
+  endif()
+endforeach()
+
+set(readme_quick_start_needles
+  "call ftimer_init()"
+  "call ftimer_start(\"work\")"
+  "call ftimer_get_summary(summary)"
+  "call ftimer_print_summary()"
+)
+
+foreach(readme_quick_start_needle IN LISTS readme_quick_start_needles)
+  string(FIND "${readme_quick_start_text}" "${readme_quick_start_needle}" quick_start_index)
+  if(quick_start_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md '## Quick Start' must keep the minimal procedural example required by the #336 audience routing: missing '${readme_quick_start_needle}'."
+    )
+  endif()
+endforeach()
+
+set(readme_install_needles
+  "find_package(fTimer CONFIG REQUIRED)"
+  "CMAKE_PREFIX_PATH"
+)
+
+foreach(readme_install_needle IN LISTS readme_install_needles)
+  string(FIND "${readme_install_text}" "${readme_install_needle}" install_index)
+  if(install_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md '## Install And Use From Another Project' must keep the downstream install guidance required by the #336 audience routing: missing '${readme_install_needle}'."
+    )
+  endif()
+endforeach()
+
+set(readme_supported_workflows_needles
+  "Serial/local timing through `ftimer` or `ftimer_core`"
+  "Strict pure-MPI timing and sparse pure-MPI union timing on the validated `mpi_f08` path"
+  "OpenMP compatibility timing through the existing APIs when one timer brackets a parallel region"
+  "Explicit worker timing through `ftimer_openmp_t`, including strict and sparse MPI+OpenMP report families"
+)
+
+foreach(readme_supported_workflows_needle IN LISTS readme_supported_workflows_needles)
+  string(FIND "${readme_supported_workflows_text}" "${readme_supported_workflows_needle}"
+    supported_workflows_index)
+  if(supported_workflows_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md '## Supported Workflows' must keep the mode summary required by the #336 audience routing: missing '${readme_supported_workflows_needle}'."
+    )
+  endif()
+endforeach()
+
 file(READ "${REPO_ROOT}/docs/troubleshooting.md" troubleshooting_doc_text)
 file(READ "${REPO_ROOT}/tests/public_symbol_allowlist.txt" public_symbol_allowlist_text)
 file(READ "${REPO_ROOT}/CMakeLists.txt" root_cmakelists_text)

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -386,38 +386,37 @@ foreach(readme_troubleshooting_needle IN LISTS readme_troubleshooting_needles)
   endif()
 endforeach()
 
-set(readme_audience_needles
-  "First-time user:"
-  "Advanced user:"
-  "Maintainer or release reviewer:"
-  "Coding agent:"
-)
-
-foreach(readme_audience_needle IN LISTS readme_audience_needles)
-  string(FIND "${release_readme_text}" "${readme_audience_needle}" audience_index)
-  if(audience_index EQUAL -1)
-    message(FATAL_ERROR
-      "README.md must keep the explicit audience split for #336: missing '${readme_audience_needle}'."
-    )
+function(extract_markdown_section text header out_var)
+  string(FIND "${text}" "## ${header}" section_start_index)
+  if(section_start_index EQUAL -1)
+    message(FATAL_ERROR "README.md must keep the '## ${header}' section.")
   endif()
-endforeach()
 
-set(readme_source_of_truth_needles
-  "[`docs/semantics.md`](docs/semantics.md)"
-  "[`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md)"
-  "[`docs/csv-schema.md`](docs/csv-schema.md)"
-  "[`docs/installed-api.md`](docs/installed-api.md)"
-  "[`docs/release-evidence.md`](docs/release-evidence.md)"
-  "[`docs/maintainer.md`](docs/maintainer.md)"
-  "[`AGENTS.md`](AGENTS.md)"
-  "[`CLAUDE.md`](CLAUDE.md)"
+  string(SUBSTRING "${text}" "${section_start_index}" -1 section_tail)
+  string(FIND "${section_tail}" "\n## " next_section_index)
+  if(next_section_index EQUAL -1)
+    set(section_text "${section_tail}")
+  else()
+    string(SUBSTRING "${section_tail}" 0 "${next_section_index}" section_text)
+  endif()
+
+  set(${out_var} "${section_text}" PARENT_SCOPE)
+endfunction()
+
+extract_markdown_section("${release_readme_text}" "Where To Go Next" readme_where_to_go_next_text)
+
+set(readme_role_routes
+  "- First-time user: stay in this README for `First Success`, `Quick Start`, and `Install And Use From Another Project`, then see the symptom-oriented [`docs/troubleshooting.md`](docs/troubleshooting.md) guide if first use goes sideways."
+  "- Advanced user: use [Supported Workflows](#supported-workflows) to choose a mode, then jump to [`docs/semantics.md`](docs/semantics.md), [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md), [`docs/csv-schema.md`](docs/csv-schema.md), or [`docs/installed-api.md`](docs/installed-api.md) for the exact contract."
+  "- Maintainer or release reviewer: use [`docs/release-evidence.md`](docs/release-evidence.md), [`docs/release.md`](docs/release.md), and [`docs/maintainer.md`](docs/maintainer.md)."
+  "- Coding agent: use [`AGENTS.md`](AGENTS.md) or [`CLAUDE.md`](CLAUDE.md) for repo workflow and source-of-truth rules, then read [`docs/semantics.md`](docs/semantics.md) and [`docs/maintainer.md`](docs/maintainer.md) as needed."
 )
 
-foreach(readme_source_of_truth_needle IN LISTS readme_source_of_truth_needles)
-  string(FIND "${release_readme_text}" "${readme_source_of_truth_needle}" source_of_truth_index)
-  if(source_of_truth_index EQUAL -1)
+foreach(readme_role_route IN LISTS readme_role_routes)
+  string(FIND "${readme_where_to_go_next_text}" "${readme_role_route}" role_route_index)
+  if(role_route_index EQUAL -1)
     message(FATAL_ERROR
-      "README.md must route detailed contracts to focused docs after #336: missing '${readme_source_of_truth_needle}'."
+      "README.md must keep the explicit #336 audience routing in '## Where To Go Next': missing '${readme_role_route}'."
     )
   endif()
 endforeach()

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -386,6 +386,42 @@ foreach(readme_troubleshooting_needle IN LISTS readme_troubleshooting_needles)
   endif()
 endforeach()
 
+set(readme_audience_needles
+  "First-time user:"
+  "Advanced user:"
+  "Maintainer or release reviewer:"
+  "Coding agent:"
+)
+
+foreach(readme_audience_needle IN LISTS readme_audience_needles)
+  string(FIND "${release_readme_text}" "${readme_audience_needle}" audience_index)
+  if(audience_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md must keep the explicit audience split for #336: missing '${readme_audience_needle}'."
+    )
+  endif()
+endforeach()
+
+set(readme_source_of_truth_needles
+  "[`docs/semantics.md`](docs/semantics.md)"
+  "[`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md)"
+  "[`docs/csv-schema.md`](docs/csv-schema.md)"
+  "[`docs/installed-api.md`](docs/installed-api.md)"
+  "[`docs/release-evidence.md`](docs/release-evidence.md)"
+  "[`docs/maintainer.md`](docs/maintainer.md)"
+  "[`AGENTS.md`](AGENTS.md)"
+  "[`CLAUDE.md`](CLAUDE.md)"
+)
+
+foreach(readme_source_of_truth_needle IN LISTS readme_source_of_truth_needles)
+  string(FIND "${release_readme_text}" "${readme_source_of_truth_needle}" source_of_truth_index)
+  if(source_of_truth_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md must route detailed contracts to focused docs after #336: missing '${readme_source_of_truth_needle}'."
+    )
+  endif()
+endforeach()
+
 file(READ "${REPO_ROOT}/docs/troubleshooting.md" troubleshooting_doc_text)
 file(READ "${REPO_ROOT}/tests/public_symbol_allowlist.txt" public_symbol_allowlist_text)
 file(READ "${REPO_ROOT}/CMakeLists.txt" root_cmakelists_text)

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -421,6 +421,22 @@ foreach(readme_role_route IN LISTS readme_role_routes)
   endif()
 endforeach()
 
+set(readme_route_destination_headings
+  "## First Success"
+  "## Quick Start"
+  "## Install And Use From Another Project"
+  "## Supported Workflows"
+)
+
+foreach(readme_route_destination_heading IN LISTS readme_route_destination_headings)
+  string(FIND "${release_readme_text}" "${readme_route_destination_heading}" destination_heading_index)
+  if(destination_heading_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md must keep the in-README destination heading required by the #336 audience routing: missing '${readme_route_destination_heading}'."
+    )
+  endif()
+endforeach()
+
 file(READ "${REPO_ROOT}/docs/troubleshooting.md" troubleshooting_doc_text)
 file(READ "${REPO_ROOT}/tests/public_symbol_allowlist.txt" public_symbol_allowlist_text)
 file(READ "${REPO_ROOT}/CMakeLists.txt" root_cmakelists_text)


### PR DESCRIPTION
Closes #336.

## Summary
- add an explicit audience split in the README for first-time users, advanced users, maintainers/release reviewers, and coding agents
- trim duplicated README contract detail for workflows, support evidence, API surface, CSV schemas, limitations, and benchmark policy down to compact summaries plus source-of-truth links
- update the release docs contract check so it enforces the new routing targets and audience split

## Validation
- `git diff --check`
- `cmake -DREPO_ROOT=/Users/hrh/.codex/worktrees/5a69/fTimer -P tests/check_init_contract_docs.cmake`
- `cmake -DREPO_ROOT=/Users/hrh/.codex/worktrees/5a69/fTimer -P tests/check_mpi_lifecycle_contract_docs.cmake`
- `cmake -DREPO_ROOT=/Users/hrh/.codex/worktrees/5a69/fTimer -P tests/check_release_docs_contract.cmake`
- `cmake -DREPO_ROOT=/Users/hrh/.codex/worktrees/5a69/fTimer -P tests/check_csv_schema_docs.cmake`