### PR TITLE
Refresh v1.0 release claims and evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,9 +260,9 @@ For the full OpenMP and hybrid lifecycle, accepted source shapes, and migration 
 Support tiers still matter, but the detailed claim ledger lives outside the README:
 
 - **Core validated** today: serial/library smoke, installed consumer coverage, and pure-MPI on the documented GNU wrapper path.
-- **Supported advanced**: OpenMP compatibility through `ftimer` / `ftimer_core`, plus explicit worker timing and strict/sparse MPI+OpenMP reporting through `ftimer_openmp_t`.
+- **Evidence-backed advanced**: OpenMP compatibility through `ftimer` / `ftimer_core`, plus explicit worker timing and strict/sparse MPI+OpenMP reporting through `ftimer_openmp_t`. OpenMPI MPI+OpenMP has routine CI coverage; MPICH MPI+OpenMP has focused local smoke/install-consumer evidence only.
 - **Plausible but unvalidated**: compiler, MPI, or OpenMP combinations not yet backed by direct automation or recorded local evidence.
-- **Experimental/deferred**: package-manager installs, profiler backends, hardware counters, traces, dashboards, and similar ecosystem work.
+- **V1.0 non-goals or post-release topics**: package-manager availability, package-recipe ownership, profiler backends, hardware counters, traces, dashboards, broader OpenMP ergonomics beyond the explicit level-1 worker runtime, and similar ecosystem work.
 - Exact status, evidence, and caveats for each release-facing claim live in [`docs/release-evidence.md`](docs/release-evidence.md). Use that ledger, not this README, when you need release-review wording.
 
 For failure-oriented guidance, see [`docs/troubleshooting.md`](docs/troubleshooting.md). For installed package stability details, see [`docs/installed-api.md`](docs/installed-api.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ before public disclosure.
 
 ## Supported Versions
 
-Pre-1.0 releases are supported on a best-effort basis. Security fixes normally
-target the latest release line and current `main` unless a maintainer documents
-another patch policy for a specific release.
+For v1.0 and later, security fixes normally target the latest stable release
+line and current `main` unless a maintainer documents another patch policy for a
+specific release. Pre-1.0 tags and snapshots remain best-effort only.
 
 ## Reporting A Vulnerability
 

--- a/docs/package-manager-readiness.md
+++ b/docs/package-manager-readiness.md
@@ -6,7 +6,12 @@ recipe. fTimer does not currently own, ship, test, or maintain Spack
 `package.py` or EasyBuild easyconfig files. Do not treat any prototype below as
 a copy-paste-ready recipe unless a later issue accepts that support cost.
 
-Status date: 2026-06-09.
+Status date: 2026-06-17.
+
+V1.0 release-claims refresh: this remains readiness guidance only. Issue #355
+owns any post-v1.0 decision to accept package-manager recipe ownership or direct
+Spack/EasyBuild validation. Until that decision changes, release notes and
+README support text should not claim package-manager availability.
 
 ## Spike Summary
 
@@ -36,9 +41,10 @@ add dependencies, CMake option flips, and the feature-mode caveats below.
 
 **Maintainer-only sketch, not a maintained Spack recipe:** this block is
 deliberately incomplete, was not executed by Spack during the readiness spike,
-and contains placeholders for a future upstream/site maintainer to replace with
-real ownership metadata, release versions, checksums, and package-manager
-validation.
+and contains `TODO-*` placeholders for a future upstream/site maintainer to
+replace with real ownership metadata, release versions, checksums, and
+package-manager validation. Those placeholders are intentional evidence that
+fTimer has not accepted recipe ownership in v1.0.
 
 ```python
 from spack.package import *
@@ -95,8 +101,10 @@ toolchain. The serial easyconfig is the base case:
 
 **Maintainer-only sketch, not a maintained EasyBuild easyconfig:** this block
 is deliberately incomplete, was not executed by EasyBuild during the readiness
-spike, and contains placeholders for a future site maintainer to replace with a
-real toolchain, dependency versions, checksums, and package-manager validation.
+spike, and contains `TODO` placeholders for a future site maintainer to replace
+with a real toolchain, dependency versions, checksums, and package-manager
+validation. Those placeholders are intentional evidence that fTimer has not
+accepted easyconfig ownership in v1.0.
 
 ```python
 easyblock = 'CMakeMake'
@@ -165,6 +173,9 @@ Specifically:
 - Do not add maintained in-repository Spack or EasyBuild recipe files now.
 - Keep the existing CMake install/export and installed-consumer tests as the
   source of truth for package behavior.
+- Keep v1.0 release notes limited to package-manager readiness guidance until
+  #355 records a different ownership decision and real package-manager
+  validation exists.
 - Consider an upstream Spack recipe contribution after a release tarball and
   checksum are available, using `mpi` and `openmp` variants and an external
   CMake consumer smoke check.

--- a/docs/release-evidence.md
+++ b/docs/release-evidence.md
@@ -15,22 +15,27 @@ Status vocabulary:
   release-validated support boundary.
 - **Non-goal**: intentionally outside the current release claim.
 
-## Dry-Run Release-Note Claim Map
+## V1.0 Release-Note Claim Map
 
-A current release note should be able to claim:
+The v1.0 release note may claim only the support areas mapped to the ledger
+rows below:
 
-- disciplined serial wall-clock timing with structured summaries, reports, CSV,
+- serial timing: disciplined serial wall-clock timing with structured summaries, reports, CSV,
   scoped guards, callbacks, mock-clock-friendly tests, and benchmark evidence;
-- pure MPI summaries and reports through the `mpi_f08` communicator contract;
-- OpenMP compatibility for existing `ftimer`/`ftimer_core` users through the
+- pure MPI: summaries and reports through the `mpi_f08` communicator contract;
+- OpenMP compatibility: existing `ftimer`/`ftimer_core` users through the
   master-thread-only carve-out;
-- opt-in true OpenMP worker timing through `ftimer_openmp_t`;
-- strict and sparse union MPI+OpenMP rank/lane summary, report, and CSV output
-  for the currently validated hybrid path;
-- stable CSV/export schemas within the documented schema lines;
-- installed CMake package consumption for supported feature modes;
-- a curated public symbol boundary; and
-- benchmark harness evidence for release-readiness sweeps and performance-risk
+- `ftimer_openmp_t`: opt-in true OpenMP worker timing through the explicit
+  object API;
+- strict/sparse hybrid output: strict and sparse union MPI+OpenMP rank/lane
+  summary, report, and CSV output, with OpenMPI as the routine CI-covered path
+  and MPICH as focused local-evidence-backed caveated support from #353;
+- stable CSV/export claims: stable CSV/export schemas within the documented
+  schema lines;
+- installed CMake package behavior: installed CMake package consumption for
+  supported feature modes and same-major 1.x package-version matching;
+- public symbols: a curated source-level public symbol boundary; and
+- benchmark evidence: harness evidence for release-readiness sweeps and performance-risk
   PRs.
 
 The same release note should not claim broad compiler portability,
@@ -41,6 +46,17 @@ matching evidence. The current [Spack and EasyBuild readiness note](package-mana
 records out-of-tree recipe guidance without making fTimer a package-recipe
 owner.
 
+## V1.0 Deferred And Non-Goal Classification
+
+| Topic | V1.0 classification | Evidence or disposition |
+| --- | --- | --- |
+| Package-manager availability and recipe ownership | Non-goal for v1.0; post-v1.0 strategic decision tracked by #355. | `docs/package-manager-readiness.md` is readiness guidance only: no in-repository Spack/EasyBuild recipes, no direct `spack`/`eb` execution, and intentional prototype placeholders. |
+| Fixed-team or no-explicit-region OpenMP worker timing | Post-1.0 design issue #294. | Current `ftimer_openmp_t` support remains the explicit timed-region, level-1 worker model documented in `docs/openmp-timing-modes.md` and `docs/semantics.md`. |
+| MPICH MPI+OpenMP permanent CI coverage | Non-goal for v1.0 under the #353 maintainer decision. | OpenMPI MPI+OpenMP is routine CI-covered. MPICH MPI+OpenMP remains local-evidence-backed caveated support, not permanent PR CI coverage. |
+| Ubuntu 24.04 MPICH pFUnit runner migration | Post-release runner maintenance tracked by #259. | Current pure-MPICH MPI CI/pFUnit coverage remains on the validated hosted Ubuntu 22.04 path with a raw launcher probe. |
+| NVHPC serial smoke/install-consumer support | Plausible but unvalidated; post-release investigation #256. | Hosted-runner NVHPC 26.3 built but smoke/install-consumer executables aborted at runtime, so README and release notes must not claim NVHPC validation. |
+| Profiler backends, hardware counters, traces, dashboards, accelerator/device synchronization, automatic MPI barriers, FPM, binary packages | Non-goals for v1.0 unless a later release issue accepts ownership and evidence. | Current docs describe wall-clock summaries and CSV exports only; `docs/release.md` owns artifact policy and release-note guardrails. |
+
 ## Claim Ledger
 
 | Release claim area | Current status | Evidence to cite | Caveats and compatibility boundary |
@@ -49,10 +65,10 @@ owner.
 | Pure MPI | Release-validated for GNU Fortran wrapper builds with OpenMPI and MPICH. | `build-mpi`, `build-mpi-mpich`, `test-mpi`, and `test-mpi-mpich` CI jobs; `tests/mpi/test_mpi_*.pf`; `examples/mpi_example.F90`; configure-time `mpi_f08` probe in `CMakeLists.txt`; `docs/semantics.md` MPI contract. | Requires MPI lifetime discipline and the `mpi_f08` `type(MPI_Comm)` contract. Legacy integer communicators, `mpif.h`, divergent collectives, and automatic MPI barriers are outside the claim. |
 | OpenMP compatibility | Release-validated for GNU Fortran OpenMP and LLVM Flang OpenMP smoke/example paths. | `build-openmp`, `build-openmp-flang`, and `test-openmp` CI jobs; `tests/test_openmp_guards.pf`; `tests/check_openmp_option_off_global_flags.cmake`; `examples/openmp_example.F90`; `docs/openmp-timing-modes.md`. | This is the master-thread-only carve-out for existing APIs. It is not general thread safety, thread-local timing, nested worker timing, or a hybrid timing model by itself. |
 | `ftimer_openmp_t` | Release-validated as the opt-in serial-lane and level-1 worker timing API in OpenMP builds; serial-context lifecycle/catalog/timing is available in non-OpenMP packages. | `tests/test_openmp_api_smoke.F90`; `tests/test_openmp_summary_smoke.F90`; OpenMP diagnostic smoke tests; `tests/check_installed_openmp_hybrid_api_surface.cmake`; `examples/openmp_worker_example.F90`; `docs/installed-api.md`. | Worker timing requires `FTIMER_USE_OPENMP=ON`, an opened level-1 timed region, pre-registered ids for the hot path, and stopped-run summary/report calls. Global downstream OpenMP flags do not retrofit OpenMP support into a non-OpenMP fTimer package. |
-| Strict/sparse hybrid output | Release-validated for OpenMPI wrapper MPI+OpenMP smoke/install-consumer coverage with GNU Fortran and OpenMP; focused local MPICH wrapper smoke/install-consumer evidence exists for the same feature mode. | `build-mpi-openmp` CI job; #306 local MPICH 5.0.1/GNU Fortran 15.2.0 `ctest --test-dir build-codex-306-mpich-hybrid --output-on-failure` run, 34/34 passed; `tests/test_openmp_mpi_summary_smoke.F90`; `tests/test_openmp_mpi_summary_3rank_smoke.F90`; `tests/check_openmp_mpi_union_descriptor_contract.cmake`; `examples/mpi_openmp_example.F90`; `tests/install-consumer/mpi_openmp_main.F90`; `README.md` hybrid contract. | MPICH hybrid is not permanent CI coverage yet; treat other MPI/compiler/OpenMP runtime combinations as plausible but unvalidated. Strict hybrid output rejects descriptor, eligible-lane, and mixed-epoch unknown missing-lane precision mismatches. Sparse union hybrid output is a separate participation-aware API and schema with explicit unknown missing-sample flags; it is not append-compatible with strict hybrid CSV. |
-| Stable CSV/export claims | Evidence-backed for the documented schema lines and append-validation behavior. | `tests/test_file_output.pf`; `tests/check_openmp_summary_smoke.cmake`; `tests/check_openmp_mpi_summary_smoke.cmake`; `tests/check_bench_csv_output.cmake`; CSV sections in `README.md`, `docs/semantics.md`, and `docs/troubleshooting.md`. | CSV is the first stable machine-readable export, not a trace/event/profiler format. Local/strict MPI, sparse MPI union, OpenMP, strict hybrid, and sparse hybrid schemas are dedicated and intentionally not append-compatible with one another. |
+| Strict/sparse hybrid output | Release-validated for OpenMPI wrapper MPI+OpenMP smoke/install-consumer coverage with GNU Fortran and OpenMP; evidence-backed local MPICH wrapper smoke/install-consumer coverage is caveated by #353 and is not permanent CI coverage. | `build-mpi-openmp` CI job; #306 local MPICH 5.0.1/GNU Fortran 15.2.0 `ctest --test-dir build-codex-306-mpich-hybrid --output-on-failure` run, 34/34 passed; `tests/test_openmp_mpi_summary_smoke.F90`; `tests/test_openmp_mpi_summary_3rank_smoke.F90`; `tests/check_openmp_mpi_union_descriptor_contract.cmake`; `examples/mpi_openmp_example.F90`; `tests/install-consumer/mpi_openmp_main.F90`; `README.md` hybrid contract. | MPICH hybrid is local-evidence-backed caveated support for v1.0, not routine PR CI coverage. Treat other MPI/compiler/OpenMP runtime combinations as plausible but unvalidated. Strict hybrid output rejects descriptor, eligible-lane, and mixed-epoch unknown missing-lane precision mismatches. Sparse union hybrid output is a separate participation-aware API and schema with explicit unknown missing-sample flags; it is not append-compatible with strict hybrid CSV. |
+| Stable CSV/export claims | Evidence-backed for the documented schema lines and append-validation behavior. | `tests/test_file_output.pf`; `tests/check_openmp_summary_smoke.cmake`; `tests/check_openmp_mpi_summary_smoke.cmake`; `tests/check_bench_csv_output.cmake`; CSV sections in `README.md`, `docs/semantics.md`, `docs/csv-schema.md`, and `docs/troubleshooting.md`. | CSV is the first stable machine-readable export, not a trace/event/profiler format. Local/strict MPI, sparse MPI union, OpenMP, strict hybrid, and sparse hybrid schemas are dedicated and intentionally not append-compatible with one another. |
 | Installed CMake package behavior | Release-validated for same-major 1.x package-version matching and the supported serial, MPI, OpenMP, and MPI+OpenMP installed-consumer paths. | `ftimer_installed_package_consumer*` CTest entries; `tests/check_installed_package_consumer.cmake`; `tests/installed-consumer-contract/package-version-probes.cmake`; `tests/install-consumer/*.F90`; installed docs check for `docs/installed-api.md` and `LICENSE`; `docs/installed-api.md`. | A 1.x install may satisfy same-major requests at or older than the installed package version. Future-major requests and same-major requests newer than the installed package are rejected. Installed `.mod` artifacts are compiler-, wrapper-, and feature-mode-specific. FPM, binary packages, cross-compiler module reuse, and broad package-manager support are non-goals unless separately validated. |
-| Spack/EasyBuild readiness | Preliminary out-of-tree recipe guidance inferred from fTimer's CMake install contract, not direct package-manager execution or maintained package-manager ownership. Serial, MPI, OpenMP, and MPI+OpenMP variants appear package-manager friendly when the package manager follows fTimer's install contract and feature-mode boundaries. | `docs/package-manager-readiness.md`; `fTimerConfig.cmake` dependency exports; `cmake/install_ftimer_modules.cmake.in`; `tests/check_installed_package_consumer.cmake`; installed-consumer CTest entries. | No Spack or EasyBuild recipe is committed in this repository. `spack` and `eb` were not available in the #311 local validation environment, so direct package-manager execution remains future upstream/site-recipe work. |
+| Spack/EasyBuild readiness | Preliminary out-of-tree recipe guidance inferred from fTimer's CMake install contract, not direct package-manager execution or maintained package-manager ownership. Serial, MPI, OpenMP, and MPI+OpenMP variants appear package-manager friendly when the package manager follows fTimer's install contract and feature-mode boundaries. | `docs/package-manager-readiness.md`; `fTimerConfig.cmake` dependency exports; `cmake/install_ftimer_modules.cmake.in`; `tests/check_installed_package_consumer.cmake`; installed-consumer CTest entries. | No Spack or EasyBuild recipe is committed in this repository. `spack` and `eb` were not available in the #311 local validation environment, so direct package-manager execution remains future upstream/site-recipe work. #355 owns any later package-manager ownership decision. |
 | Public symbols | Evidence-backed by an allowlisted source-level API boundary. | `tests/public_symbol_allowlist.txt`; `tests/check_public_symbol_allowlist.cmake`; `docs/installed-api.md`; `src/ftimer.F90`, `src/ftimer_core.F90`, `src/ftimer_openmp.F90`, and `src/ftimer_types.F90`. | New module-level public names must be intentionally classified as stable, unstable public-by-necessity, or test-only. Installed implementation module artifacts are not stable import targets. |
 | Benchmark evidence | Evidence-backed for trend review and release-readiness sweeps, not pass/fail thresholds. Durable comparisons require the benchmark CSV plus the provenance sidecar policy in `docs/release.md`. | `build-bench`, `build-openmp-bench`, and `build-mpi-openmp-bench` CI jobs; `bench/ftimer_bench.F90`; `bench_csv_smoke`; serial CI artifact `ftimer-bench-serial-<sha>`; benchmark commands in `README.md` and `docs/release.md`. | GitHub-hosted runner timings are noisy. Serial CSV artifacts are uploaded by CI; OpenMP and MPI+OpenMP benchmark CI jobs currently smoke-check parseable CSV but do not upload durable feature-enabled artifacts. Feature-enabled trend evidence is local CSV plus sidecar unless a future issue adds sidecar-aware CI artifact upload. |
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -19,6 +19,10 @@ Before starting a release candidate:
   [`docs/release-evidence.md`](release-evidence.md) and update any rows whose
   CI jobs, tests, examples, caveats, or support status changed since the last
   release.
+- Review the v1.0 deferred/non-goal classification table in
+  [`docs/release-evidence.md`](release-evidence.md) before drafting release
+  notes. Do not convert a post-release or non-goal topic into a release claim
+  without a linked maintainer decision and matching evidence.
 - Keep the release claim within the documented support boundary: serial timing,
   pure-MPI timing, the narrow master-thread-only OpenMP carve-out, the
   `ftimer_openmp` lifecycle/configuration/timer-catalog and id-first
@@ -33,10 +37,16 @@ Before starting a release candidate:
   [`docs/release-evidence.md`](release-evidence.md). Other MPI/compiler/OpenMP
   runtime combinations remain plausible but unvalidated until a release issue
   adds matching evidence.
+- Keep the #353 MPICH MPI+OpenMP decision visible in release wording: MPICH
+  hybrid is local-evidence-backed caveated support for v1.0, not routine PR CI
+  coverage. Do not fold #259's pure-MPICH hosted-runner maintenance into a
+  hybrid support claim.
 - Do not promote deferred non-goals into the release unless a linked issue has
   changed scope. Current non-goals include full profiler integration, FPM
-  packaging, hardware counters, traces, accelerator timelines, automatic MPI
-  barriers, and stable callback semantic identity.
+  packaging, package-manager recipe ownership or availability, hardware
+  counters, traces, accelerator timelines, automatic MPI barriers, broad
+  OpenMP fixed-team ergonomics beyond the explicit level-1 worker runtime, and
+  stable callback semantic identity.
 
 ## Version And Compatibility
 
@@ -267,7 +277,11 @@ Release notes should be short and evidence-backed. Include:
 
 Do not claim production readiness, broad compiler support, general hybrid
 OpenMP timing, profiler-backend integration, or binary package availability
-unless the release validation and docs support that exact claim.
+unless the release validation and docs support that exact claim. If mentioned,
+name validation skips explicitly: package-manager execution was unavailable for
+the readiness spike, MPICH hybrid is local-evidence-backed rather than permanent
+CI-covered, and NVHPC remains unvalidated unless #256 or a later issue changes
+that evidence.
 
 ## Tag And Publish
 

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -1248,6 +1248,84 @@ foreach(required_release_evidence_term IN LISTS required_release_evidence_terms)
 endforeach()
 
 file(STRINGS "${REPO_ROOT}/docs/release-evidence.md" release_evidence_lines)
+
+function(require_release_evidence_line_contains row_label)
+  set(row_text "")
+  set(expected_prefix "| ${row_label} |")
+
+  foreach(release_evidence_line IN LISTS release_evidence_lines)
+    string(FIND "${release_evidence_line}" "${expected_prefix}" release_evidence_line_prefix_index)
+    if(release_evidence_line_prefix_index EQUAL 0)
+      set(row_text "${release_evidence_line}")
+    endif()
+  endforeach()
+
+  if(row_text STREQUAL "")
+    message(FATAL_ERROR
+      "docs/release-evidence.md must keep a table row beginning with '${expected_prefix}'."
+    )
+  endif()
+
+  foreach(required_row_term IN LISTS ARGN)
+    string(FIND "${row_text}" "${required_row_term}" required_row_term_index)
+    if(required_row_term_index EQUAL -1)
+      message(FATAL_ERROR
+        "docs/release-evidence.md row '${row_label}' must keep row-local term '${required_row_term}'."
+      )
+    endif()
+  endforeach()
+endfunction()
+
+require_release_evidence_line_contains("Package-manager availability and recipe ownership"
+  "Non-goal for v1.0"
+  "#355"
+  "readiness guidance only"
+  "no direct `spack`/`eb` execution"
+)
+
+require_release_evidence_line_contains("Fixed-team or no-explicit-region OpenMP worker timing"
+  "Post-1.0 design issue #294"
+  "explicit timed-region"
+  "level-1 worker model"
+)
+
+require_release_evidence_line_contains("MPICH MPI+OpenMP permanent CI coverage"
+  "Non-goal for v1.0"
+  "#353"
+  "not permanent PR CI coverage"
+)
+
+require_release_evidence_line_contains("Ubuntu 24.04 MPICH pFUnit runner migration"
+  "Post-release runner maintenance tracked by #259"
+  "Ubuntu 22.04"
+  "raw launcher probe"
+)
+
+require_release_evidence_line_contains("NVHPC serial smoke/install-consumer support"
+  "Plausible but unvalidated"
+  "#256"
+  "must not claim NVHPC validation"
+)
+
+require_release_evidence_line_contains("Profiler backends, hardware counters, traces, dashboards, accelerator/device synchronization, automatic MPI barriers, FPM, binary packages"
+  "Non-goals for v1.0"
+  "wall-clock summaries and CSV exports only"
+  "artifact policy and release-note guardrails"
+)
+
+require_release_evidence_line_contains("Strict/sparse hybrid output"
+  "#353"
+  "not permanent CI coverage"
+  "local-evidence-backed caveated support for v1.0"
+  "not routine PR CI coverage"
+)
+
+require_release_evidence_line_contains("Spack/EasyBuild readiness"
+  "No Spack or EasyBuild recipe is committed"
+  "direct package-manager execution remains future"
+  "#355 owns any later package-manager ownership decision"
+)
+
 set(required_release_evidence_rows
   "Serial timing"
   "Pure MPI"

--- a/tests/check_release_docs_contract.cmake
+++ b/tests/check_release_docs_contract.cmake
@@ -1139,6 +1139,25 @@ foreach(readme_v1_package_contract_term IN LISTS readme_v1_package_contract_term
   endif()
 endforeach()
 
+set(readme_v1_claim_boundary_terms
+  "**Evidence-backed advanced**"
+  "OpenMPI MPI+OpenMP has routine CI coverage; MPICH MPI+OpenMP has focused local smoke/install-consumer evidence only."
+  "**V1.0 non-goals or post-release topics**"
+  "package-manager availability"
+  "broader OpenMP ergonomics beyond the explicit level-1 worker runtime"
+  "Use that ledger, not this README, when you need release-review wording."
+)
+
+foreach(readme_v1_claim_boundary_term IN LISTS readme_v1_claim_boundary_terms)
+  string(FIND "${release_readme_text}" "${readme_v1_claim_boundary_term}"
+    readme_v1_claim_boundary_index)
+  if(readme_v1_claim_boundary_index EQUAL -1)
+    message(FATAL_ERROR
+      "README.md must keep v1 release-claim boundary term: ${readme_v1_claim_boundary_term}"
+    )
+  endif()
+endforeach()
+
 set(installed_api_v1_package_contract_terms
   "For the 1.x release line, CMake package version compatibility uses"
   "`SameMajorVersion`"
@@ -1174,7 +1193,30 @@ foreach(release_evidence_v1_package_contract_term IN LISTS release_evidence_v1_p
   endif()
 endforeach()
 
+file(READ "${REPO_ROOT}/docs/release.md" release_doc_text)
+set(release_doc_v1_claim_boundary_terms
+  "Review the v1.0 deferred/non-goal classification table"
+  "Keep the #353 MPICH MPI+OpenMP decision visible"
+  "local-evidence-backed caveated support for v1.0"
+  "package-manager recipe ownership or availability"
+  "OpenMP fixed-team ergonomics"
+  "package-manager execution was unavailable"
+  "NVHPC remains unvalidated unless #256 or a later issue changes"
+)
+
+foreach(release_doc_v1_claim_boundary_term IN LISTS release_doc_v1_claim_boundary_terms)
+  string(FIND "${release_doc_text}" "${release_doc_v1_claim_boundary_term}"
+    release_doc_v1_claim_boundary_index)
+  if(release_doc_v1_claim_boundary_index EQUAL -1)
+    message(FATAL_ERROR
+      "docs/release.md must keep v1 release-claim boundary term: ${release_doc_v1_claim_boundary_term}"
+    )
+  endif()
+endforeach()
+
 set(required_release_evidence_terms
+  "V1.0 Release-Note Claim Map"
+  "V1.0 Deferred And Non-Goal Classification"
   "Serial timing"
   "Pure MPI"
   "OpenMP compatibility"
@@ -1187,6 +1229,13 @@ set(required_release_evidence_terms
   "Benchmark evidence"
   "Plausible but unvalidated"
   "Release-validated"
+  "local-evidence-backed caveated support"
+  "not permanent CI coverage"
+  "#355"
+  "#294"
+  "#259"
+  "#256"
+  "#353"
 )
 
 foreach(required_release_evidence_term IN LISTS required_release_evidence_terms)
@@ -1262,6 +1311,9 @@ file(READ "${REPO_ROOT}/docs/package-manager-readiness.md" package_manager_readi
 set(package_manager_required_terms
   "spack"
   "eb"
+  "Status date: 2026-06-17."
+  "V1.0 release-claims refresh: this remains readiness guidance only."
+  "Issue #355"
   "Serial | Package-manager friendly"
   "MPI | Package-manager friendly"
   "OpenMP | Package-manager friendly"
@@ -1274,6 +1326,7 @@ set(package_manager_required_terms
   "v1.0.0.tar.gz"
   "version(\"1.0.0\""
   "version = '1.0.0'"
+  "Those placeholders are intentional evidence"
   "depends_on(\"cmake@3.24:\", when=\"+openmp\", type=\"build\")"
   "LLVM Flang OpenMP packages have the compiler-id support fTimer requires"
   "wrapper-, and feature-mode-specific"
@@ -1285,6 +1338,21 @@ foreach(package_manager_required_term IN LISTS package_manager_required_terms)
   if(package_manager_term_index EQUAL -1)
     message(FATAL_ERROR
       "docs/package-manager-readiness.md must keep package-manager readiness acceptance term: ${package_manager_required_term}"
+    )
+  endif()
+endforeach()
+
+file(READ "${REPO_ROOT}/SECURITY.md" security_doc_text)
+set(security_policy_terms
+  "For v1.0 and later, security fixes normally target the latest stable release"
+  "Pre-1.0 tags and snapshots remain best-effort only."
+)
+
+foreach(security_policy_term IN LISTS security_policy_terms)
+  string(FIND "${security_doc_text}" "${security_policy_term}" security_policy_term_index)
+  if(security_policy_term_index EQUAL -1)
+    message(FATAL_ERROR
+      "SECURITY.md must keep v1 release-line support wording: ${security_policy_term}"
     )
   endif()
 endforeach()


### PR DESCRIPTION
Closes #352.

## Summary

- Refreshes the v1.0 release-note claim map in `docs/release-evidence.md` so each release-facing claim points back to a ledger row.
- Adds an explicit v1.0 deferred/non-goal classification table for package-manager ownership, fixed-team OpenMP ergonomics, MPICH hybrid CI scope, Ubuntu 24.04 MPICH runner migration, NVHPC, and other non-goals.
- Tightens README/release/security/package-manager wording so v1.0 claims stay inside the evidence boundary, especially the #353 MPICH MPI+OpenMP decision and #355 package-manager ownership boundary.
- Extends `ftimer_release_docs_contract` to pin the refreshed evidence and release-note guardrails.

## Validation

- `rg -n --hidden --glob "!.git/**" --glob "!build*/**" -i "pre-1\\.0|0\\.2\\.0|v0\\.2\\.0|compatib|deferred|TODO|release-blocker|release-audit|package-version" .`
- `cmake -B build-smoke`
- `cmake --build build-smoke`
- `cmake -E chdir build-smoke ctest --output-on-failure -R "ftimer_release_docs_contract|ftimer_csv_schema_docs|ftimer_openmp_hybrid_examples_contract"`
- `git diff --check`

Notes: configure passed with the existing CMake developer warning from `GNUInstallDirs` under LLVM Flang 22.1.7. The audit `rg` still reports intentional historical/pre-1.0 comments, maintainer workflow terms, package-manager prototype `TODO` placeholders, and compatibility/deferred terms now classified by the docs.