### PR TITLE
Clarify documentation audience boundaries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,9 @@ cmake --build build
 cmake -E chdir build ctest --output-on-failure
 ```
 
-MPI and OpenMP validation commands are listed in `AGENTS.md`, `README.md`, and
-`docs/release.md`.
+MPI and OpenMP validation commands for contributors are listed in `README.md`.
+Release-check validation lives in [`docs/release.md`](docs/release.md), and the
+maintainer routing page links the workflow-specific PR and review procedures.
 
 ## Pull Requests
 
@@ -61,7 +62,10 @@ release evidence, or CI proof paths. It is not required for private
 implementation-only edits.
 
 Repository PR handling, review labels, fallback review, and findings disposition
-are documented in `docs/maintainer.md` and `docs/workflows/`.
+are maintainer workflow topics documented in
+[`docs/maintainer.md`](docs/maintainer.md) and `docs/workflows/`. Coding-agent
+specific instructions remain in `AGENTS.md` and `CLAUDE.md`; contributors do
+not need those files for ordinary build, test, or PR navigation.
 
 ## Coding And Documentation Expectations
 

--- a/README.md
+++ b/README.md
@@ -494,12 +494,12 @@ User-facing references:
 - Installed API stability and public symbol boundary: [`docs/installed-api.md`](docs/installed-api.md)
 - CSV schema dictionary: [`docs/csv-schema.md`](docs/csv-schema.md)
 - OpenMP timing modes and migration guide: [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md)
-- Current architecture reference: [`docs/design.md`](docs/design.md)
 - Support and security reporting: [`SUPPORT.md`](SUPPORT.md), [`SECURITY.md`](SECURITY.md)
 
 Contributor, maintainer, and release references:
 
 - Contributor guidance: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Current architecture and repository-layout reference: [`docs/design.md`](docs/design.md)
 - Maintainer workflow: [`docs/maintainer.md`](docs/maintainer.md)
 - Release claim evidence: [`docs/release-evidence.md`](docs/release-evidence.md)
 - Release checklist and artifact policy: [`docs/release.md`](docs/release.md)

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Support tiers still matter, but the detailed claim ledger lives outside the READ
 - **Experimental/deferred**: package-manager installs, profiler backends, hardware counters, traces, dashboards, and similar ecosystem work.
 - Exact status, evidence, and caveats for each release-facing claim live in [`docs/release-evidence.md`](docs/release-evidence.md). Use that ledger, not this README, when you need release-review wording.
 
-For failure-oriented guidance, see [`docs/troubleshooting.md`](docs/troubleshooting.md). For architecture and validation context, see [`docs/design.md`](docs/design.md). For installed package stability details, see [`docs/installed-api.md`](docs/installed-api.md).
+For failure-oriented guidance, see [`docs/troubleshooting.md`](docs/troubleshooting.md). For installed package stability details, see [`docs/installed-api.md`](docs/installed-api.md).
 
 ## Compile-Out / No-Op Instrumentation Pattern
 

--- a/README.md
+++ b/README.md
@@ -155,12 +155,19 @@ For metadata headers, construct `ftimer_metadata_t` values by assigning `%key` a
 
 ## Where To Go Next
 
-Use the shortest path that matches your role:
+Use the shortest path that matches what you are trying to do. The normal user
+journey does not require the maintainer workflow or coding-agent files.
 
-- First-time user: stay in this README for `First Success`, `Quick Start`, and `Install And Use From Another Project`, then see the symptom-oriented [`docs/troubleshooting.md`](docs/troubleshooting.md) guide if first use goes sideways.
-- Advanced user: use [Supported Workflows](#supported-workflows) to choose a mode, then jump to [`docs/semantics.md`](docs/semantics.md), [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md), [`docs/csv-schema.md`](docs/csv-schema.md), or [`docs/installed-api.md`](docs/installed-api.md) for the exact contract.
-- Maintainer or release reviewer: use [`docs/release-evidence.md`](docs/release-evidence.md), [`docs/release.md`](docs/release.md), and [`docs/maintainer.md`](docs/maintainer.md).
-- Coding agent: use [`AGENTS.md`](AGENTS.md) or [`CLAUDE.md`](CLAUDE.md) for repo workflow and source-of-truth rules, then read [`docs/semantics.md`](docs/semantics.md) and [`docs/maintainer.md`](docs/maintainer.md) as needed.
+For users:
+
+- First-time users: stay in this README for `First Success`, `Quick Start`, and `Install And Use From Another Project`, then use the symptom-oriented [`docs/troubleshooting.md`](docs/troubleshooting.md) guide if first use goes sideways.
+- Advanced users: use [Supported Workflows](#supported-workflows) to choose a mode, then jump to [`docs/semantics.md`](docs/semantics.md), [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md), [`docs/csv-schema.md`](docs/csv-schema.md), or [`docs/installed-api.md`](docs/installed-api.md) for the exact contract.
+
+For project work:
+
+- Contributors and maintainers: start with [`CONTRIBUTING.md`](CONTRIBUTING.md) for contribution expectations. Use [`docs/maintainer.md`](docs/maintainer.md) and the routed workflow docs only when you are opening, reviewing, or closing out repository work.
+- Release reviewers: use [`docs/release-evidence.md`](docs/release-evidence.md) for claim evidence and [`docs/release.md`](docs/release.md) for release checklist and artifact policy.
+- Coding agents: use [`AGENTS.md`](AGENTS.md) or [`CLAUDE.md`](CLAUDE.md) for agent-specific repository rules. Those files preserve workflow context for automation, but they are not part of the ordinary user path.
 
 ## Install And Use From Another Project
 
@@ -480,18 +487,27 @@ The harness records trend evidence, not pass/fail thresholds, and GitHub-hosted 
 
 ## More Detail
 
+User-facing references:
+
 - Runtime semantics: [`docs/semantics.md`](docs/semantics.md)
 - Troubleshooting guide: [`docs/troubleshooting.md`](docs/troubleshooting.md)
-- Current architecture reference: [`docs/design.md`](docs/design.md)
 - Installed API stability and public symbol boundary: [`docs/installed-api.md`](docs/installed-api.md)
 - CSV schema dictionary: [`docs/csv-schema.md`](docs/csv-schema.md)
 - OpenMP timing modes and migration guide: [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md)
-- Release claim evidence: [`docs/release-evidence.md`](docs/release-evidence.md)
-- Maintainer workflow: [`docs/maintainer.md`](docs/maintainer.md)
-- Release checklist and artifact policy: [`docs/release.md`](docs/release.md)
-- Coding-agent workflow guide: [`AGENTS.md`](AGENTS.md), [`CLAUDE.md`](CLAUDE.md)
-- Contributor guidance: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Current architecture reference: [`docs/design.md`](docs/design.md)
 - Support and security reporting: [`SUPPORT.md`](SUPPORT.md), [`SECURITY.md`](SECURITY.md)
+
+Contributor, maintainer, and release references:
+
+- Contributor guidance: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Maintainer workflow: [`docs/maintainer.md`](docs/maintainer.md)
+- Release claim evidence: [`docs/release-evidence.md`](docs/release-evidence.md)
+- Release checklist and artifact policy: [`docs/release.md`](docs/release.md)
+
+Coding-agent references:
+
+- Coding-agent workflow guides: [`AGENTS.md`](AGENTS.md), [`CLAUDE.md`](CLAUDE.md)
+- Codex review prompt contracts: [`.github/prompts/README.md`](.github/prompts/README.md), [`.github/prompts/detailed/README.md`](.github/prompts/detailed/README.md)
 
 When current-state sources disagree, use this repository-wide precedence order:
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -410,6 +410,7 @@ library path.
 **Maintainer and release docs**
 
 - [`CONTRIBUTING.md`](../CONTRIBUTING.md): contribution expectations and contributor-facing validation
+- [`docs/design.md`](design.md): current architecture, repository layout, validation reality, and workflow context
 - [`docs/maintainer.md`](maintainer.md) and [`docs/workflows/`](workflows/): issue/PR/review operating procedures
 - [`docs/release.md`](release.md): release checklist, validation matrix, and artifact policy
 - [`docs/release-evidence.md`](release-evidence.md): support-claim evidence and caveats

--- a/docs/design.md
+++ b/docs/design.md
@@ -393,18 +393,36 @@ The repository also carries a detailed prompt library under `.github/prompts/det
 
 ## Documentation Boundaries
 
-The docs set is intentionally split by purpose:
+The docs set is intentionally split by audience and purpose. The README is the
+normal entry point for users; maintainer and coding-agent workflow files are
+kept available for repository operations without being part of the first-use
+library path.
+
+**User docs**
 
 - [`README.md`](../README.md): user-facing setup, usage, limitations, and examples
 - [`docs/troubleshooting.md`](troubleshooting.md): symptom-oriented remedies for first-use build, MPI, OpenMP, CSV, and summary/report failures
 - [`docs/semantics.md`](semantics.md): current runtime contract and behavior
-- [`docs/design.md`](design.md): current repository architecture, validation reality, and workflow context
-- [`docs/openmp-timing-modes.md`](openmp-timing-modes.md): OpenMP and
-  MPI+OpenMP mode selection, accepted current examples, and migration guidance
-- `docs/history/`: historical decision records and implementation-planning
-  artifacts. These are not the navigation surface for current behavior.
-- [`docs/implementation-history.md`](implementation-history.md): historical phase roadmap and landing history
+- [`docs/installed-api.md`](installed-api.md): installed package, public symbol, and downstream consumption contract
+- [`docs/csv-schema.md`](csv-schema.md): CSV schema families and reader-aid fixtures
+- [`docs/openmp-timing-modes.md`](openmp-timing-modes.md): OpenMP and MPI+OpenMP mode selection, accepted current examples, and migration guidance
+
+**Maintainer and release docs**
+
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md): contribution expectations and contributor-facing validation
 - [`docs/maintainer.md`](maintainer.md) and [`docs/workflows/`](workflows/): issue/PR/review operating procedures
+- [`docs/release.md`](release.md): release checklist, validation matrix, and artifact policy
+- [`docs/release-evidence.md`](release-evidence.md): support-claim evidence and caveats
+
+**Coding-agent docs**
+
+- [`AGENTS.md`](../AGENTS.md) and [`CLAUDE.md`](../CLAUDE.md): coding-agent repository instructions, build/test context, and source-of-truth rules
+- `.github/prompts/`: Codex review prompt contracts and fallback prompt library
+
+**Historical docs**
+
+- `docs/history/`: historical decision records and implementation-planning artifacts. These are not the navigation surface for current behavior.
+- [`docs/implementation-history.md`](implementation-history.md): historical phase roadmap and landing history
 
 Keeping those boundaries sharp matters. When current behavior changes, update the document that owns that contract instead of leaving design notes or historical plans to imply current behavior indirectly.
 

--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -2,7 +2,15 @@
 
 # Maintainer Guide
 
-This document routes to workflow-specific docs. Shared coding-agent context lives in `CLAUDE.md` / `AGENTS.md`; this file is for maintainer workflow, not implementation guidance.
+This document routes maintainers to workflow-specific docs for issue setup, PR
+opening, review monitoring, findings disposition, and release closeout. It is
+not the first-stop user documentation for building or using fTimer; normal
+users should start with [`README.md`](../README.md), examples, and
+[`docs/troubleshooting.md`](troubleshooting.md).
+
+Shared coding-agent context lives in `CLAUDE.md` / `AGENTS.md`. Those files
+remain available for automation and source-of-truth discipline, but this guide
+keeps the human maintainer workflow separate from agent implementation context.
 
 ## Repository Bootstrap
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -79,13 +79,13 @@ then require GitHub CI to pass before tagging.
 | Diff hygiene | Yes |
 | CI | Yes |
 
-Use the commands from `AGENTS.md` and `README.md` for each build mode. Minimum
-release-prep evidence should include the exact commands run, the local toolchain
-used, and whether the corresponding required CI jobs passed. Include
-`git diff --check` in every release-prep PR. Include the benchmark harness when
-hot-path timing behavior, lookup/cached-id behavior, context growth or
-parent-stack accounting, summary generation, report/CSV formatting, or MPI
-summary/report behavior changed.
+Use the commands from `README.md` and this release checklist for each build
+mode. Minimum release-prep evidence should include the exact commands run, the
+local toolchain used, and whether the corresponding required CI jobs passed.
+Include `git diff --check` in every release-prep PR. Include the benchmark
+harness when hot-path timing behavior, lookup/cached-id behavior, context
+growth or parent-stack accounting, summary generation, report/CSV formatting,
+or MPI summary/report behavior changed.
 
 Benchmark CSVs are review evidence, not a CI pass/fail threshold. Start trend
 review with the rows for flat name-based start/stop, cached-id start/stop,

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -406,17 +406,22 @@ endfunction()
 extract_markdown_section("${release_readme_text}" "Where To Go Next" readme_where_to_go_next_text)
 
 set(readme_role_routes
-  "- First-time user: stay in this README for `First Success`, `Quick Start`, and `Install And Use From Another Project`, then see the symptom-oriented [`docs/troubleshooting.md`](docs/troubleshooting.md) guide if first use goes sideways."
-  "- Advanced user: use [Supported Workflows](#supported-workflows) to choose a mode, then jump to [`docs/semantics.md`](docs/semantics.md), [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md), [`docs/csv-schema.md`](docs/csv-schema.md), or [`docs/installed-api.md`](docs/installed-api.md) for the exact contract."
-  "- Maintainer or release reviewer: use [`docs/release-evidence.md`](docs/release-evidence.md), [`docs/release.md`](docs/release.md), and [`docs/maintainer.md`](docs/maintainer.md)."
-  "- Coding agent: use [`AGENTS.md`](AGENTS.md) or [`CLAUDE.md`](CLAUDE.md) for repo workflow and source-of-truth rules, then read [`docs/semantics.md`](docs/semantics.md) and [`docs/maintainer.md`](docs/maintainer.md) as needed."
+  "The normal user"
+  "journey does not require the maintainer workflow or coding-agent files."
+  "For users:"
+  "- First-time users: stay in this README for `First Success`, `Quick Start`, and `Install And Use From Another Project`, then use the symptom-oriented [`docs/troubleshooting.md`](docs/troubleshooting.md) guide if first use goes sideways."
+  "- Advanced users: use [Supported Workflows](#supported-workflows) to choose a mode, then jump to [`docs/semantics.md`](docs/semantics.md), [`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md), [`docs/csv-schema.md`](docs/csv-schema.md), or [`docs/installed-api.md`](docs/installed-api.md) for the exact contract."
+  "For project work:"
+  "- Contributors and maintainers: start with [`CONTRIBUTING.md`](CONTRIBUTING.md) for contribution expectations. Use [`docs/maintainer.md`](docs/maintainer.md) and the routed workflow docs only when you are opening, reviewing, or closing out repository work."
+  "- Release reviewers: use [`docs/release-evidence.md`](docs/release-evidence.md) for claim evidence and [`docs/release.md`](docs/release.md) for release checklist and artifact policy."
+  "- Coding agents: use [`AGENTS.md`](AGENTS.md) or [`CLAUDE.md`](CLAUDE.md) for agent-specific repository rules. Those files preserve workflow context for automation, but they are not part of the ordinary user path."
 )
 
 foreach(readme_role_route IN LISTS readme_role_routes)
   string(FIND "${readme_where_to_go_next_text}" "${readme_role_route}" role_route_index)
   if(role_route_index EQUAL -1)
     message(FATAL_ERROR
-      "README.md must keep the explicit #336 audience routing in '## Where To Go Next': missing '${readme_role_route}'."
+      "README.md must keep the explicit #338 audience-boundary routing in '## Where To Go Next': missing '${readme_role_route}'."
     )
   endif()
 endforeach()

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -427,16 +427,23 @@ foreach(readme_role_route IN LISTS readme_role_routes)
   endif()
 endforeach()
 
+string(FIND "${readme_where_to_go_next_text}" "For users:"
+  readme_where_user_start)
 string(FIND "${readme_where_to_go_next_text}" "For project work:"
   readme_where_project_start)
-if(readme_where_project_start EQUAL -1)
+
+if(readme_where_user_start EQUAL -1 OR
+   readme_where_project_start EQUAL -1 OR
+   NOT readme_where_user_start LESS readme_where_project_start)
   message(FATAL_ERROR
-    "README.md must keep the 'For project work:' boundary in '## Where To Go Next'."
+    "README.md must order '## Where To Go Next' as user routes before project-work routes."
   )
 endif()
 
-string(SUBSTRING "${readme_where_to_go_next_text}" 0
-  "${readme_where_project_start}" readme_where_user_text)
+math(EXPR readme_where_user_length
+  "${readme_where_project_start} - ${readme_where_user_start}")
+string(SUBSTRING "${readme_where_to_go_next_text}" "${readme_where_user_start}"
+  "${readme_where_user_length}" readme_where_user_text)
 
 set(readme_project_only_targets
   "CONTRIBUTING.md"

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -404,6 +404,7 @@ function(extract_markdown_section text header out_var)
 endfunction()
 
 extract_markdown_section("${release_readme_text}" "Where To Go Next" readme_where_to_go_next_text)
+extract_markdown_section("${release_readme_text}" "More Detail" readme_more_detail_text)
 
 set(readme_role_routes
   "The normal user"
@@ -422,6 +423,128 @@ foreach(readme_role_route IN LISTS readme_role_routes)
   if(role_route_index EQUAL -1)
     message(FATAL_ERROR
       "README.md must keep the explicit #338 audience-boundary routing in '## Where To Go Next': missing '${readme_role_route}'."
+    )
+  endif()
+endforeach()
+
+set(readme_more_detail_labels
+  "User-facing references:"
+  "Contributor, maintainer, and release references:"
+  "Coding-agent references:"
+)
+
+foreach(readme_more_detail_label IN LISTS readme_more_detail_labels)
+  string(FIND "${readme_more_detail_text}" "${readme_more_detail_label}"
+    more_detail_label_index)
+  if(more_detail_label_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md must keep the #338 audience grouping in '## More Detail': missing '${readme_more_detail_label}'."
+    )
+  endif()
+endforeach()
+
+string(FIND "${readme_more_detail_text}" "User-facing references:"
+  more_detail_user_start)
+string(FIND "${readme_more_detail_text}"
+  "Contributor, maintainer, and release references:" more_detail_project_start)
+string(FIND "${readme_more_detail_text}" "Coding-agent references:"
+  more_detail_agent_start)
+
+if(more_detail_user_start EQUAL -1 OR
+   more_detail_project_start EQUAL -1 OR
+   more_detail_agent_start EQUAL -1 OR
+   NOT more_detail_user_start LESS more_detail_project_start OR
+   NOT more_detail_project_start LESS more_detail_agent_start)
+  message(FATAL_ERROR
+    "README.md must order '## More Detail' as user-facing, project, then coding-agent references."
+  )
+endif()
+
+math(EXPR more_detail_user_length
+  "${more_detail_project_start} - ${more_detail_user_start}")
+string(SUBSTRING "${readme_more_detail_text}" "${more_detail_user_start}"
+  "${more_detail_user_length}" readme_more_detail_user_text)
+
+math(EXPR more_detail_project_length
+  "${more_detail_agent_start} - ${more_detail_project_start}")
+string(SUBSTRING "${readme_more_detail_text}" "${more_detail_project_start}"
+  "${more_detail_project_length}" readme_more_detail_project_text)
+
+string(SUBSTRING "${readme_more_detail_text}" "${more_detail_agent_start}" -1
+  readme_more_detail_agent_text)
+
+set(readme_more_detail_user_needles
+  "[`docs/semantics.md`](docs/semantics.md)"
+  "[`docs/troubleshooting.md`](docs/troubleshooting.md)"
+  "[`docs/installed-api.md`](docs/installed-api.md)"
+  "[`docs/csv-schema.md`](docs/csv-schema.md)"
+  "[`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md)"
+  "[`docs/design.md`](docs/design.md)"
+  "[`SUPPORT.md`](SUPPORT.md), [`SECURITY.md`](SECURITY.md)"
+)
+
+foreach(readme_more_detail_user_needle IN LISTS readme_more_detail_user_needles)
+  string(FIND "${readme_more_detail_user_text}"
+    "${readme_more_detail_user_needle}" more_detail_user_needle_index)
+  if(more_detail_user_needle_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md '## More Detail' user-facing references must include '${readme_more_detail_user_needle}'."
+    )
+  endif()
+endforeach()
+
+set(readme_more_detail_project_needles
+  "[`CONTRIBUTING.md`](CONTRIBUTING.md)"
+  "[`docs/maintainer.md`](docs/maintainer.md)"
+  "[`docs/release-evidence.md`](docs/release-evidence.md)"
+  "[`docs/release.md`](docs/release.md)"
+)
+
+foreach(readme_more_detail_project_needle IN LISTS readme_more_detail_project_needles)
+  string(FIND "${readme_more_detail_project_text}"
+    "${readme_more_detail_project_needle}" more_detail_project_needle_index)
+  if(more_detail_project_needle_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md '## More Detail' project references must include '${readme_more_detail_project_needle}'."
+    )
+  endif()
+endforeach()
+
+set(readme_more_detail_agent_needles
+  "[`AGENTS.md`](AGENTS.md), [`CLAUDE.md`](CLAUDE.md)"
+  "[`.github/prompts/README.md`](.github/prompts/README.md), [`.github/prompts/detailed/README.md`](.github/prompts/detailed/README.md)"
+)
+
+foreach(readme_more_detail_agent_needle IN LISTS readme_more_detail_agent_needles)
+  string(FIND "${readme_more_detail_agent_text}"
+    "${readme_more_detail_agent_needle}" more_detail_agent_needle_index)
+  if(more_detail_agent_needle_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md '## More Detail' coding-agent references must include '${readme_more_detail_agent_needle}'."
+    )
+  endif()
+endforeach()
+
+set(readme_agent_only_targets
+  "AGENTS.md"
+  "CLAUDE.md"
+  ".github/prompts/"
+)
+
+foreach(readme_agent_only_target IN LISTS readme_agent_only_targets)
+  string(FIND "${readme_more_detail_user_text}" "${readme_agent_only_target}"
+    agent_only_in_user_index)
+  if(NOT agent_only_in_user_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md must not put '${readme_agent_only_target}' in '## More Detail' user-facing references."
+    )
+  endif()
+
+  string(FIND "${readme_more_detail_project_text}" "${readme_agent_only_target}"
+    agent_only_in_project_index)
+  if(NOT agent_only_in_project_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md must not put '${readme_agent_only_target}' in '## More Detail' contributor/maintainer/release references."
     )
   endif()
 endforeach()

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -427,6 +427,35 @@ foreach(readme_role_route IN LISTS readme_role_routes)
   endif()
 endforeach()
 
+string(FIND "${readme_where_to_go_next_text}" "For project work:"
+  readme_where_project_start)
+if(readme_where_project_start EQUAL -1)
+  message(FATAL_ERROR
+    "README.md must keep the 'For project work:' boundary in '## Where To Go Next'."
+  )
+endif()
+
+string(SUBSTRING "${readme_where_to_go_next_text}" 0
+  "${readme_where_project_start}" readme_where_user_text)
+
+set(readme_project_only_targets
+  "CONTRIBUTING.md"
+  "docs/design.md"
+  "docs/maintainer.md"
+  "docs/release-evidence.md"
+  "docs/release.md"
+)
+
+foreach(readme_project_only_target IN LISTS readme_project_only_targets)
+  string(FIND "${readme_where_user_text}" "${readme_project_only_target}"
+    project_only_in_where_user_index)
+  if(NOT project_only_in_where_user_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md must not put '${readme_project_only_target}' in the user-facing part of '## Where To Go Next'."
+    )
+  endif()
+endforeach()
+
 set(readme_more_detail_labels
   "User-facing references:"
   "Contributor, maintainer, and release references:"
@@ -545,6 +574,16 @@ foreach(readme_agent_only_target IN LISTS readme_agent_only_targets)
   if(NOT agent_only_in_project_index EQUAL -1)
     message(FATAL_ERROR
       "README.md must not put '${readme_agent_only_target}' in '## More Detail' contributor/maintainer/release references."
+    )
+  endif()
+endforeach()
+
+foreach(readme_project_only_target IN LISTS readme_project_only_targets)
+  string(FIND "${readme_more_detail_user_text}" "${readme_project_only_target}"
+    project_only_in_more_detail_user_index)
+  if(NOT project_only_in_more_detail_user_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md must not put '${readme_project_only_target}' in '## More Detail' user-facing references."
     )
   endif()
 endforeach()

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -479,7 +479,6 @@ set(readme_more_detail_user_needles
   "[`docs/installed-api.md`](docs/installed-api.md)"
   "[`docs/csv-schema.md`](docs/csv-schema.md)"
   "[`docs/openmp-timing-modes.md`](docs/openmp-timing-modes.md)"
-  "[`docs/design.md`](docs/design.md)"
   "[`SUPPORT.md`](SUPPORT.md), [`SECURITY.md`](SECURITY.md)"
 )
 
@@ -495,6 +494,7 @@ endforeach()
 
 set(readme_more_detail_project_needles
   "[`CONTRIBUTING.md`](CONTRIBUTING.md)"
+  "[`docs/design.md`](docs/design.md)"
   "[`docs/maintainer.md`](docs/maintainer.md)"
   "[`docs/release-evidence.md`](docs/release-evidence.md)"
   "[`docs/release.md`](docs/release.md)"

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -463,6 +463,22 @@ foreach(readme_project_only_target IN LISTS readme_project_only_targets)
   endif()
 endforeach()
 
+set(readme_agent_only_targets
+  "AGENTS.md"
+  "CLAUDE.md"
+  ".github/prompts/"
+)
+
+foreach(readme_agent_only_target IN LISTS readme_agent_only_targets)
+  string(FIND "${readme_where_user_text}" "${readme_agent_only_target}"
+    agent_only_in_where_user_index)
+  if(NOT agent_only_in_where_user_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md must not put '${readme_agent_only_target}' in the user-facing part of '## Where To Go Next'."
+    )
+  endif()
+endforeach()
+
 set(readme_more_detail_labels
   "User-facing references:"
   "Contributor, maintainer, and release references:"
@@ -560,12 +576,6 @@ foreach(readme_more_detail_agent_needle IN LISTS readme_more_detail_agent_needle
     )
   endif()
 endforeach()
-
-set(readme_agent_only_targets
-  "AGENTS.md"
-  "CLAUDE.md"
-  ".github/prompts/"
-)
 
 foreach(readme_agent_only_target IN LISTS readme_agent_only_targets)
   string(FIND "${readme_more_detail_user_text}" "${readme_agent_only_target}"


### PR DESCRIPTION
## Summary

- Separate README navigation into user, contributor/maintainer/release, and coding-agent paths
- Route contributors and maintainers through CONTRIBUTING and docs/maintainer without making AGENTS/CLAUDE part of the normal user journey
- Update docs/design documentation-boundary inventory and the release docs contract check for the #338 audience split

Closes #338.
Parent: #334.

## Validation

- `git diff --check`
- `cmake -DREPO_ROOT=/Users/hrh/.codex/worktrees/b8d8/fTimer -P tests/check_release_docs_contract.cmake`
- `cmake -DREPO_ROOT=/Users/hrh/.codex/worktrees/b8d8/fTimer -P tests/check_init_contract_docs.cmake`
- `cmake -DREPO_ROOT=/Users/hrh/.codex/worktrees/b8d8/fTimer -P tests/check_mpi_lifecycle_contract_docs.cmake`
- `cmake -DREPO_ROOT=/Users/hrh/.codex/worktrees/b8d8/fTimer -P tests/check_csv_schema_docs.cmake`