### PR TITLE
Add documentation audience guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,10 @@ not need those files for ordinary build, test, or PR navigation.
 - Prefer correctness and explicit error handling over silent fallbacks.
 - Preserve deterministic tests by using the injectable mock clock instead of
   sleeps or wall-clock timing assumptions.
+- Use the short audience guide in
+  [`docs/documentation-audience.md`](docs/documentation-audience.md) when
+  deciding what belongs in public docs, contract references, maintainer
+  workflow docs, release evidence, or agent guidance.
 - Keep public API and installed-package docs aligned with implementation.
 - Keep release-scope docs honest about what current `main` supports and what is
   deferred.

--- a/docs/documentation-audience.md
+++ b/docs/documentation-audience.md
@@ -1,0 +1,49 @@
+> **When to read this:** When editing public docs, examples, maintainer docs,
+> release evidence, or agent guidance and deciding what detail belongs where.
+
+# Documentation Audience Guide
+
+fTimer documentation should be human-first at the public entry points and
+machine-checkable where exact contracts matter. Keep this guide short in spirit:
+it exists to route detail to the right home, not to create another approval
+layer.
+
+## Document Roles
+
+- `README.md`: the first user path. Lead with the task a user is trying to
+  complete, show a working command or source shape, and link out for exact
+  contracts.
+- `examples/`: buildable demonstrations of supported source shapes. Keep
+  caveats close to the example they affect, especially for MPI, OpenMP, hybrid
+  timing, and installed-package consumption.
+- `docs/troubleshooting.md`: symptom-oriented recovery steps for builds,
+  package consumption, MPI, OpenMP, CSV, and summary/report failures. It should
+  tell users what to try next before sending them to contract references.
+- `docs/semantics.md`: the runtime contract. Put exhaustive behavior, edge
+  cases, error-status rules, MPI/OpenMP boundaries, and source-of-truth
+  precedence here instead of expanding the README.
+- `docs/installed-api.md`: the installed source/API and package-consumption
+  contract. Use it for stable imports, public-symbol boundaries, installed
+  artifacts, schema or report surface changes, and compatibility notes.
+- `docs/release-evidence.md`: the claim-evidence ledger. Keep release-facing
+  support claims narrow here, with concrete CI jobs, tests, examples, and
+  caveats.
+- `docs/maintainer.md` and `docs/workflows/`: maintainer process. Keep PR
+  routing, review labels, fallback review, findings disposition, release
+  closeout, and repository bootstrap details out of ordinary user docs.
+- `AGENTS.md` and `CLAUDE.md`: coding-agent operating context. Preserve
+  machine-readable workflow detail and source-of-truth discipline here, but do
+  not make normal users read these files to build or use fTimer.
+
+## Practical Rules
+
+- Lead with a user task, then give the smallest correct example or command.
+- Keep exhaustive contracts in focused reference docs, and link to them from
+  public entry points.
+- Put caveats near the example, command, or claim they qualify.
+- Avoid maintainer-process language in user docs unless the user needs it to
+  choose a build, API, or support boundary.
+- Preserve source-of-truth links for machine-readable detail instead of
+  duplicating long rules in multiple places.
+- When docs disagree, fix the disagreement in the highest-precedence source and
+  route lower-precedence docs to it instead of paraphrasing a second contract.

--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -74,6 +74,9 @@ download identity and cache identity together when updating pinned tools.
 
 Use the workflow docs below for workflow-specific operating procedures. Load only the workflow you need.
 
+- [`docs/documentation-audience.md`](documentation-audience.md) — where public
+  docs, contract references, release evidence, maintainer workflow docs, and
+  agent guidance should each carry detail
 - [`docs/workflows/pr-open.md`](workflows/pr-open.md) — opening a PR,
   applying review labels, review prompt library
 - [`docs/workflows/review-monitoring.md`](workflows/review-monitoring.md) —

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -6,6 +6,7 @@ set(required_paths
   README.md
   docs/design.md
   docs/csv-schema.md
+  docs/documentation-audience.md
   docs/fault-model-traceability.md
   docs/installed-api.md
   docs/implementation-history.md


### PR DESCRIPTION
## Summary

- Phase / issue: Closes #339 under umbrella #334.
- Scope: Adds a short maintainer/contributor-facing documentation audience guide, references it from contributor and maintainer docs, and includes it in the release-doc contract path list.

## Checks

- [x] Linked to the relevant GitHub issue
- [ ] Codex review routing has applied the expected automatic review labels, or I added any missing ones manually
- [ ] Added any extra Codex review labels needed beyond the automatic set
- [x] Docs updated to match behavior changes
- [x] Tests or smoke-path coverage updated as appropriate
- [x] Workflow/bootstrap docs updated if repo process changed

Validation:

- `cmake -DREPO_ROOT=/Users/hrh/.codex/worktrees/0823/fTimer -P tests/check_release_docs_contract.cmake`
- `git diff --cached --check`
- `git diff --check`

## Notes

- Follow-up work: none.
- Deferred items: none.