### PR TITLE
Make README examples teach safer timing defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,38 @@ program quick_start
 end program quick_start
 ```
 
+For production call sites, thread `ierr` through the same sequence so failures
+stay visible and quiet:
+
+```fortran
+integer :: ierr
+type(ftimer_summary_t) :: summary
+
+call ftimer_init(ierr=ierr)
+if (ierr /= 0) error stop
+
+call ftimer_start("work", ierr=ierr)
+if (ierr /= 0) error stop
+
+call ftimer_stop("work", ierr=ierr)
+if (ierr /= 0) error stop
+
+call ftimer_get_summary(summary, ierr=ierr)
+if (ierr /= 0) error stop
+
+call ftimer_print_summary(ierr=ierr)
+if (ierr /= 0) error stop
+
+call ftimer_finalize(ierr=ierr)
+if (ierr /= 0) error stop
+```
+
+`ftimer_get_summary()` and `ftimer_print_summary()` are live snapshots. For a
+final local report, stop all timers first and treat `summary%has_active_timers`
+as a sign that you are still looking at an interim snapshot. See
+[`docs/semantics.md`](docs/semantics.md) for the full local-summary and report
+contract.
+
 Use `ftimer` for the procedural API and `ftimer_types` for shared types and constants such as `ftimer_summary_t`, `ftimer_context_diagnostic_t`, `ftimer_mpi_summary_t`, `ftimer_mpi_union_summary_t`, `ftimer_metadata_t`, and `FTIMER_MISMATCH_*`.
 
 For lexical blocks with early exits, the procedural API also provides a scalar scoped guard:
@@ -177,6 +209,40 @@ fTimer currently supports a small set of distinct stories:
 - Application-owned instrumentation facades that can select either the real fTimer implementation or a dependency-free no-op implementation at build time
 
 Choose the smallest mode that matches the measurement you need. Start with serial, add strict MPI only when every rank shares the same descriptor tree, add sparse MPI union when participation is rank-conditional, keep existing OpenMP calls outside the parallel region for compatibility timing, and use `ftimer_openmp_t` only when you need per-lane worker data.
+
+For pure-MPI timing, fTimer reduces rank-local wall-clock intervals. It does
+not add an implicit barrier around the timed region, and every rank in the
+captured communicator must enter each MPI summary/report collective. See
+[`docs/semantics.md`](docs/semantics.md) for the runtime contract and
+[`docs/troubleshooting.md`](docs/troubleshooting.md) for failure-oriented
+remedies.
+
+For OpenMP compatibility timing, bracket the parallel region from serial
+context:
+
+```fortran
+call ftimer_start("parallel_region", ierr=ierr)
+!$omp parallel
+! worker work
+!$omp end parallel
+call ftimer_stop("parallel_region", ierr=ierr)
+```
+
+Avoid this misleading anti-pattern on current `main`:
+
+```fortran
+!$omp parallel
+call ftimer_start("worker_work")
+! worker work
+call ftimer_stop("worker_work")
+!$omp end parallel
+```
+
+With `FTIMER_USE_OPENMP=ON`, those worker-thread calls through the existing
+`ftimer` / `ftimer_core` APIs are silent no-ops. Use `ftimer_openmp_t` when
+you need real worker-lane timing, and see
+[`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md) for the full
+migration guide.
 
 CSV schemas follow the same split: local/strict MPI share one v2 family, while sparse MPI union, local OpenMP, strict MPI+OpenMP, and sparse MPI+OpenMP union each use dedicated schemas that are not append-compatible with one another.
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Choose the smallest mode that matches the measurement you need. Start with seria
 
 For pure-MPI timing, fTimer reduces rank-local wall-clock intervals. It does
 not add an implicit barrier around the timed region, and every rank in the
-captured communicator must enter each MPI summary/report collective. See
+captured communicator must enter each MPI summary/report/CSV collective. See
 [`docs/semantics.md`](docs/semantics.md) for the runtime contract and
 [`docs/troubleshooting.md`](docs/troubleshooting.md) for failure-oriented
 remedies.

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -466,8 +466,6 @@ set(readme_quick_start_needles
   "call ftimer_start(\"work\")"
   "call ftimer_get_summary(summary)"
   "call ftimer_print_summary()"
-  "call ftimer_init(ierr=ierr)"
-  "call ftimer_print_summary(ierr=ierr)"
   "summary%has_active_timers"
   "[`docs/semantics.md`](docs/semantics.md) for the full local-summary and report"
 )
@@ -480,6 +478,37 @@ foreach(readme_quick_start_needle IN LISTS readme_quick_start_needles)
     )
   endif()
 endforeach()
+
+set(readme_quick_start_checked_ierr_snippet [=[
+integer :: ierr
+type(ftimer_summary_t) :: summary
+
+call ftimer_init(ierr=ierr)
+if (ierr /= 0) error stop
+
+call ftimer_start("work", ierr=ierr)
+if (ierr /= 0) error stop
+
+call ftimer_stop("work", ierr=ierr)
+if (ierr /= 0) error stop
+
+call ftimer_get_summary(summary, ierr=ierr)
+if (ierr /= 0) error stop
+
+call ftimer_print_summary(ierr=ierr)
+if (ierr /= 0) error stop
+
+call ftimer_finalize(ierr=ierr)
+if (ierr /= 0) error stop
+]=])
+
+string(FIND "${readme_quick_start_text}" "${readme_quick_start_checked_ierr_snippet}"
+  quick_start_checked_ierr_index)
+if(quick_start_checked_ierr_index EQUAL -1)
+  message(FATAL_ERROR
+    "README.md '## Quick Start' must keep the checked ierr production idiom as an ordered snippet."
+  )
+endif()
 
 set(readme_install_needles
   "find_package(fTimer CONFIG REQUIRED)"
@@ -501,10 +530,8 @@ set(readme_supported_workflows_needles
   "OpenMP compatibility timing through the existing APIs when one timer brackets a parallel region"
   "Explicit worker timing through `ftimer_openmp_t`, including strict and sparse MPI+OpenMP report families"
   "not add an implicit barrier around the timed region"
-  "MPI summary/report collective"
-  "call ftimer_start(\"parallel_region\", ierr=ierr)"
+  "MPI summary/report/CSV collective"
   "Avoid this misleading anti-pattern on current `main`"
-  "call ftimer_start(\"worker_work\")"
   "worker-thread calls through the existing"
   "[`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md)"
 )
@@ -518,6 +545,39 @@ foreach(readme_supported_workflows_needle IN LISTS readme_supported_workflows_ne
     )
   endif()
 endforeach()
+
+set(readme_supported_workflows_openmp_compat_snippet [=[
+call ftimer_start("parallel_region", ierr=ierr)
+!$omp parallel
+! worker work
+!$omp end parallel
+call ftimer_stop("parallel_region", ierr=ierr)
+]=])
+
+string(FIND "${readme_supported_workflows_text}"
+  "${readme_supported_workflows_openmp_compat_snippet}" supported_workflows_openmp_compat_index)
+if(supported_workflows_openmp_compat_index EQUAL -1)
+  message(FATAL_ERROR
+    "README.md '## Supported Workflows' must keep the accepted OpenMP compatibility bracketing snippet."
+  )
+endif()
+
+set(readme_supported_workflows_openmp_antipattern_snippet [=[
+!$omp parallel
+call ftimer_start("worker_work")
+! worker work
+call ftimer_stop("worker_work")
+!$omp end parallel
+]=])
+
+string(FIND "${readme_supported_workflows_text}"
+  "${readme_supported_workflows_openmp_antipattern_snippet}"
+  supported_workflows_openmp_antipattern_index)
+if(supported_workflows_openmp_antipattern_index EQUAL -1)
+  message(FATAL_ERROR
+    "README.md '## Supported Workflows' must keep the misleading OpenMP worker-call anti-pattern snippet."
+  )
+endif()
 
 file(READ "${REPO_ROOT}/docs/troubleshooting.md" troubleshooting_doc_text)
 file(READ "${REPO_ROOT}/tests/public_symbol_allowlist.txt" public_symbol_allowlist_text)

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -466,6 +466,10 @@ set(readme_quick_start_needles
   "call ftimer_start(\"work\")"
   "call ftimer_get_summary(summary)"
   "call ftimer_print_summary()"
+  "call ftimer_init(ierr=ierr)"
+  "call ftimer_print_summary(ierr=ierr)"
+  "summary%has_active_timers"
+  "[`docs/semantics.md`](docs/semantics.md) for the full local-summary and report"
 )
 
 foreach(readme_quick_start_needle IN LISTS readme_quick_start_needles)
@@ -496,6 +500,13 @@ set(readme_supported_workflows_needles
   "Strict pure-MPI timing and sparse pure-MPI union timing on the validated `mpi_f08` path"
   "OpenMP compatibility timing through the existing APIs when one timer brackets a parallel region"
   "Explicit worker timing through `ftimer_openmp_t`, including strict and sparse MPI+OpenMP report families"
+  "not add an implicit barrier around the timed region"
+  "MPI summary/report collective"
+  "call ftimer_start(\"parallel_region\", ierr=ierr)"
+  "Avoid this misleading anti-pattern on current `main`"
+  "call ftimer_start(\"worker_work\")"
+  "worker-thread calls through the existing"
+  "[`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md)"
 )
 
 foreach(readme_supported_workflows_needle IN LISTS readme_supported_workflows_needles)


### PR DESCRIPTION
## Summary
- keep the first procedural README example minimal while adding a nearby checked-`ierr` production idiom
- make live local snapshots versus final stopped-run reports explicit in the quick-start guidance
- add concise MPI and OpenMP safe-default cues near the first workflow-routing path and pin them in the release docs contract check

## Validation
- `git diff --check`
- `cmake -B build-smoke`
- `ctest --test-dir build-smoke --output-on-failure -R '^(ftimer_init_contract_docs|ftimer_mpi_lifecycle_contract_docs|ftimer_release_docs_contract)$'`

Closes #337